### PR TITLE
Dodano opcje, aby kontrolować zakończenie rundy po zwycięstwie rewolucji

### DIFF
--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -64,10 +64,12 @@ using Content.Shared.Chat;
 using Content.Server.Chat.Systems;
 using Content.Server.PDA.Ringer;
 using Content.Server.Traitor.Uplink;
+using Content.Shared.CCVar;
 using Content.Shared.Changeling;
 using Content.Shared.Heretic;
 using Content.Shared.Implants;
 using Robust.Shared.Audio;
+using Robust.Shared.Configuration;
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -93,6 +95,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
     [Dependency] private readonly ChatSystem _chatSystem = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly UplinkSystem _uplink = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
 
 
     //Used in OnPostFlash, no reference to the rule component is available
@@ -205,7 +208,11 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
         }
 
         // funkystation
-        if (component.RevVictoryEndTime != null && _timing.CurTime >= component.RevVictoryEndTime)
+        if (
+            component.RevVictoryEndTime != null
+            && _timing.CurTime >= component.RevVictoryEndTime
+            && _cfg.GetCVar(CCVars.ShouldEndRoundOnRevVictory) // Polonium - let round continue on rev victory if config says so
+            )
         {
             EndRound();
 

--- a/Content.Shared/CCVar/_Polonium/CCVars.Game.cs
+++ b/Content.Shared/CCVar/_Polonium/CCVars.Game.cs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2024 nikitosych <admin@ss14.pl>
+//
+// SPDX-License-Identifier: MIT
+
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    /// <summary>
+    /// Whether the round should end when revolutionaries achieve victory.
+    /// </summary>
+    public static readonly CVarDef<bool> ShouldEndRoundOnRevVictory =
+        CVarDef.Create("game.should_end_round_on_rev_victory", true, CVar.SERVERONLY);
+}


### PR DESCRIPTION
…cjonistów

<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR

Po prostu dodałem możliwość przedłużenia rundy, jeśli rewolucja wygrała. Przydatne podczas prowadzenia eventów.

Robi się to za pomocą komendy `sudo cvar game.should_end_round_on_rev_victory False`. Wartość opcji zostanie przywrócona po restarcie serwera.

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
:cl: Nikitapl
- add: Dodano możliwość przedłużenia rundy po zwycięstwie rewolucji
