### PR TITLE
engi dopiero po godzinie

### DIFF
--- a/Resources/Prototypes/Roles/requirement_overrides.yml
+++ b/Resources/Prototypes/Roles/requirement_overrides.yml
@@ -45,7 +45,7 @@
       time: 3600 # 1 hour
     TechnicalAssistant:
     - !type:OverallPlaytimeRequirement
-      time: 0
+      time: 3600 # 1 hour
     MedicalIntern:
     - !type:OverallPlaytimeRequirement
       time: 0
@@ -71,8 +71,7 @@
     - !type:OverallPlaytimeRequirement
       time: 3600 # 1 hour
     Brigmedic:
-    - !type:DepartmentTimeRequirement
-      department: Civilian
+    - !type:OverallPlaytimeRequirement
       time: 3600 # 1 hour
     HeadOfSecurity:
     - !type:OverallPlaytimeRequirement


### PR DESCRIPTION
## Informacje o PR
Pomocnik techniczny wymaga 1h ogólnego czasu gry

## Powód / Balans
Raiderzy lubią engi, bo może spowodować spustoszenie.
Brigmedowi zmieniłem z civ na ogólne dla ujednorodnienia.

## Szczegóły techniczne
Dodane 1h overall playtime dla technical assistant w requirement_overrides.yml
zmienione 1h w civilian na 1h ogólnego

---

**Changelog**
:cl: Zintex
- tweak: Pomocnik techniczny teraz wymaga 1h ogólnego czasu gry
- tweak: Zmieniony wymóg dla Brigmeda z 1h w civilian na 1h ogólnego.
