### PR TITLE
Update backpack.ftl

### DIFF
--- a/Resources/Locale/pl-PL/thief/backpack.ftl
+++ b/Resources/Locale/pl-PL/thief/backpack.ftl
@@ -29,7 +29,7 @@ thief-backpack-category-tools-description =
 thief-backpack-category-chemistry-name = zestaw anatomiczny
 thief-backpack-category-chemistry-description =
     Osiągnąłeś szczyt fizycznych możliwości... z drobną pomocą.
-    Zawiera: Implant kieszonkowy, implant nowej tożsamości, butelkę efedryny,
+    Zawiera: Implant wolności, implant nowej tożsamości, butelkę efedryny,
     strzykawkę, szejker i mydło omega.
 thief-backpack-category-syndie-name = zestaw Syndykata
 thief-backpack-category-syndie-description =


### PR DESCRIPTION
Poprawka w zestawie złodzieja ponieważ nie dostaję się implantu kieszonkowego a uwalniący

<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Implant kieszonkowy -> Implant wolności
## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
bo mnie 2 razy wprowadził w błąd
## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: Czuat
- tweak: Zmieniono opis zestawu złodzieja na poprawny

