### PR TITLE
Usunięto niepotrzebny przedimek

### DIFF
--- a/Resources/Locale/pl-PL/character-appearance/components/humanoid-appearance-component.ftl
+++ b/Resources/Locale/pl-PL/character-appearance/components/humanoid-appearance-component.ftl
@@ -1,2 +1,2 @@
-humanoid-appearance-component-unknown-species = Person
-humanoid-appearance-component-examine = { CAPITALIZE(SUBJECT($user)) } { CONJUGATE-BE($user) } { INDEFINITE($age) } { $age } { $species }.
+humanoid-appearance-component-unknown-species = Osoba
+humanoid-appearance-component-examine = { CAPITALIZE(SUBJECT($user)) } { CONJUGATE-BE($user) } { $age } { $species }.


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->
<!-- Niektóre sekcje możesz pominąć, jeśli nie mają zastosowania. -->

## Informacje o PR

Poprawiłem trochę okno przeglądu entity usuwając niepotrzebny przedimek w ftl. Aby przetłumaczyć to okno w całości, należy przetłumaczyć wszystkie prototypy, ponieważ:

```cs
// SharedHumanoidAppearanceSystem

/// <summary>
/// Takes ID of the species prototype, returns UI-friendly name of the species.
/// </summary>
public string GetSpeciesRepresentation(string speciesId)
{
    if (_proto.TryIndex<SpeciesPrototype>(speciesId, out var species))
    {
        return Loc.GetString(species.Name);
    }

    Log.Error("Tried to get representation of unknown species: {speciesId}");
    return Loc.GetString("humanoid-appearance-component-unknown-species");
}
```

, a w przypadku jednego małego issue jest to zbyt kłopotliwe. Dzięki temu PR przynajmniej nieco lepiej widać, co dzieje się w tym oknie

## Media

<img width="357" height="206" alt="{42D11A5C-C8FE-49CF-8AE9-0D2589170E72}" src="https://github.com/user-attachments/assets/20fe4b24-d8bc-42b1-8a84-bec0105be3fa" />
