### PR TITLE
Wprowadzono wymogi czasowe dla ról dowodzenia i ochrony

### DIFF
--- a/Resources/Prototypes/Roles/requirement_overrides.yml
+++ b/Resources/Prototypes/Roles/requirement_overrides.yml
@@ -127,6 +127,10 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 10800 #3 hrs
+    - !type:TraitsRequirement # Funky
+      inverted: true
+      traits:
+      - Pacifist
     HeadOfSecurity:
     - !type:DepartmentTimeRequirement
       department: Security
@@ -141,10 +145,18 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 10800 #3 hrs
+    - !type:TraitsRequirement # Funky
+      inverted: true
+      traits:
+      - Pacifist
     Warden:
     - !type:DepartmentTimeRequirement
       department: Security
       time: 28800 #8 hrs
+    - !type:TraitsRequirement # Funky
+      inverted: true
+      traits:
+      - Pacifist
     ResearchAssistant:
     - !type:OverallPlaytimeRequirement
       time: 0

--- a/Resources/Prototypes/Roles/requirement_overrides.yml
+++ b/Resources/Prototypes/Roles/requirement_overrides.yml
@@ -29,26 +29,56 @@
   id: Zeroed
   jobs:
     Captain:
+    - !type:DepartmentTimeRequirement
+      department: Engineering
+      time: 7200 #2 hrs
+    - !type:DepartmentTimeRequirement
+      department: Medical
+      time: 7200 #2 hrs
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 1800 #5 hrs
+    - !type:DepartmentTimeRequirement
+      department: Command
+      time: 36000 #10 hrs
     - !type:OverallPlaytimeRequirement
-      time: 3600 # 1 hour
+      time: 72000 #20 hrs
     HeadOfPersonnel:
     - !type:OverallPlaytimeRequirement
-      time: 3600 # 1 hour
+      time: 36000 #10 hrs
+    - !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 7200 #2 hrs
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 7200 #2 hrs
+    - !type:DepartmentTimeRequirement
+      department: Command
+      time: 7200 #2 hrs
     AtmosphericTechnician:
     - !type:OverallPlaytimeRequirement
       time: 3600 # 1 hour
     ChiefEngineer:
-    - !type:OverallPlaytimeRequirement
-      time: 3600 # 1 hour
+    - !type:DepartmentTimeRequirement
+      department: Engineering
+      time: 36000 #10 hrs
     StationEngineer:
     - !type:OverallPlaytimeRequirement
       time: 3600 # 1 hour
     TechnicalAssistant:
     - !type:OverallPlaytimeRequirement
       time: 3600 # 1 hour
+    - !type:DepartmentTimeRequirement
+      department: Engineering
+      time: 36000 #10 hrs
+      inverted: true # stop playing intern if you're good at engineering!
     MedicalIntern:
     - !type:OverallPlaytimeRequirement
       time: 0
+    - !type:DepartmentTimeRequirement
+      department: Medical
+      time: 36000 #10 hrs
+      inverted: true # stop playing intern if you're good at med!
     MedicalDoctor:
     - !type:OverallPlaytimeRequirement
       time: 3600 # 1 hour
@@ -62,29 +92,66 @@
     - !type:OverallPlaytimeRequirement
       time: 3600 # 1 hour
     ChiefMedicalOfficer:
-    - !type:OverallPlaytimeRequirement
-      time: 3600 # 1 hour
+    - !type:RoleTimeRequirement
+      role: JobChemist
+      time: 10800 #3 hrs
+    - !type:RoleTimeRequirement
+      role: JobMedicalDoctor
+      time: 10800 #3 hrs
+    - !type:DepartmentTimeRequirement
+      department: Medical
+      time: 36000 #10 hrs
     SecurityOfficer:
-    - !type:OverallPlaytimeRequirement
-      time: 3600 # 1 hour
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 10800 #3 hrs
+    - !type:TraitsRequirement # Funky
+      inverted: true
+      traits:
+      - Pacifist
     SecurityCadet:
     - !type:OverallPlaytimeRequirement
-      time: 3600 # 1 hour
+      time: 18000 #5 hrs
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 #10 hrs
+      inverted: true # stop playing intern if you're good at security!
+    - !type:TraitsRequirement # Funky
+      inverted: true
+      traits:
+      - Pacifist
     Brigmedic:
-    - !type:OverallPlaytimeRequirement
-      time: 3600 # 1 hour
+    - !type:DepartmentTimeRequirement
+      department: Medical
+      time: 10800 #3 hrs
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 10800 #3 hrs
     HeadOfSecurity:
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 54000 #15 hrs
     - !type:OverallPlaytimeRequirement
-      time: 3600 # 1 hour
+      time: 72000 #20 hrs
+    - !type:TraitsRequirement # Funky
+      inverted: true
+      traits:
+      - Pacifist
     Detective:
-    - !type:OverallPlaytimeRequirement
-      time: 3600 # 1 hour
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 10800 #3 hrs
     Warden:
-    - !type:OverallPlaytimeRequirement
-      time: 3600 # 1 hour
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 28800 #8 hrs
     ResearchAssistant:
     - !type:OverallPlaytimeRequirement
       time: 0
+    - !type:DepartmentTimeRequirement
+      department: Science
+      time: 36000 #10 hrs
+      inverted: true # stop playing intern if you're good at science!
     Scientist:
     - !type:OverallPlaytimeRequirement
       time: 0
@@ -92,14 +159,16 @@
     - !type:OverallPlaytimeRequirement
       time: 0
     ResearchDirector:
-    - !type:OverallPlaytimeRequirement
-      time: 3600 # 1 hour
+    - !type:DepartmentTimeRequirement
+      department: Science
+      time: 36000 #10 hrs
     Borg:
     - !type:OverallPlaytimeRequirement
-      time: 3600 # 1 hour
+      time: 18000 #5 hrs
     StationAi:
-    - !type:OverallPlaytimeRequirement
-      time: 3600 # 1 hour
+    - !type:RoleTimeRequirement
+      role: JobBorg
+      time: 18000 #5 hrs
     Boxer:
     - !type:OverallPlaytimeRequirement
       time: 0
@@ -113,8 +182,15 @@
     - !type:OverallPlaytimeRequirement
       time: 0
     Quartermaster:
-    - !type:OverallPlaytimeRequirement
-      time: 3600 # 1 hour
+    - !type:RoleTimeRequirement
+      role: JobCargoTechnician
+      time: 10800 #3 hrs
+    - !type:RoleTimeRequirement
+      role: JobSalvageSpecialist
+      time: 10800 #3 hrs
+    - !type:DepartmentTimeRequirement
+      department: Cargo
+      time: 36000 #10 hrs
     CargoTechnician:
     - !type:OverallPlaytimeRequirement
       time: 3600 # 1 hour

--- a/Resources/Prototypes/Roles/requirement_overrides.yml
+++ b/Resources/Prototypes/Roles/requirement_overrides.yml
@@ -37,7 +37,7 @@
       time: 7200 #2 hrs
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 1800 #5 hrs
+      time: 18000 #5 hrs
     - !type:DepartmentTimeRequirement
       department: Command
       time: 36000 #10 hrs


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Wprowadzono wymogi czasowe dla ról dowodzenia i ochrony. Bazowałem na bazowych wymaganiach, lecz je poluzowałem około o połowę by były możliwe do osiągnięcia w sensownym czasie bez przenoszenia godzin z innego serwera i ograniczyłem też wymogi grania konkretną rolą w departamencie. W skrócie 10h w danym departamencie wymagane dla heada. Kapitan wymaga 20h ogólnego czasu, 2h w med, 2h w engi, 5h w sec i 10h w command. Hop 2h w sevice, sec i command. Kadet wymaga 5h ogólnego czasu gry. Hos 15h w security i 20h ogólnie. 
Stażyści wygasają po 10h w dziale, czyli po odblokowaniu dowódcy. Nie chcemy, by doświadczeni gracze zajmowali sloty dla stażystów i prowadzącego z tym błędnego przekonania o ich małych umiejętnościach.

Po wprowadzeniu, myślę że rzucimy ogłoszenie by gracze otwierali tickety na przeniesienie czasu, by szok z wprowadzenia tej zmiany był ograniczony. Można też być w miarę elastycznym i dopisać sztuczne godziny jeśli graczowi który grał dużo daną rolą, a nie spełnia teraz wymagań.

## Powód / Balans
Gracze narzekają na niekompetencję dowódców i ochroniarzy. Sugestia wprowadzenia tego była poruszana kilkakrotnie na ogólnym czacie, również było to wspomniane w ankiecie, więc to adresuje uwagi społeczności.

Również, dla części graczy może być do zachęta by grać różnymi rolami celem odblokowania wszystkich ról.

## Szczegóły techniczne
modyfikujemy requirement_overrides.

---

**Changelog**
:cl: Zintex
- tweak: Zmieniono wymogi czasowe dla ról
