### PR TITLE
Poprawiona ścieżka do alien kids w lobby.yml

### DIFF
--- a/Resources/Prototypes/SoundCollections/lobby.yml
+++ b/Resources/Prototypes/SoundCollections/lobby.yml
@@ -23,6 +23,7 @@
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 vectorassembly <vectorassembly@icloud.com>
 # SPDX-FileCopyrightText: 2026 Damian Zieliński <zientasek.pl@gmail.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Poprawiona ścieżka do alien kids w lobby.yml

## Powód / Balans
przypadkiem zmieniłem ścieżkę do alien kids:
https://github.com/polonium14/polonium-station/pull/384
ten PR to poprawia

## Szczegóły techniczne
zmieniona ścieżka na poprawną

---

**Changelog**
:cl: Zintex
- fix: Poprawiona ścieżka do muzyki lobby alien kids
