### PR TITLE
Pluszak Itan-Kio dodany do bibelotów w wyposażeniu postaci

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -19,6 +19,7 @@
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2026 Damian Zieliński <zientasek.pl@gmail.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -85,6 +85,7 @@
 # SPDX-FileCopyrightText: 2026 Damian Zieliński <zientasek.pl@gmail.com>
 # SPDX-FileCopyrightText: 2026 MaiaArai <158123176+YaraaraY@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 Nikita (Nick) <174215049+nikitosych@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
 # SPDX-FileCopyrightText: 2026 Zergologist <114537969+Chedd-Error@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT


### PR DESCRIPTION
## Informacje o PR
Plushak Itan-Kio dodany do bibelotów w wyposażeniu postaci

## Powód / Balans
Pluszak Itan-Kio będzie się częściej pojawiał w grze, więc to dzieło będzie bardziej widoczne. Oraz inne serwery miewają swoje maskotki w bibelotach, np. ta Cirno którą mamy od Funky. Powinniśmy dodawać kolejne nasze pluszaki w to miejsce.

## Szczegóły techniczne
Dodany wpis pluszaka do Loadouts trinkets.yml i loudout_groups.yml.
Ta grupa loadoutów jest dostępna dla wszystkich ról.

## Media
<img width="788" height="802" alt="image" src="https://github.com/user-attachments/assets/fe932cdc-60e5-432a-be89-6de8abe3c677" />


---

**Changelog**
:cl: Zintex
- add: Plushak Itan-Kio dodany do bibelotów w wyposażeniu postaci