### PR TITLE
Z by użyć strzelby

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Ranged/SharedPumpActionSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/SharedPumpActionSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Popups;
 using Content.Shared.Interaction.Events; // Polonium Edit, added
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
+using Content.Shared.Wieldable.Components;  // Polonium Edit, added
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 
@@ -26,7 +27,7 @@ public abstract class SharedPumpActionSystem : EntitySystem
         SubscribeLocalEvent<PumpActionComponent, ExaminedEvent>(OnExamined, before: [typeof(SharedGunSystem)]);
         SubscribeLocalEvent<PumpActionComponent, AttemptShootEvent>(OnAttemptShoot);
         SubscribeLocalEvent<PumpActionComponent, GunShotEvent>(OnGunShot);
-        SubscribeLocalEvent<PumpActionComponent, UseInHandEvent>(OnPumpUse, before: [typeof(SharedGunSystem)]); // Polonium Edit OnUniqueActionEvent -> UseInHandEvent, OnUniqueAction -> OnPumpUse
+        SubscribeLocalEvent<PumpActionComponent, UseInHandEvent>(OnUseInHand, before: [typeof(SharedGunSystem)]); // Polonium Edit OnUniqueActionEvent -> UseInHandEvent, OnUniqueAction -> OnUseInHand
         SubscribeLocalEvent<PumpActionComponent, EntRemovedFromContainerMessage>(OnEntRemovedFromContainer);
     }
 
@@ -57,9 +58,12 @@ public abstract class SharedPumpActionSystem : EntitySystem
         Dirty(ent);
     }
 
-    private void OnPumpUse(Entity<PumpActionComponent> ent, ref UseInHandEvent args) // Polonium Edit OnUniqueAction -> OnPumpUse, UserUID -> User
+    private void OnUseInHand(Entity<PumpActionComponent> ent, ref UseInHandEvent args) // Polonium Edit OnUniqueAction -> OnUseInHand, UserUID -> User
     {
         if (args.Handled)
+            return;
+
+        if (TryComp(ent, out WieldableComponent? wieldableComp) && !wieldableComp.Wielded)
             return;
 
         if (Pump(ent, args.User)) // Polonium Edit UserUID -> User
@@ -81,8 +85,8 @@ public abstract class SharedPumpActionSystem : EntitySystem
 
         if (ammo.Count <= 0)
         {
-            _popup.PopupClient(Loc.GetString("cm-gun-no-ammo-message"), user, user);
-            return true;
+            _audio.PlayPredicted(ent.Comp.Sound, ent, user);
+            return false;
         }
 
         if (!ent.Comp.Running || ent.Comp.Pumped)


### PR DESCRIPTION
Strzelba normalnie pompowana na z

<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Pompowanie strzelby idzie na przycisk z a nie na spacje domyślnie
## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
I ded
## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->

https://github.com/user-attachments/assets/ca1b39c0-865e-4f7d-a1f3-9512e0228465


---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
:cl: Szyszkrzyneczka

- tweak: Pompowanie strzelby na klawisz Z zamiast spacji
