### PR TITLE
Dodanie extended accessu robotics dla scientista

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
@@ -30,6 +30,7 @@
 # SPDX-FileCopyrightText: 2025 Mish <bluscout78@yahoo.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2026 Damian Zieliński <zientasek.pl@gmail.com>
+# SPDX-FileCopyrightText: 2026 Nikita (Nick) <174215049+nikitosych@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Dodano robotics do extended access (dodatkowy access przy skeleton crew) naukowca

## Powód / Balans
Station engineer ma w extended access atmosferykę, to scientist powinien analogicznie mieć robotykę. Poza tym na małych mapach (jak chibi) może nie być slotu dla robotyka, a są rzeczy wymagające tego accessu (jak vendor dla robotyka na chibi)

## Szczegóły techniczne
do scientist.yml dodana sekcja extendedAccess a w niej Robotics

## Media
<img width="1919" height="1078" alt="image" src="https://github.com/user-attachments/assets/425b85ec-03a9-4bdf-a023-9038a7bddace" />

---

**Changelog**
:cl: Zintex
- add: Dodano naukowcowi dostęp do robotyki przy niskim popie 