### PR TITLE
poprawa accessu smart fridge w botanice

### DIFF
--- a/Resources/Maps/_Polonium/saltern.yml
+++ b/Resources/Maps/_Polonium/saltern.yml
@@ -61615,6 +61615,8 @@ entities:
     - type: Transform
       pos: 16.5,-3.5
       parent: 2
+- proto: SmartFridge
+  entities:
   - uid: 9401
     components:
     - type: Transform


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Zmieniony smart fridge medical na smart fridge. 

## Powód / Balans
Botanik i kucharz nie mieli accessu do medycznej wersji

## Szczegóły techniczne
nowy prototyp, przesuwamy tam definicję z wersji medical

---

**Changelog**
:cl: Zintex
- fix: Saltern: poprawione dostępny Smart Fridge w botanice
