### PR TITLE
wybór pistoletu startowego u nadzorcy i komendanta

### DIFF
--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -474,6 +474,7 @@
   - HeadofSecurityJobTrinkets
   - SecurityStar
   - GroupSpeciesBreathToolSecurity
+  - LoadoutSecurityOfficerWeapon
 
 - type: roleLoadout
   id: JobWarden
@@ -491,6 +492,7 @@
   - WardenJobTrinkets
   - SecurityStar
   - GroupSpeciesBreathToolSecurity
+  - LoadoutSecurityOfficerWeapon
 
 - type: roleLoadout
   id: JobSecurityOfficer

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -118,7 +118,6 @@
     id: HoSPDA
     gloves: ClothingHandsGlovesCombat
     ears: ClothingHeadsetAltSecurity
-    pocket1: WeaponEnergyGunEnergyPistol # funkystation
   storage:
     back:
     - Flash

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -104,7 +104,6 @@
     #eyes: ClothingEyesGlassesSecurity
     id: WardenPDA
     ears: ClothingHeadsetWarden # funkystation
-    pocket1: WeaponEnergyGunEnergyPistol # funkystation
   storage:
     back:
     - Flash


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Dodany wybór pistoletu startowego u nadzorcy i komendanta

## Powód / Balans
Zwykły ochroniarz może sobie wybrać pistolet startowy, dlaczego hos i warden nie może?

## Szczegóły techniczne
usunięty laserowy pistolet ze stałego wyposażenia hosa i wardena, dodana grupa loadoutu z pistoletami ochrony do loadoutu wardena i hosa

---

**Changelog**
:cl: Zintex
- add: Komendant i Nadzorca mogą wybrać startowy pistolet w menu wyposażenia
