### PR TITLE
Sensowne requirement_overrides.yml

### DIFF
--- a/Resources/Prototypes/Roles/requirement_overrides.yml
+++ b/Resources/Prototypes/Roles/requirement_overrides.yml
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: 2024 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Nikita (Nick) <174215049+nikitosych@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 nikitosych <boriszyn@gmail.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Damian Zieliński <zientasek.pl@gmail.com>
+# SPDX-FileCopyrightText: 2026 Nikita (Nick) <174215049+nikitosych@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
 # SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
 #


### PR DESCRIPTION
## Informacje o PR
Zmieniono wymagane 1h w Civilian na 1h ogólne, dodane override dla IAA oraz zmienione dla Magistratu

## Powód / Balans
Zmieniono wymagane 1h w Civilian na 1h ogólne - wymaganie 1h w cywilnym do każdej roli jest bez sensu. Gracz mógłby grać medical internem i 100h, a i tak by nie odblokował lekarza, bo nie grał godziny chociażby kucharzem. Wymuszane są godziny w arbitralnym departamencie. Także gracze nie chcący tracić rundy na granie w civilian, bo koniecznie chcą być np. inżynierem, są uwięzieni w roli pomocnika.
Dopisany IAA do override, to jest najniższa rola z tych z CC, to ma mniejsze wymagania niż reszta.
Zwiększone wymaganie Magistratu do 10h, Magistrat to big deal rola i wymaga dużej wiedzy Space Law, stąd 10h w Sec (podobnie jak 10h w Command dla NTR). Bazowo także Magistrat wymaga głównie godzin w sec.

## Szczegóły techniczne
W requirement_overrides.yml tam gdzie było     
- !type:DepartmentTimeRequirement
      department: Service
zmieniono na !type:OverallPlaytimeRequirement
Dodano do listy IAA i zmieniono wymagania dla magistrate.

---

**Changelog**
:cl: Zintex
- tweak: Zmieniono wymaganie do odblokowania ról z czasu w departamencie cywilnym do czasu ogólnego.
- tweak: Odblokowanie Magistratu wymaga teraz 10h w Sec.
- tweak: Zmniejszone wymagania czasu gry dla IAA