### PR TITLE
Poprawki i tweaki do secret plus.

### DIFF
--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -56,18 +56,14 @@
   - type: GameRule
     minPlayers: 5
     delay:
-      min: 240
-      max: 420
-  - type: AntagRandomObjectives
-    sets:
-    - groups: TraitorObjectiveGroups
-    maxDifficulty: 3
+      min: 600
+      max: 900
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn
     definitions:
     - prefRoles: [ Traitor ]
       max: 4
-      playerRatio: 8
+      playerRatio: 15
       chaosScore: 100 # Polonium
       blacklist:
         components:
@@ -96,6 +92,7 @@
     - prefRoles: [ Changeling ]
       max: 4
       playerRatio: 18
+      chaosScore: 150
       lateJoinAdditional: true
       mindRoles:
       - MindRoleTraitor

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -30,7 +30,7 @@
     CalmTraitor: 0.15
     CalmLing: 0.05
     Changeling: 0.05
-    Heretic: 0.11
+    CalmHeretic: 0.11
     # CorporateAgent: 0.025
     # XenomorphsInfestationRoundstart: 0.02
 
@@ -46,7 +46,7 @@
     Traitor: 0.25
     CalmLing: 0.07
     Changeling: 0.07
-    Heretic: 0.11
+    CalmHeretic: 0.11
     Nukeops: 0.05
     Revolutionary: 0.05
     lowZombies: 0.03
@@ -76,6 +76,7 @@
     Wizard: 0.025
     CosmicCult: 0.05
     BloodCult: 0.05
+    MalfAi: 0.05
     # CorporateAgent: 0.025
     # XenomorphsInfestationRoundstart: 0.02
 

--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -15,7 +15,7 @@
   components:
   - type: HereticRule
   - type: GameRule
-    minPlayers: 8
+    minPlayers: 20
   - type: AntagObjectives
     objectives:
     - HereticKnowledgeObjective
@@ -28,6 +28,7 @@
     - prefRoles: [ Heretic ]
       max: 2
       playerRatio: 25
+      chaosScore: 250
       lateJoinAdditional: true
       mindRoles:
       - MindRoleHeretic
@@ -38,10 +39,10 @@
   id: CalmHeretic # For Dual Antag Gamemodes (i dont want 4 damn heretics with 4 lings)
   components:
   - type: GameRule
-    minPlayers: 20
+    minPlayers: 15
     delay:
-      min: 30
-      max: 60
+      min: 1200
+      max: 1800
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn
     agentName: heretic-roundend-name
@@ -49,4 +50,5 @@
     - prefRoles: [ Heretic ]
       max: 2
       playerRatio: 18
+      chaosScore: 200
       lateJoinAdditional: true


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Poprawki i tweaki do secret plus.

## Powód / Balans
Heretic nie miał chaos score, to go nie pickowało. Zamieniłem go na wariant calmheretica, bo ten wariant służy to stosowania go obok innych gamemodów. Dostosowałem w nim też minimum graczy i mniejszy koszt od podstawowego heretica. CalmTraitorowi wyrzuciłem ten max difficulty, bo dawał traitorów bez celów, zamiast tego się aktywują później. Zmienione im zostało ratio, by przy wybraniu obu traitorowych gamemode przy 20 graczach nie zrobiło 4 traitorów, tylko 3. CalmLing też ma dopisany koszt, bo nie miał, a nie wiem czy go dziedziczył. Ma też nieco mniejszy od podstawowego linga.
Większa różnorodność antagonistów, naprawieni traitorzy bez celów.

## Szczegóły techniczne
edycja yml

---

**Changelog**
:cl: Zintex
- tweak: Zmiana wymagań i kosztów co do heretyków, calm traitorów oraz calm lingów w secret plus.
- fix: Calm traitorzy już dostają zadania inne niż przetrwaj.
- fix: Poprawa pickowania heretyków na secret plus