### PR TITLE
Balans odzysku

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -46,6 +46,8 @@
       - id: RadioHandheldCargo #funkystation
       - id: SeismicCharge
         amount: 2
+      - id: RemoteSignaller
+      - id: Multitool
       - id: WeaponFlareGun
       - id: BoxShotgunFlare
 
@@ -63,5 +65,7 @@
       - id: RadioHandheldCargo #funkystation
       - id: SeismicCharge
         amount: 2
+      - id: RemoteSignaller
+      - id: Multitool
       - id: WeaponFlareGun
       - id: BoxShotgunFlare

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
@@ -28,7 +28,7 @@
     RadioHandheldCargo: 2 #funkystation
     WeaponGrapplingGun: 4
     WeaponProtoKineticAccelerator: 4
-    ShuttleGunKineticCircuitboard: 2 # Polonium, tymczasowo by zachęcić ludzi do skorzystania i przypomnieć że coś takiego wgle istnieje
+    ShuttleGunKineticCircuitboard: 4 # Polonium, tymczasowo by zachęcić ludzi do skorzystania i przypomnieć że coś takiego wgle istnieje
     SeismicCharge: 2
     FultonBeacon: 1
     Fulton: 2

--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -357,7 +357,7 @@
           acts: ["Destruction"]
   - type: Gun
     projectileSpeed: 20
-    fireRate: 2
+    fireRate: 0.5
     selectedMode: SemiAuto
     angleDecay: 45
     minAngle: 5

--- a/Resources/Prototypes/_Polonium/Catalog/salvage_catalog.yml
+++ b/Resources/Prototypes/_Polonium/Catalog/salvage_catalog.yml
@@ -8,7 +8,7 @@
   - SalvageVendorStandard
   conditions:
   - !type:ListingLimitedStockCondition
-    stock: 2
+    stock: 4
 
 
 - type: listing
@@ -20,7 +20,7 @@
   categories:
   - SalvageVendorEquipment
   cost:
-    SalvageTicket: 150
+    SalvageTicket: 100
 
 - type: listing
   id: SalvageVendorShuttleGunSeismicCircuitboard
@@ -31,7 +31,7 @@
   categories:
   - SalvageVendorEquipment
   cost:
-    SalvageTicket: 100
+    SalvageTicket: 50
 
 - type: listing
   id: SalvageVendorShuttleGunPlasmaCutterCircuitboard
@@ -42,7 +42,7 @@
   categories:
   - SalvageVendorEquipment
   cost:
-    SalvageTicket: 500
+    SalvageTicket: 350
 
 - type: listing
   id: SalvageVendorShuttleMineralVacuumCircuitboard
@@ -53,7 +53,7 @@
   categories:
   - SalvageVendorEquipment
   cost:
-    SalvageTicket: 500
+    SalvageTicket: 350
 
 - type: listing
   id: SalvageVendorOreBoxVacuum
@@ -62,6 +62,6 @@
   icon: { sprite:  _Polonium/Structures/Storage/vacuumorebox.rsi, state: vacuumorebox}
   productEntity: OreBoxVacuum
   categories:
-  - SalvageVendorStandard
+  - SalvageVendorEquipment
   cost:
     SalvageTicket: 300

--- a/Resources/Prototypes/_Polonium/Entities/Objects/Devices/Circuitboards/Machine/cannons.yml
+++ b/Resources/Prototypes/_Polonium/Entities/Objects/Devices/Circuitboards/Machine/cannons.yml
@@ -15,9 +15,9 @@
     prototype: ShuttleGunSeismic
     stackRequirements:
       MatterBin: 2
-      Manipulator: 4
+      Manipulator: 1
       Steel: 5
-      CableHV: 5
+      CableHV: 1
 
 - type: entity
   id: ShuttleGunPlasmaCutterCircuitboard
@@ -32,12 +32,12 @@
     prototype: ShuttleGunPlasmaCutter
     stackRequirements:
       MatterBin: 2
-      Manipulator: 4
-      Capacitor: 7
+      Manipulator: 3
+      Capacitor: 2
       Steel: 5
       Glass: 2
-      CableHV: 5
-      Uranium: 1
+      CableHV: 3
+      Gold: 1
 
 - type: entity
   id: ShuttleGunMineralVacuumCircuitboard
@@ -51,10 +51,10 @@
   - type: MachineBoard
     prototype: ShuttleGunMineralVacuum
     stackRequirements:
-      MatterBin: 6
+      MatterBin: 4
       Manipulator: 2
       Capacitor: 2
       Steel: 5
       Glass: 2
-      CableHV: 5
+      CableHV: 2
       Gold: 1

--- a/Resources/Prototypes/_Polonium/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/_Polonium/Entities/Structures/Shuttles/cannons.yml
@@ -93,7 +93,7 @@
         - !type:DoActsBehavior
           acts: ["Destruction"]
   - type: Gun
-    fireRate: 2
+    fireRate: 1.1
     projectileSpeed: 60
     useKey: false
     soundGunshot:


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->

Zwiększa darmową ilość dział KPA, zmniejsza ceny wszystkich dział, poprawnie umieszcza automatyczne pudło na rudy w zakładce ekwipunek, i zmniejsza wymagania do budowy dział na plazmę i odkurzacza

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->

Balansowanie #542 

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: Szyszkrzyneczka

- tweak: Zwiększa darmową ilość dział KPA, zmniejsza ceny wszystkich dział, poprawnie umieszcza automatyczne pudło na rudy w zakładce ekwipunek, i zmniejsza wymagania do budowy dział na plazmę i odkurzacza


