### PR TITLE
kalibracje i poprawki do secretplus

### DIFF
--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -41,6 +41,7 @@
     - prefRoles: [ Thief ]
       max: 3
       playerRatio: 20 #funky reduce le rate
+      chaosScore: 100 # Goobstation
       lateJoinAdditional: true
       allowNonHumans: true
       multiAntagSetting: NotExclusive

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -400,7 +400,7 @@
   parent: BaseGameRule
   components:
   - type: GameRule
-    minPlayers: 15
+    minPlayers: 10
     delay:
       min: 600
       max: 900

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -54,16 +54,21 @@
   id: CalmTraitor # For Dual Antag Gamemodes / Funky: For gamemodes that need nerfed antags
   components:
   - type: GameRule
-    minPlayers: 15
+    minPlayers: 5
     delay:
       min: 240
       max: 420
+  - type: AntagRandomObjectives
+    sets:
+    - groups: TraitorObjectiveGroups
+    maxDifficulty: 3
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn
     definitions:
     - prefRoles: [ Traitor ]
       max: 4
-      playerRatio: 15
+      playerRatio: 8
+      chaosScore: 100 # Polonium
       blacklist:
         components:
         - AntagImmune
@@ -80,10 +85,10 @@
   id: CalmLing # For Dual Antag Gamemodes / Funky: For gamemodes that need nerfed antags
   components:
   - type: GameRule
-    minPlayers: 15
+    minPlayers: 10
     delay:
-      min: 30
-      max: 60
+      min: 1200
+      max: 1800
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn
     agentName: changeling-roundend-name

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -26,8 +26,10 @@
     Thief: 0.2
     # Shadowling: 0.02
     # normal
-    Traitor: 0.25
-    Changeling: 0.10
+    Traitor: 0.1
+    CalmTraitor: 0.15
+    CalmLing: 0.05
+    Changeling: 0.05
     Heretic: 0.11
     # CorporateAgent: 0.025
     # XenomorphsInfestationRoundstart: 0.02
@@ -42,15 +44,18 @@
   id: SecretPlusPrimary
   weights:
     Traitor: 0.25
-    Changeling: 0.10
+    CalmLing: 0.07
+    Changeling: 0.07
     Heretic: 0.11
     Nukeops: 0.05
     Revolutionary: 0.05
-    Zombie: 0.04 # in search of how to make a rule always run alone? just tag it with LoneRunRule like zombies are
+    lowZombies: 0.03
+    medZombies: 0.02
     BlobGameMode: 0.05
     Wizard: 0.025
     CosmicCult: 0.05
     BloodCult: 0.05
+    MalfAi: 0.05
     # CorporateAgent: 0.025
     # XenomorphsInfestationRoundstart: 0.02
     # OopsAllThieves: 0.02
@@ -70,6 +75,7 @@
     BlobGameMode: 0.05
     Wizard: 0.025
     CosmicCult: 0.05
+    BloodCult: 0.05
     # CorporateAgent: 0.025
     # XenomorphsInfestationRoundstart: 0.02
 
@@ -100,16 +106,17 @@
   components:
   - type: SecretPlus
     # if you've come here due to "too many antags", lower chaos change for less midrounds and lower starting chaos for less roundstarts
-    minStartingChaos: 11 # scales per player
-    maxStartingChaos: 22
+    minStartingChaos: 22 # scales per player
+    maxStartingChaos: 33
     livingChaosChange: -0.018
     deadChaosChange: 0.020
     # chance for greenshift as well as evilshift
-    chaosChangeVariationMin: 0.65
+    chaosChangeVariationMin: 0.8
     chaosChangeVariationMax: 1.3
     # often fires chud events so relatively low
     eventIntervalMin: 90
     eventIntervalMax: 400
+    DisallowedEvents: [ FriendlySpawn ]
     # there's some misc variables in the comp if you want to try tweaking those
   - type: SelectedGameRules
     scheduledGameRules: !type:NestedSelector
@@ -121,8 +128,8 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: SecretPlus
-    minStartingChaos: 20
-    maxStartingChaos: 33
+    minStartingChaos: 33
+    maxStartingChaos: 44
     livingChaosChange: -0.028
     deadChaosChange: 0.030
     chaosChangeVariationMin: 0.8
@@ -134,8 +141,8 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: SecretPlus
-    minStartingChaos: 40
-    maxStartingChaos: 40 # ling-blob-nukeops is fun
+    minStartingChaos: 45
+    maxStartingChaos: 60 # ling-blob-nukeops is fun
     livingChaosChange: -0.03
     deadChaosChange: 0.03
     chaosExponent: 1

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -116,7 +116,7 @@
     # often fires chud events so relatively low
     eventIntervalMin: 90
     eventIntervalMax: 400
-    DisallowedEvents: [ FriendlySpawn ]
+    disallowedEvents: [ FriendlySpawn ]
     # there's some misc variables in the comp if you want to try tweaking those
   - type: SelectedGameRules
     scheduledGameRules: !type:NestedSelector


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Skalibrowano wartości startowego chaosu by spawnowały odpowiednią liczbę antagów oraz dodano calm antagonistów z mniejszymi celami, opóźnionym startem i mniejszym koszcie w punktach, dla większej różnorodności. Naprawiono wybieranie złodzieja, bo nie działało (bo nie było wpisanego chaos score). Przetestowałem na testowym serwerze robiąc kilka instancji klienta i tak mając kilku graczy, wybierało właściwie i z dobrą proporcja gamerule.

## Powód / Balans
Secretplus wybierał wyłącznie traitorów oraz nie wybierał złodzieja. Teraz czasem, przy większym popie pojawią się ułatwione zombie (z mniejszą infekcją) oraz ułatwieni traitorzy i lingi (opóźniony start, mniej celów)

## Szczegóły techniczne
zmiany w yml

---

**Changelog**
:cl: Zintex
- tweak: Kalibracja trybu secretplus i większa różnorodność w antagonistach
- fix: Naprawiono wybieranie gamerule thief w secretplus