### PR TITLE
Fiks mebli od N14

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/other_furniture.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/other_furniture.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2025 Nikita (Nick) <174215049+nikitosych@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   parent: Dresser
   id: N14Dresser


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR

Fixes #519 

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
:cl: Nikita
- fix: Grandfather clock, telewizja (N14) i garderoba (N14) są teraz zniszczalne!
