### PR TITLE
Poprawka nazwy prototypu na mapie Dev

### DIFF
--- a/Resources/Maps/Test/dev_map.yml
+++ b/Resources/Maps/Test/dev_map.yml
@@ -1572,7 +1572,7 @@ entities:
     - type: Transform
       pos: 7.5,12.5
       parent: 179
-- proto: BORSniperGun
+- proto: WeaponBORSniperGun
   entities:
   - uid: 1673
     components:


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Poprawka `BORSniperRifle` na `WeaponBORSniperRifle` na mapie Dev.
