### PR TITLE
Podział puli dzwięków harpii na męskie i żeńskie

### DIFF
--- a/Resources/Prototypes/SoundCollections/harpy.yml
+++ b/Resources/Prototypes/SoundCollections/harpy.yml
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 jackel234 <52829582+jackel234@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Wudanty <wudanty@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/_DV/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_DV/Voice/speech_emote_sounds.yml
@@ -9,6 +9,8 @@
 # SPDX-FileCopyrightText: 2025 jackel234 <52829582+jackel234@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 vectorassembly <vectorassembly@icloud.com>
+# SPDX-FileCopyrightText: 2026 Nikita (Nick) <174215049+nikitosych@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Wudanty <wudanty@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Dźwięki męskie/żeńskie zostały oddzielone dla korelujących płci.
## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
Ludzie często zakładają jakiej płci jest postać w oparciu o dźwięki jakie wydaje. Ciągłe poprawianie innych jest po czasie męczące.
## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
Utworzenie oddzielnych soundCollection dla harpii.

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
:cl: Wudanty
- tweak: Podzielono dźwięki harpii na męskie i żeńskie.
