### PR TITLE
Usunięcie buga co crashuje grę w związku z przecinakami plazmowymi

### DIFF
--- a/Content.Server/_Goobstation/MaterialEnergy/MaterialEnergySystem.cs
+++ b/Content.Server/_Goobstation/MaterialEnergy/MaterialEnergySystem.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
 // SPDX-FileCopyrightText: 2024 yglop <95057024+yglop@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2026 Szyszkrzyneczka <rammus.vult@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Content.Server/_Goobstation/MaterialEnergy/MaterialEnergySystem.cs
+++ b/Content.Server/_Goobstation/MaterialEnergy/MaterialEnergySystem.cs
@@ -43,11 +43,14 @@ namespace Content.Server._Goobstation.MaterialEnergy
             foreach (var fueltype in component.MaterialWhiteList)
             {
                 if (_composition.MaterialComposition.ContainsKey(fueltype))
+                {
                     AddBatteryCharge(
                         uid,
                         args.Used,
                         _composition.MaterialComposition[fueltype],
                         materialStack.Count);
+                    args.Handled = true;
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->

Znika bug co crashuje gre jak włożyć 1 sztaba plazma do przecinak plazmowy

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->

Gamebreaking bug

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->

włożyłem args.Handled = true w jedną linijke kodu

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
:cl: Szyszkrzyneczka
- fix: Włożenie sztabki plazmy do przecinarki plazmowej już nie crashuje serwera
