### PR TITLE
Nerf statku instygator

### DIFF
--- a/Resources/Maps/Shuttles/ShuttleEvent/instigator.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/instigator.yml
@@ -773,13 +773,6 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: BoxFolderNuclearCodes
-  entities:
-  - uid: 526
-    components:
-    - type: Transform
-      pos: 1.5254097,1.4605976
-      parent: 1
 - proto: BoxFolderRed
   entities:
   - uid: 327

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -120,6 +120,16 @@
     balance:
       Telecrystal: 50
 
+- type: entity
+  parent: BaseUplinkRadio
+  # Polonium - 25 TC
+  id: BaseUplinkRadio25TC
+  suffix: 25 TC
+  components:
+  - type: Store
+    balance:
+      Telecrystal: 25
+
 # Nukeops reinforcement variant with 50 TC
 - type: entity
   parent: BaseUplinkRadioNukeopsReinforcement

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -122,6 +122,7 @@
     gloves: ClothingHandsGlovesCombatBloodred
     back: ClothingBackpack
     shoes: ClothingShoesBootsCombatFilled
+    pocket1: BaseUplinkRadio25TC
   storage:
     back:
     - BoxSurvivalSyndicate
@@ -134,7 +135,7 @@
     head: ClothingHeadHatOutlawHat
     outerClothing: ClothingOuterArmorBasicSlim
     back: ClothingBackpackSatchel
-    pocket1: BaseUplinkRadio125TC
+    pocket1: BaseUplinkRadio25TC
     pocket2: EnergySword
 
 # Nanotrasen Paramilitary Unit Gear


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR

Ogólnie te goście nie są nuke'owcami, a więc takie moce nie są im potrzebne

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
:cl: Nikita_pl
- remove: Syndykat ze statku "Instigator" nie może już wysadzić stacji - zabrano im kody
- tweak: Syndykat ze statku "Instigator" ma 75 TK na ekipę zamiast 125
