### PR TITLE
Fiks nazwy poziomu dostępu

### DIFF
--- a/Resources/Locale/pl-PL/_Impstation/prototypes/access/accesses.ftl
+++ b/Resources/Locale/pl-PL/_Impstation/prototypes/access/accesses.ftl
@@ -4,4 +4,4 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
-id-card-access-level-logistics = Logistics
+id-card-access-level-logistics = Zaopatrzenie


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Poprawia ten problem:
<img width="761" height="420" alt="{97AC26BF-780D-4945-B5AC-E7BF2D402783}" src="https://github.com/user-attachments/assets/9164bf80-d96e-493c-b0f7-d05e23993ea9" />

Zmieniłem nazwę na tę, która mi się wydaje najbardziej pasująca.

Ogólnie ten poziom oznacza to:
> used to approve orders, given to the QM, Cargo Techs, and HoP.

**Changelog**
:cl: Nikitapl
- tweak: Zaktualizowano tłumaczenie nazwy poziomu dostępu dla uprawnień dotyczących logistyki/zatwierdzania ładunków.
