### PR TITLE
Command może być antagonistami

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -43,6 +43,7 @@
 # SPDX-FileCopyrightText: 2025 Kip <tfraser520@gmail.com>
 # SPDX-FileCopyrightText: 2025 Mish <bluscout78@yahoo.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Damian Zieliński <zientasek.pl@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -67,7 +67,7 @@
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"
   supervisors: job-supervisors-captain
-  canBeAntag: false
+  canBeAntag: true # Polonium
   access:
   - Cargo
   - Salvage

--- a/Resources/Prototypes/Roles/Jobs/Civilian/visitor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/visitor.yml
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2024 SlamBamActionman <83650252+SlamBamActionman@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Damian Zieliński <zientasek.pl@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/Roles/Jobs/Civilian/visitor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/visitor.yml
@@ -12,7 +12,7 @@
   name: job-name-visitor
   description: job-description-visitor
   playTimeTracker: JobVisitor
-  canBeAntag: false
+  canBeAntag: true # Polonium
   icon: JobIconVisitor
   setPreference: false
   overrideConsoleVisibility: true

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -45,6 +45,8 @@
 # SPDX-FileCopyrightText: 2025 Teasq <Xerithin@gmail.com>
 # SPDX-FileCopyrightText: 2025 YaraaraY <158123176+YaraaraY@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Damian Zieliński <zientasek.pl@gmail.com>
+# SPDX-FileCopyrightText: 2026 Nikita (Nick) <174215049+nikitosych@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -63,7 +63,7 @@
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"
   supervisors: job-supervisors-captain
-  canBeAntag: false
+  canBeAntag: true # Polonium
   access:
   - Maintenance
   - Engineering

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -70,7 +70,7 @@
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"
   supervisors: job-supervisors-captain
-  canBeAntag: false
+  canBeAntag: true # Polonium
   access:
   - Medical
   - Command

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -46,6 +46,7 @@
 # SPDX-FileCopyrightText: 2025 Mish <bluscout78@yahoo.com>
 # SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Damian Zieliński <zientasek.pl@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -73,7 +73,7 @@
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"
   supervisors: job-supervisors-captain
-  canBeAntag: false
+  canBeAntag: true # Polonium
   access:
   - Research
   - Robotics # funkystation

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -49,6 +49,7 @@
 # SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Mish <bluscout78@yahoo.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Damian Zieliński <zientasek.pl@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Sprawiono, że większość ról command: CMO, RD, CE i QM może być atagonistami. Kapitan, HoS i HoP oraz CC nie mogą być antagonistami. Także dałem bycie antagonistą do wizytorów.

## Powód / Balans
Przy niskim popie jest mało osób które mogą stać się antagonistami, czasem ich wcale nie ma, bo każdy na stacji ma rolę command lub sec. Przez co antagonistę dostają ci sami ludzie, jak ktoś dostanie antagonistę, a gra na innej roli zwykle, to widać że nie przydzieliło mu tej roli. Także lista podejrzanych jest krótka, bo bywa że tylko 2-4 graczy antagonistami może być, co utrudnia antagonistom ukrywanie się. Także na space station 13 te role mogły być antagonistami, mógł być tam także HoP, ale uznałem że lepiej by osoba z tak wielkim accessem i druga po kapitanie nie powinna dostawać antagonisty.
Pewność, że nie ma antagonisty wśród dowodzenia sprawia, że ochrona bardziej pobłażliwie traktuje wykroczenia dowodzenia, "bo przecież nie może być antagonistą".


## Szczegóły techniczne
Zmiana flagi canBeAntag na true


---

**Changelog**
:cl: Zintex
- tweak: CMO, RD, CE i QM mogą być teraz antagonistami.
