### PR TITLE
dostosowany test integracyjny od spawnpointów prac

### DIFF
--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -45,6 +45,7 @@
 // SPDX-FileCopyrightText: 2025 Evaisa <mail@evaisa.dev>
 // SPDX-FileCopyrightText: 2025 Ichaie <ichaicoelho@gmail.com>
 // SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus <90893484+LaCumbiaDelCoronavirus@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Nikita (Nick) <174215049+nikitosych@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Spanky <180730777+spanky-spanky@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Spanky <scott@wearejacob.com>
 // SPDX-FileCopyrightText: 2025 Steve <marlumpy@gmail.com>
@@ -58,6 +59,7 @@
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 // SPDX-FileCopyrightText: 2025 willow <willowzeta632146@proton.me>
 // SPDX-FileCopyrightText: 2025 wilowzeta <willowzeta632146@proton.me>
+// SPDX-FileCopyrightText: 2026 Damian Zieliński <zientasek.pl@gmail.com>
 //
 // SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->
closes #410
## Informacje o PR
dostosowany test integracyjny od spawnpointów prac pod zmianę gdzie spawnuje role w punktach late joinu przy braku spawnpointa

## Powód / Balans
Łatwiejsze dodawanie ról do map bez oblewania testów. 
Rozwiązane issue: https://github.com/polonium14/polonium-station/issues/410

## Szczegóły techniczne
Jak mapa ma spawn point late join, to nie sprawdzamy obecności spawn pointów od roli, bo to wystarczy by rola się zespawnowała.