### PR TITLE
Overhaul eksplozji

### DIFF
--- a/Content.Client/Explosion/ExplosionShockwaveOverlay.cs
+++ b/Content.Client/Explosion/ExplosionShockwaveOverlay.cs
@@ -1,0 +1,171 @@
+using System.Numerics;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+
+namespace Content.Client.Explosion;
+
+/// <summary>
+/// Full-screen post-process overlay that renders expanding distortion rings
+/// for explosion shockwaves, synced to server time.
+/// Nuclear-grade waves additionally render a blinding white flash on top.
+/// </summary>
+public sealed class ExplosionShockwaveOverlay : Overlay
+{
+    private readonly IGameTiming _timing;
+    private readonly ExplosionShockwaveSystem _system;
+    private readonly ShaderInstance _shader;
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+    public override bool RequestScreenTexture => true;
+
+    private const int MaxRings = 8;
+    private const string ShaderID = "Shockwave";
+    public ExplosionShockwaveOverlay(ExplosionShockwaveSystem system, IPrototypeManager protoManager, IGameTiming timing)
+    {
+        _system = system;
+        _timing = timing;
+        _shader = protoManager.Index<ShaderPrototype>(ShaderID).Instance().Duplicate();
+        ZIndex = 102;
+    }
+
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        return args.Viewport.Eye != null && _system.ActiveWaves.Count > 0;
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        if (ScreenTexture == null || args.Viewport.Eye == null)
+            return;
+
+        var viewport = args.Viewport;
+        var eye = viewport.Eye!;
+        var now = _timing.CurTime.TotalSeconds;
+        var worldHandle = args.WorldHandle;
+        var renderScale = viewport.RenderScale * eye.Scale;
+
+        var drawn = 0;
+        foreach (var wave in _system.ActiveWaves)
+        {
+            if (drawn >= MaxRings)
+                break;
+
+            if (wave.MapId != args.MapId)
+                continue;
+
+            var elapsed = (float) Math.Max(0, now - wave.ServerStartSeconds);
+            var t = Math.Clamp(elapsed / wave.DurationSeconds, 0f, 1f);
+
+            var radiusTiles = t * wave.MaxRadiusTiles;
+            if (radiusTiles <= 0f)
+                continue;
+
+            var centerLocal = viewport.WorldToLocal(wave.EpicenterWorld);
+            centerLocal.Y = viewport.Size.Y - centerLocal.Y;
+
+            var ppm = EyeManager.PixelsPerMeter;
+            var radiusPx = radiusTiles * ppm;
+
+            var baseThickness = wave.Flash
+                ? Math.Clamp(wave.MaxRadiusTiles * 0.25f, 4f, 16f)
+                : Math.Clamp(wave.MaxRadiusTiles * 0.12f, 2f, 8f);
+            var thicknessPx = baseThickness * ppm;
+
+            var fadeIn = Math.Clamp(t * 5f, 0f, 1f);
+            var fadeOut = Math.Clamp((t - 0.6f) / 0.4f, 0f, 1f);
+            var strength = wave.Intensity * fadeIn * (1f - fadeOut);
+
+            var warpPx = strength * thicknessPx * 0.5f;
+
+            if (warpPx < 0.01f)
+                continue;
+
+            _shader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
+            _shader.SetParameter("center", centerLocal);
+            _shader.SetParameter("radius", radiusPx);
+            _shader.SetParameter("thickness", thicknessPx);
+            _shader.SetParameter("warpStrength", warpPx);
+            _shader.SetParameter("renderScale", renderScale);
+
+            worldHandle.UseShader(_shader);
+            worldHandle.DrawRect(args.WorldAABB, Color.White);
+            worldHandle.UseShader(null);
+
+            drawn++;
+        }
+
+        //  nuclear flash overlays drawn ON TOP of all distortion, so the shader doesn't overwrite them
+        foreach (var wave in _system.ActiveWaves)
+        {
+            if (!wave.Flash)
+                continue;
+
+            if (wave.MapId != args.MapId)
+                continue;
+
+            var elapsed = (float) Math.Max(0, now - wave.ServerStartSeconds);
+            DrawNuclearFlash(worldHandle, args, elapsed, wave.DurationSeconds);
+        }
+    }
+
+    /// <summary>
+    /// Renders a full-screen blinding flash for nuclear detonations
+    /// Timings are stretched to survive frame hitches from explosion
+    /// Phase 1 (0–0.5s): white flash
+    /// Phase 2 (0.5–1.2s): white to orange
+    /// Phase 3 (1.2–3s): orange glow fade
+    /// Phase 4 (3s+): red tint fading out
+    /// </summary>
+    private static void DrawNuclearFlash(
+        DrawingHandleWorld handle,
+        in OverlayDrawArgs args,
+        float elapsed,
+        float duration)
+    {
+        float alpha;
+        Color tint;
+
+        if (elapsed < 0.5f)
+        {
+            alpha = 1f;
+            tint = Color.White;
+        }
+        else if (elapsed < 1.2f)
+        {
+            var p = (elapsed - 0.5f) / 0.7f;
+            var ease = p * p;
+            alpha = 1f - ease * 0.4f;
+            tint = Lerp(Color.White, new Color(1f, 0.85f, 0.5f), ease);
+        }
+        else if (elapsed < 3f)
+        {
+            var p = (elapsed - 1.2f) / 1.8f;
+            var ease = p * p;
+            alpha = 0.6f * (1f - ease);
+            tint = Lerp(new Color(1f, 0.85f, 0.5f), new Color(1f, 0.4f, 0.1f), ease);
+        }
+        else
+        {
+            var p = Math.Clamp((elapsed - 3f) / Math.Max(duration - 3f, 0.5f), 0f, 1f);
+            alpha = 0.1f * (1f - p);
+            tint = new Color(1f, 0.3f, 0.05f);
+        }
+
+        if (alpha <= 0.005f)
+            return;
+
+        var color = new Color(tint.R, tint.G, tint.B, alpha);
+        handle.UseShader(null);
+        handle.DrawRect(args.WorldAABB, color);
+    }
+
+    private static Color Lerp(Color a, Color b, float t)
+    {
+        return new Color(
+            a.R + (b.R - a.R) * t,
+            a.G + (b.G - a.G) * t,
+            a.B + (b.B - a.B) * t);
+    }
+}

--- a/Content.Client/Explosion/ExplosionShockwaveSystem.cs
+++ b/Content.Client/Explosion/ExplosionShockwaveSystem.cs
@@ -1,0 +1,95 @@
+using Content.Shared.Explosion;
+using Robust.Client.Graphics;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+using Vector2 = System.Numerics.Vector2;
+
+namespace Content.Client.Explosion;
+
+/// <summary>
+/// Listens for <see cref="ExplosionShockwaveEvent"/> from the server
+/// and manages the shockwave distortion overlay lifecycle.
+/// </summary>
+public sealed class ExplosionShockwaveSystem : EntitySystem
+{
+    [Dependency] private readonly IOverlayManager _overlays = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IPrototypeManager _protoManager = default!;
+
+    private ExplosionShockwaveOverlay? _overlay;
+
+    public readonly List<ShockwaveInstance> ActiveWaves = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeNetworkEvent<ExplosionShockwaveEvent>(OnShockwave);
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        RemoveOverlay();
+        ActiveWaves.Clear();
+    }
+
+    private void OnShockwave(ExplosionShockwaveEvent ev)
+    {
+        ActiveWaves.Add(new ShockwaveInstance
+        {
+            MapId = ev.MapId,
+            EpicenterWorld = ev.EpicenterWorld,
+            ServerStartSeconds = ev.ServerStartSeconds,
+            MaxRadiusTiles = ev.MaxRadiusTiles,
+            DurationSeconds = ev.DurationSeconds,
+            Intensity = ev.Intensity,
+            Flash = ev.Flash,
+        });
+
+        EnsureOverlay();
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (ActiveWaves.Count == 0)
+            return;
+
+        var now = _timing.CurTime.TotalSeconds;
+        ActiveWaves.RemoveAll(w => now - w.ServerStartSeconds >= w.DurationSeconds);
+
+        if (ActiveWaves.Count == 0)
+            RemoveOverlay();
+    }
+
+    private void EnsureOverlay()
+    {
+        if (_overlay != null)
+            return;
+
+        _overlay = new ExplosionShockwaveOverlay(this, _protoManager, _timing);
+        _overlays.AddOverlay(_overlay);
+    }
+
+    private void RemoveOverlay()
+    {
+        if (_overlay == null)
+            return;
+
+        _overlays.RemoveOverlay(_overlay);
+        _overlay = null;
+    }
+
+    public sealed class ShockwaveInstance
+    {
+        public MapId MapId;
+        public Vector2 EpicenterWorld;
+        public double ServerStartSeconds;
+        public float MaxRadiusTiles;
+        public float DurationSeconds;
+        public float Intensity;
+        public bool Flash;
+    }
+}

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -512,29 +512,29 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
             RaiseNetworkEvent(new ExplosionShockwaveEvent(
                 epicenter.MapId, pos, now,
                 maxRadiusTiles: 1f,
-                durationSeconds: 4f,
+                durationSeconds: 3f,
                 intensity: 0f,
                 flash: true), filter);
 
             // 1 - fast inner distortion ring
             RaiseNetworkEvent(new ExplosionShockwaveEvent(
-                epicenter.MapId, pos, now + 0.4,
+                epicenter.MapId, pos, now + 0.3,
                 maxRadiusTiles: 60f,
-                durationSeconds: 2f,
+                durationSeconds: 1.4f,
                 intensity: 1f), filter);
 
             // 2 - primary shockwave
             RaiseNetworkEvent(new ExplosionShockwaveEvent(
-                epicenter.MapId, pos, now + 0.5,
+                epicenter.MapId, pos, now + 0.35,
                 maxRadiusTiles: 120f,
-                durationSeconds: 3.5f,
+                durationSeconds: 2.5f,
                 intensity: 0.85f), filter);
 
             // 3 - pressure wave
             RaiseNetworkEvent(new ExplosionShockwaveEvent(
-                epicenter.MapId, pos, now + 1.0,
+                epicenter.MapId, pos, now + 0.7,
                 maxRadiusTiles: 200f,
-                durationSeconds: 5f,
+                durationSeconds: 3.5f,
                 intensity: 0.4f), filter);
 
             return;
@@ -545,7 +545,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
         var visualRange = shockwaveRadius + 30f;
 
         var intensity = Math.Clamp(MathF.Sqrt(totalIntensity) / 15f, 0.15f, 1f);
-        var duration = Math.Clamp(shockwaveRadius / 20f, 0.4f, 2.5f);
+        var duration = Math.Clamp(shockwaveRadius / 28f, 0.3f, 1.8f);
 
         var ev = new ExplosionShockwaveEvent(
             epicenter.MapId, pos, now,

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -83,6 +83,7 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Explosion.EntitySystems;
@@ -109,6 +110,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     private EntityQuery<FlammableComponent> _flammableQuery;
     private EntityQuery<PhysicsComponent> _physicsQuery;
@@ -129,8 +131,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
     ///     find errors. However some components, like rogue arrows, or some commands like the admin-smite need to have
     ///     a "default" option specified outside of yaml data-fields. Hence this const string.
     /// </remarks>
-    [ValidatePrototypeId<ExplosionPrototype>]
-    public const string DefaultExplosionPrototypeId = "Default";
+    public static readonly ProtoId<ExplosionPrototype> DefaultExplosionPrototypeId = "Default";
 
     public override void Initialize()
     {
@@ -413,6 +414,9 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
         // camera shake
         CameraShake(iterationIntensity.Count * 4f, pos, queued.TotalIntensity);
 
+        // PVS bypass shockwave distortion ring
+        SendShockwave(pos, iterationIntensity.Count, queued.TotalIntensity);
+
         //For whatever bloody reason, sound system requires ENTITY coordinates.
         var mapEntityCoords = _transformSystem.ToCoordinates(_mapSystem.GetMap(pos.MapId), pos);
 
@@ -484,5 +488,70 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
             if (effect > 0.01f)
                 _recoilSystem.KickCamera(uid, -delta.Normalized() * effect);
         }
+    }
+
+    /// <summary>
+    /// Sends shockwave distortion events to all players in the visual range
+    /// </summary>
+    private void SendShockwave(MapCoordinates epicenter, int iterationCount, float totalIntensity)
+    {
+        const float MinIntensityForShockwave = 20f;
+        const float NuclearIntensityThreshold = 50000f;
+
+        if (totalIntensity < MinIntensityForShockwave)
+            return;
+
+        var now = _timing.CurTime.TotalSeconds;
+        var pos = epicenter.Position;
+
+        if (totalIntensity >= NuclearIntensityThreshold)
+        {
+            var filter = Filter.BroadcastMap(epicenter.MapId);
+
+            // 0 - flash
+            RaiseNetworkEvent(new ExplosionShockwaveEvent(
+                epicenter.MapId, pos, now,
+                maxRadiusTiles: 1f,
+                durationSeconds: 4f,
+                intensity: 0f,
+                flash: true), filter);
+
+            // 1 - fast inner distortion ring
+            RaiseNetworkEvent(new ExplosionShockwaveEvent(
+                epicenter.MapId, pos, now + 0.4,
+                maxRadiusTiles: 60f,
+                durationSeconds: 2f,
+                intensity: 1f), filter);
+
+            // 2 - primary shockwave
+            RaiseNetworkEvent(new ExplosionShockwaveEvent(
+                epicenter.MapId, pos, now + 0.5,
+                maxRadiusTiles: 120f,
+                durationSeconds: 3.5f,
+                intensity: 0.85f), filter);
+
+            // 3 - pressure wave
+            RaiseNetworkEvent(new ExplosionShockwaveEvent(
+                epicenter.MapId, pos, now + 1.0,
+                maxRadiusTiles: 200f,
+                durationSeconds: 5f,
+                intensity: 0.4f), filter);
+
+            return;
+        }
+
+        var radius = IntensityToRadius(totalIntensity, 1f, float.MaxValue);
+        var shockwaveRadius = MathF.Max(radius * 1.5f, 10f);
+        var visualRange = shockwaveRadius + 30f;
+
+        var intensity = Math.Clamp(MathF.Sqrt(totalIntensity) / 15f, 0.15f, 1f);
+        var duration = Math.Clamp(shockwaveRadius / 20f, 0.4f, 2.5f);
+
+        var ev = new ExplosionShockwaveEvent(
+            epicenter.MapId, pos, now,
+            shockwaveRadius, duration, intensity);
+
+        var shockwaveFilter = Filter.Empty().AddInRange(epicenter, visualRange, _playerManager, EntityManager);
+        RaiseNetworkEvent(ev, shockwaveFilter);
     }
 }

--- a/Content.Shared/Explosion/ExplosionShockwaveEvent.cs
+++ b/Content.Shared/Explosion/ExplosionShockwaveEvent.cs
@@ -1,0 +1,43 @@
+using System;
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
+using Vector2 = System.Numerics.Vector2;
+
+namespace Content.Shared.Explosion;
+
+/// <summary>
+/// Broadcast by the server when an explosion occurs so clients can render a screen-space distortion shockwave ring synced to server time
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class ExplosionShockwaveEvent : EntityEventArgs
+{
+    public MapId MapId { get; }
+    public Vector2 EpicenterWorld { get; }
+    public double ServerStartSeconds { get; }
+    public float MaxRadiusTiles { get; }
+    public float DurationSeconds { get; }
+    public float Intensity { get; }
+
+    /// <summary>
+    /// Whether to render a blinding white flash before the distortion ring
+    /// </summary>
+    public bool Flash { get; }
+
+    public ExplosionShockwaveEvent(
+        MapId mapId,
+        Vector2 epicenterWorld,
+        double serverStartSeconds,
+        float maxRadiusTiles,
+        float durationSeconds,
+        float intensity,
+        bool flash = false)
+    {
+        MapId = mapId;
+        EpicenterWorld = epicenterWorld;
+        ServerStartSeconds = serverStartSeconds;
+        MaxRadiusTiles = maxRadiusTiles;
+        DurationSeconds = durationSeconds;
+        Intensity = intensity;
+        Flash = flash;
+    }
+}

--- a/Resources/Prototypes/Shaders/shaders.yml
+++ b/Resources/Prototypes/Shaders/shaders.yml
@@ -204,3 +204,8 @@
   id: IonStorm
   kind: source
   path: "/Textures/Shaders/ion_storm.swsl"
+
+- type: shader
+  id: Shockwave
+  kind: source
+  path: "/Textures/Shaders/shockwave.swsl"

--- a/Resources/Textures/Shaders/shockwave.swsl
+++ b/Resources/Textures/Shaders/shockwave.swsl
@@ -1,0 +1,25 @@
+uniform sampler2D SCREEN_TEXTURE;
+uniform highp vec2 center;       // epicenter in fragment-space pixels
+uniform highp float radius;      // current wavefront radius in pixels
+uniform highp float thickness;   // ring half-width in pixels
+uniform highp float warpStrength; // distortion magnitude (0..1 range typical)
+uniform highp vec2 renderScale;
+
+void fragment()
+{
+    highp vec2 frag = FRAGCOORD.xy;
+    highp vec2 delta = frag - center;
+    highp float dist = length(delta / renderScale);
+
+    highp float ringDist = abs(dist - radius);
+
+    highp float mask = 1.0 - smoothstep(0.0, thickness, ringDist);
+
+    highp float sign_dir = dist < radius ? -1.0 : 1.0;
+    highp float warp = mask * warpStrength * sign_dir;
+
+    highp vec2 dir = dist > 0.001 ? normalize(delta) : vec2(0.0, 1.0);
+    highp vec2 displaced = frag + dir * warp * renderScale;
+
+    COLOR = zTextureSpec(SCREEN_TEXTURE, displaced * SCREEN_PIXEL_SIZE);
+}


### PR DESCRIPTION
## Informacje o PR
Dodano wizualny efekt fali uderzeniowej (shockwave) przy eksplozjach. Przy zwykłych wybuchach pojawia się pierścień dystorsji ekranu, a przy dużych eksplozjach (nuke, ABS) dodatkowo jest wielofazowy efekt z oślepiającym błyskiem i kilkoma falami ciśnienia. 

**Ważne uwagi:**
1. Shader processuje tylko jeden pierścień na raz. Więcej pierścieni — więcej przejść shadera (ograniczone przez `MaxRings` w overlay'u). Wybuch nuklerny tworzy 4 fali, więc teoretycznie 2 jednoczesnych nuke'a => 8 pierścieni (limit). Jak potrzeba więcej — trzeba przerobić shader na tablice (podobnie do tego, jak zrealizowana jest singulo).
2. Flash (błysk tej fali) rysuje się w WorldSpace, więc pokrywa całą mapę, NIE viewport gracza. W przypliżeniu lub przy niestandardowych rozdzielczościach mogą być artefakty. **Warto przetestować**
3. Event `ExplosionShockwaveEvent` celowo nie jest powiązane z obiektem. Jest on wysyłany bezpośrednio przez `Filter.AddInRange` / `BroadcastMap` żeby pominąć PVS. Jeśli ktoś zdecyduje się przerobić to na komponent wykorzystujący `EntityState`, efekt dla graczy znajdujących się w oddali może się popsuć.

## Powód / Balans
Eksplozje wyglądały dość płasko — widziałeś tylko sprite'y ognia na kafelkach i trzęsienie kamery. Teraz masz wizualny feedback, że coś naprawdę jebło. Efekt jest czysto kosmetyczny, nie wpływa na gameplay ani na balans.

## Szczegóły techniczne
- Nowy shader `shockwave.swsl` — przesuwa piksele radialnie na froncie rozszerzającego się pierścienia
- `ExplosionShockwaveEvent` — event sieciowy (bypassuje PVS przez `Filter.AddInRange`/`BroadcastMap`)
- `ExplosionShockwaveSystem` + `ExplosionShockwaveOverlay` po stronie klienta — zarządza cyklem życia overlaya
- Hook w `ExplosionSystem.SendShockwave()` — automatycznie wybiera zwykły lub nuklearny wariant na podstawie progu intensywności >=50k
- Nuklearny wariant: 4 fazy — flash (sam błysk, bez dystorsji), szybki wewnętrzny pierścień, główna fala uderzeniowa, końcowa fala ciśnienia

## Media
[niebieski_bum.webm](https://github.com/user-attachments/assets/49da466c-8c18-4b53-b54e-5c6bb241ab9b)


---

**Changelog**

:cl: Nikita_pl
- add: Eksplozje mają teraz wizualny efekt fali uderzeniowej z dystorsją ekranu
- add: Wybuchy nuklearne i BSA mają dodatkowy efekt oślepiającego błysku i kilku fal ciśnienia