### PR TITLE
Cluster i saltern do rotacji

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -57,6 +57,8 @@
   # low pop
   - Cluster
   - Saltern
+  - Cork
+  - Omega
   - Eden
   - Gax
   - Bagel


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Dodany Cluster i Saltern do rotacji.

## Powód / Balans
Najlepsze mapy na nasz pop.

## Szczegóły techniczne
Dodane Cluster i Saltern do Resources/Prototypes/Maps/Pools/default.yml

## Media
![cluster_beloved](https://github.com/user-attachments/assets/e55fb73a-0b40-4c08-974f-d5b2f4de1a52)


---

**Changelog**
:cl: Zintex
- add: Dodano Cluster i Saltern do rotacji.
