### PR TITLE
Komunikat o nienapompowanej broni

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Ranged/SharedPumpActionSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/SharedPumpActionSystem.cs
@@ -39,7 +39,10 @@ public abstract class SharedPumpActionSystem : EntitySystem
             return;
 
         if (!ent.Comp.Pumped)
+        {
+            args.Message = Loc.GetString("cm-gun-pump-first");
             args.Cancelled = true;
+        }
     }
 
     private void OnGunShot(Entity<PumpActionComponent> ent, ref GunShotEvent args)


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Dodałem komunikat, który informuje użytkownika, jeśli próbuje strzelać z nienapompowanej broni