### PR TITLE
Aktualizacja wyposażenia brigmeda, VIS MPS do wyboru jako startowa broń ochrony

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -169,7 +169,7 @@
   - type: StorageFill
     contents:
       - id: ClothingEyesGlassesMedSec
-      - id: WeaponDisabler
+      - id: Truncheon
       - id: TrackingImplanter
         amount: 2
       - id: ClothingOuterHardsuitBrigmedic
@@ -182,6 +182,12 @@
       - id: ClothingOuterVestArmorMedSec
       - id: ClothingUniformJumpsuitBrigmedic
       - id: ClothingUniformJumpskirtBrigmedic
+      - id: ClothingMaskBreathMedicalSecurity
+      - id: SecHypo
+      - id: HandheldGPSBasic
+      - id: ClothingHandsGlovesNitrile
+      - id: DefibrillatorCompact
+      - id: BoxBodyBag
       - id: autoInjectorCartridgeCaseFilled
       - id: MedkitFilled
       - id: MedkitCombatFilled

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -388,7 +388,7 @@
     stateDoorOpen: armory_open
     stateDoorClosed: brigmedic_door
   - type: AccessReader
-    access: [["Medical"]]
+    access: [["Medical"], ["HeadOfSecurity"], ["Armory"]]
 
 # Security Officer
 - type: entity

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -231,6 +231,12 @@
     back:
     - WeaponPistolMk58
 
+- type: loadout
+  id: SecurityOfficerVIS
+  storage:
+    back:
+    - VisMPSPistol
+
 # Misc
 - type: loadout
   id: SecStar

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -2248,6 +2248,7 @@
   loadouts:
   - SecurityOfficerEnergyGun
   - SecurityOfficerPistol
+  - SecurityOfficerVIS
 
 # Brigmedic - Polonium
 - type: loadoutGroup

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -528,6 +528,7 @@
   - Trinkets
   - SecurityStar
   - GroupSpeciesBreathToolSecurity
+  - LoadoutSecurityOfficerWeapon
 
 - type: roleLoadout
   id: JobDetective

--- a/Resources/Prototypes/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/brigmedic.yml
@@ -46,16 +46,14 @@
     id: BrigmedicPDA
     ears: ClothingHeadsetBrigmedic
     belt: ClothingBeltMedicalFilled
-    pocket1: WeaponPistolMk58
-    pocket2: WeaponDisabler
+    pocket1: FlashlightSeclite
+    pocket2: Truncheon
   storage:
     back:
     - Flash
-    - MagazinePistol
     - SecHypo # Goobstation
     - autoInjectorCartridgeCaseSoftFilled
     - Handcuffs
-    - ClothingMaskBreathMedicalSecurity
 
 - type: jobAlternateTitle
   id: SecurityMedic

--- a/Resources/Prototypes/_EinsteinEngines/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Catalog/Fills/Lockers/security.yml
@@ -1,4 +1,4 @@
 - type: entity
   id: LockerBrigmedicFilledHardsuit
   suffix: Corpsman, Filled, Hardsuit
-  parent: LockerBrigmedicFilled
+  parent: LockerBrigmedicFilled # inheriting from other locker because there is no need to have different equipment for 2. Don't list contents below. - Polonium

--- a/Resources/Prototypes/_EinsteinEngines/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Catalog/Fills/Lockers/security.yml
@@ -1,36 +1,4 @@
 - type: entity
   id: LockerBrigmedicFilledHardsuit
   suffix: Corpsman, Filled, Hardsuit
-  parent: LockerBrigmedic
-  components:
-  - type: StorageFill
-    contents:
-    - id: ClothingEyesGlassesSunglasses # Polonium edit
-    - id: WeaponDisabler
-    - id: TrackingImplanter
-      amount: 2
-    - id: ClothingOuterHardsuitBrigmedic # WD EDIT: ClothingOuterHardsuitCombatCorpsman -> ClothingOuterHardsuitBrigmedic
-    - id: ClothingUniformJumpsuitBrigmedic
-    - id: ClothingUniformJumpskirtBrigmedic
-    - id: HandheldGPSBasic # Added GPS because I just think it should be there tbh.
-    - id: MedkitFilled
-    - id: MedkitCombatFilled
-      prob: 0.6
-    - id: MedkitAdvancedFilled
-      prob: 0.4
-    - id: MedkitOxygenFilled
-      prob: 0.3
-    - id: MedkitBruteFilled
-      prob: 0.3
-    - id: MedkitToxinFilled
-      prob: 0.3
-    - id: MedkitBurnFilled
-      prob: 0.7
-    # - id: LunchboxSecurityFilledRandom
-    #   prob: 0.3
-    - id: ClothingHandsGlovesNitrile
-    - id: ClothingBeltCorpsmanWebbing
-    - id: DefibrillatorCompact
-    - id: BoxBodyBag
-    - id: ClothingMaskGasSecurity
-    - id: OxygenTankFilled
+  parent: LockerBrigmedicFilled


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Zamieniono disablery na pałki pod ogólne zmiany w security, broń jest wybierana w wyposażeniu tak jak u oficera ochrony, dodany wybór VIS MPS wśród startowej broni sec. Drugi prototyp wypełnionej szafki jest niepotrzebny, zostało zrobione, że dziedziczy swoją zawartość z tego pierwszego dla zachowania kompatybilności. Dodane accessy armory i head of security do szafki brigmeda, by mogła być otwierana także przez wardena i hosa (nie mogli otwierać jej wcześniej przez brak med accessu).

## Powód / Balans
https://github.com/polonium14/polonium-station/issues/548
Brigmeda nie ma na funky, więc security redux go nie dotknęło i posiadał disabler który nie powinien być w grze. Te zmiany to poprawiają. Także brigmed ma zrobiony wybór broni tak jak secoff ma. VIS MPS w wyborze broni spopularyzuje bardziej używanie naszego contentu - i tak zamieniamy na wielu mapach MK na vis.

## Szczegóły techniczne
zmiany w yml

## Media
<img width="770" height="339" alt="Zrzut ekranu 2026-05-01 021949" src="https://github.com/user-attachments/assets/b7f108ec-7d02-46d9-bec9-6bb8c0d132e1" />


---

**Changelog**
:cl: Zintex
- add: VIS MPS w wyborze startowej broni ochrony
- tweak: Zaktualizowano wyposażenie Brigmeda.
