### PR TITLE
Używanie spawnpointów latejoin gdy nie ma właściwego dla roli

### DIFF
--- a/Content.Server/Spawners/EntitySystems/SpawnPointSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/SpawnPointSystem.cs
@@ -12,6 +12,7 @@
 // SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 // SPDX-FileCopyrightText: 2026 Damian Zieliński <zientasek.pl@gmail.com>
+// SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
 //
 // SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Przy braku spawnpointu dla danej roli na mapie, gracz zostanie zespawnowany w lokacji late join.
Dotychczas, taki gracz był spawnowany w losowym spawnpoincie na całej stacji.

## Powód / Balans
Pozwoli nam to dodawać role do map bez potrzeby dodawania spawnpointów roli. Także sprawi, że gracze nie będą się spawnowali w losowych miejscach przy braku spawn , co powodowało, że mógł zostać zespawnowany w miejscu z którego nie mógł wyjść przez brak wymaganego accessu. Teraz taki gracz zespawnowany w lokacji late join nie będzie uwięziony, bo te lokacje są ogólnodostępne (no i tak byłby tam zespawnowany jakby dołączył w trakcie rundy).

Podsumowując:
- Umożliwia dodawanie roli do mapy bez dodania spawn pointa. Dzięki temu możemy dodać nowe role na każdej mapie albo mapom zmienić role.
- Brak spawn pointa będzie miał taki sam experience jak spawn w late joinie, także niewielka niedogodność.
- Po update mapy albo usunięciu spawn pointa z dowolnego innego powodu gracz nie będzie uwięziony w losowym spawnie, a zespawnuje się w ogólnodostępnej lokacji.

## Szczegóły techniczne
W SpawnPointSystem.cs gdy gra jest na etapie roundstart, zapisujemy lokacje latejoin w liście. Gdy nie ma spawnpointów, używamy tych zapasowych, dzięki czemu późniejszy kod od spawnowania gdziekolwiek się nie uruchomi o ile są spawn pointy latejoin na mapie (a będą na każdej przyzwoicie zrobionej mapie). 

## Media
https://github.com/user-attachments/assets/8c4a9d21-b0e9-4f11-995e-57d253d75732

---

**Changelog**
:cl: Zintex
- tweak: Spawnowanie w lokacji late join zamiast w losowej, jeśli nie znaleziono właściwego spawn pointu.
