### PR TITLE
poprawa ścieżki szklanego Centcomm airlocka

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/airlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/airlocks.yml
@@ -363,4 +363,4 @@
   suffix: Central Command
   components:
   - type: Sprite
-    sprite: Structures/Doors/Airlocks/Glass/centcomm.rsi
+    sprite: _DV/Structures/Doors/Airlocks/Glass/centcomm.rsi


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Śluzy szklane centralnego dowodzenia miały ścieżkę do starej tekstrury.

## Powód / Balans
Poprawa niespójności graficznej.

## Szczegóły techniczne
dodanie _DV na przodzie ścieżki

## Media
przed zmianą:
<img width="243" height="260" alt="image" src="https://github.com/user-attachments/assets/4fa7d214-b674-4cc3-bc01-8ac9d1e92539" />

po zmianie:
<img width="229" height="226" alt="image" src="https://github.com/user-attachments/assets/ff21f30c-06fe-4ebd-b580-188498ac3ba4" />


---

**Changelog**
:cl: Zintex
- fix: Poprawiona ścieżka do tekstury szklanych śluz centralnego dowództwa