### PR TITLE
Zmiany w limitach graczy niektórych map

### DIFF
--- a/Resources/Prototypes/Maps/eden.yml
+++ b/Resources/Prototypes/Maps/eden.yml
@@ -35,7 +35,7 @@
   id: Eden
   mapName: 'Eden'
   mapPath: /Maps/_Polonium/eden.yml #Polonium - Brigmed
-  minPlayers: 7
+  minPlayers: 15
   maxPlayers: 55
   stations:
     Eden:

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -32,7 +32,7 @@
   id: Omega
   mapName: 'Omega'
   mapPath: /Maps/_Funkystation/omega.yml
-  minPlayers: 7
+  minPlayers: 15
   maxPlayers: 35
   stations:
     Omega:

--- a/Resources/Prototypes/_DV/Maps/chibi.yml
+++ b/Resources/Prototypes/_DV/Maps/chibi.yml
@@ -3,7 +3,7 @@
   mapName: 'Chibi'
   mapPath: /Maps/_DV/chibi.yml
   minPlayers: 0
-  maxPlayers: 12
+  maxPlayers: 15
   stations:
     Chibi:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
:cl: Nikita
- tweak: Zwiększono limit graczy do gry na mapach Eden, Omega
- tweak: Zwiększono maksymalną liczbę graczy do gry na Chibi
