### PR TITLE
Ulepszenia do nowych broni

### DIFF
--- a/Resources/Locale/pl-PL/prototypes/generated/entities/objects/weapons/guns/ammunition/magazines/light_rifle.ftl
+++ b/Resources/Locale/pl-PL/prototypes/generated/entities/objects/weapons/guns/ammunition/magazines/light_rifle.ftl
@@ -1,8 +1,8 @@
 ent-BaseMagazineLightRifle = magazynek (.30 karabinowe)
     .desc = { ent-BaseItem.desc }
-ent-MagazineLightRifleBox = magazynek pudełkowy do L6 SAW (.30 karabinowe)
+ent-MagazineLightRifleBox = magazynek pudełkowy (.30 karabinowe)
     .desc = { ent-BaseMagazineLightRifle.desc }
-ent-MagazineLightRifleBoxEmpty = pusty magazynek pudełkowy do L6 SAW (.30 karabinowe)
+ent-MagazineLightRifleBoxEmpty = pusty magazynek pudełkowy (.30 karabinowe)
     .desc = { ent-MagazineLightRifleBox.desc }
 ent-MagazineLightRifle = magazynek (.30 karabinowe)
     .desc = { ent-BaseMagazineLightRifle.desc }

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -14,6 +14,9 @@
   - type: GunWieldBonus
     minAngle: -21
     maxAngle: -47
+  - type: EyeCursorOffset # Polonium
+    maxOffset: 4
+    pvsIncrease: 0.4
   - type: Gun
     minAngle: 21
     maxAngle: 48

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -14,6 +14,9 @@
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/Shotguns/BigLeady.rsi
   - type: GunRequiresWield
+  - type: PumpAction
+    sound:
+      path: /Audio/_Mono/Weapons/Guns/Cock/shotgun_cock.ogg
   - type: Gun
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/bigshotgun_fire.ogg
@@ -77,6 +80,9 @@
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/Shotguns/BigBuddy.rsi
   - type: GunRequiresWield
+  - type: PumpAction
+    sound:
+      path: /Audio/_Mono/Weapons/Guns/Cock/shotgun_cock.ogg
   - type: Gun
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/bigshotgun_fire.ogg

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -23,6 +23,9 @@
   - type: GunWieldBonus
     minAngle: -27
     maxAngle: -36
+  - type: EyeCursorOffset # Polonium
+    maxOffset: 2.3
+    pvsIncrease: 0.23
   - type: Gun
     minAngle: 27
     maxAngle: 39
@@ -133,8 +136,8 @@
   - type: Appearance
   - type: CursorOffsetRequiresWield
   - type: EyeCursorOffset
-    maxOffset: 7
-    pvsIncrease: 0.7
+    maxOffset: 1.5 # Polonium
+    pvsIncrease: 0.15
   - type: SpeedModifiedOnWield # Mono
     walkModifier: 0.85
     sprintModifier: 0.85


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR

**Changelog**
:cl: Nikitosych
- tweak: Zmniejszono zasięg przesunięcia kamery przy celowaniu z karabinu Mk 98.
- tweak: Big Leady i Big Buddy wymagają teraz przeładowania pompką przed strzałem.