### PR TITLE
Przywracanie ciemnych strojów ochrony

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
@@ -176,7 +176,7 @@
    components:
    - type: StorageFill
      contents:
-       - id: ClothingUniformJumpsuitSec
+       - id: ClothingUniformJumpsuitSecBase
        - id: ClothingBackpackSecurity
        - id: ClothingShoesBootsJack
        - id: ClothingEyesGlassesSunglasses

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -581,9 +581,9 @@
   description: Can hold security gear like handcuffs and flashes.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Belt/security_belt.rsi
+    sprite: Clothing/Belt/security.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Belt/security_belt.rsi
+    sprite: Clothing/Belt/security.rsi
   - type: ExplosionResistance # Goobstation
     damageCoefficient: 0.5
   - type: Storage
@@ -760,9 +760,9 @@
   description: A versatile chest rig for holding security gear.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Belt/security_webbing.rsi
+    sprite: Clothing/Belt/securitywebbing.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Belt/security_webbing.rsi
+    sprite: Clothing/Belt/securitywebbing.rsi
 
 - type: entity
   parent: [ ClothingBeltStorageBase, BaseSecurityCargoContraband ]

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -137,9 +137,9 @@
   description: A corporate beret with an officer's rank emblem. A stylish clothing option for security officers.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Head/Hats/security_beret.rsi
+    sprite: Clothing/Head/Hats/beret_security.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Head/Hats/security_beret.rsi
+    sprite: Clothing/Head/Hats/beret_security.rsi
   - type: Tag
     tags:
     - ClothMade
@@ -153,9 +153,9 @@
   description: A campaign hat for the Nanotrasen Troopers, comes with a case too, but you lost it.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Head/Hats/security.rsi
+    sprite: Clothing/Head/Hats/security_trooper_hat.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Head/Hats/security.rsi
+    sprite: Clothing/Head/Hats/security_trooper_hat.rsi
   - type: Tag
     tags:
     - ClothMade
@@ -227,9 +227,9 @@
   description: A white beret with a commander's rank emblem.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Head/Hats/hos_beret.rsi
+    sprite: Clothing/Head/Hats/beret_hos.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Head/Hats/hos_beret.rsi
+    sprite: Clothing/Head/Hats/beret_hos.rsi
   - type: Tag
     tags:
     - ClothMade
@@ -243,9 +243,9 @@
   description: A corporate red beret with a warden's rank emblem. For officers that are more inclined towards style than safety.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Head/Hats/warden_beret.rsi
+    sprite: Clothing/Head/Hats/beret_warden.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Head/Hats/warden_beret.rsi
+    sprite: Clothing/Head/Hats/beret_warden.rsi
 
 - type: entity
   parent: ClothingHeadBase
@@ -443,9 +443,9 @@
   description: The standard-issue cap of the Head of Security. For showing the officers who's in charge.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Head/Hats/hos.rsi
+    sprite: Clothing/Head/Hats/hoshat.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Head/Hats/hos.rsi
+    sprite: Clothing/Head/Hats/hoshat.rsi
   - type: Tag
     tags:
     - ClothMade
@@ -648,9 +648,9 @@
   description: The warden's hat. This hat emphasizes that you are THE LAW
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Head/Hats/warden.rsi
+    sprite: Clothing/Head/Hats/warden.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Head/Hats/warden.rsi
+    sprite: Clothing/Head/Hats/warden.rsi
   - type: StealTarget
     stealGroup: ClothingHeadHatWarden
 

--- a/Resources/Prototypes/Entities/Clothing/Head/soft.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/soft.yml
@@ -266,9 +266,9 @@
   description: It's a robust baseball hat in tasteful red colour.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Head/Hats/security_soft.rsi
+    sprite: Clothing/Head/Soft/secsoft.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Head/Hats/security_soft.rsi
+    sprite: Clothing/Head/Soft/secsoft.rsi
 
 - type: entity
   parent: [ClothingHeadHeadHatBaseFlipped, ClothingHeadHatSecsoft]

--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -75,7 +75,7 @@
   description: An exquisite dark and red cloak fitting for those who can assert dominance over wrongdoers. Take a stab at being civil in prosecution!
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Neck/Cloaks/hos_cloak.rsi
+    sprite: Clothing/Neck/Cloaks/hos.rsi
   - type: StealTarget
     stealGroup: HeadCloak
   - type: MeleeWeapon

--- a/Resources/Prototypes/Entities/Clothing/Neck/mantles.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/mantles.yml
@@ -84,9 +84,9 @@
   description: This ostentatious mantle is a symbol of commitment to the station.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Neck/Mantle/hos_mantle.rsi
+    sprite: Clothing/Neck/mantles/hosmantle.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Neck/Mantle/hos_mantle.rsi
+    sprite: Clothing/Neck/mantles/hosmantle.rsi
   - type: MeleeWeapon
     damage:
       types:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -70,9 +70,9 @@
   description: A standard Type I armored vest that provides decent protection against most types of damage.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/OuterClothing/Vests/security.rsi
+    sprite: Clothing/OuterClothing/Armor/security.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/OuterClothing/Vests/security.rsi
+    sprite: Clothing/OuterClothing/Armor/security.rsi
   - type: Armor #Based on /tg/ but slightly compensated to fit the fact that armor stacks in SS14.
     modifiers:
       coefficients:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -184,9 +184,9 @@
   description: A greatcoat enhanced with a special alloy for some extra protection and style for those with a commanding presence.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/OuterClothing/Coats/hos.rsi
+    sprite: Clothing/OuterClothing/Coats/hos_trenchcoat.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/OuterClothing/Coats/hos.rsi
+    sprite: Clothing/OuterClothing/Coats/hos_trenchcoat.rsi
 
 - type: entity
   parent: ClothingOuterStorageToggleableBase
@@ -409,9 +409,9 @@
   description: A sturdy, utilitarian jacket designed to protect a warden from any brig-bound threats.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/OuterClothing/Coats/warden.rsi
+    sprite: Clothing/OuterClothing/Coats/warden.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/OuterClothing/Coats/warden.rsi
+    sprite: Clothing/OuterClothing/Coats/warden.rsi
 
 - type: entity
   parent: ClothingOuterStorageBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -328,9 +328,9 @@
   description: A sturdy, utilitarian winter coat designed to protect a head of security from any brig-bound threats and hypothermic events.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/OuterClothing/WinterCoats/hos_wintercoat.rsi
+    sprite: Clothing/OuterClothing/WinterCoats/coathosarmored.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/OuterClothing/WinterCoats/hos_wintercoat.rsi
+    sprite: Clothing/OuterClothing/WinterCoats/coathosarmored.rsi
 
 ##########################################################
 
@@ -618,9 +618,20 @@
   description: A winter coat outfitted with standard type I armored vest padding with some modifications as to fit both the padding and the insulation.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/OuterClothing/WinterCoats/sec_wintercoat.rsi
+    sprite: Clothing/OuterClothing/WinterCoats/coat.rsi
+    layers:
+    - state: SEC-icon
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: SEC-inhand-left
+      right:
+      - state: SEC-inhand-right
   - type: Clothing
-    sprite: _Funkystation/Clothing/OuterClothing/WinterCoats/sec_wintercoat.rsi
+    sprite: Clothing/OuterClothing/WinterCoats/coat.rsi
+    clothingVisuals:
+      outerClothing:
+      - state: SEC-equipped-OUTERCLOTHING
   - type: Armor
     modifiers:
       coefficients:
@@ -661,9 +672,9 @@
   description: A sturdy, utilitarian winter coat designed to protect a warden from any brig-bound threats and hypothermic events.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/OuterClothing/WinterCoats/ward_wintercoat.rsi
+    sprite: Clothing/OuterClothing/WinterCoats/coatwardenarmored.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/OuterClothing/WinterCoats/ward_wintercoat.rsi
+    sprite: Clothing/OuterClothing/WinterCoats/coatwardenarmored.rsi
 
 ################################################################
 

--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -214,9 +214,9 @@
   description: Nanotrasen-issue Security winter boots for cold combat scenarios or cold combat situations. All cold combat, all the time.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Shoes/Boots/insulatedjackboots.rsi
+    sprite: Clothing/Shoes/Boots/winterbootssec.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Shoes/Boots/insulatedjackboots.rsi
+    sprite: Clothing/Shoes/Boots/winterbootssec.rsi
   - type: ClothingSlowOnDamageModifier # Goobstation
     modifier: 0.55
   - type: ClothingModifyStunTime # Goobstation

--- a/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
@@ -102,3 +102,9 @@
   id: HeadofSecurityArmorVestSlim
   equipment:
     outerClothing: ClothingOuterArmorBasicSlim
+
+# Shoes
+- type: loadout
+  id: HeadofSecurityFunkyWinterBoots
+  equipment:
+    shoes: ClothingShoesBootsWinterSecFunkyExclusive

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -2001,6 +2001,15 @@
   - HeadofSecurityWinterCoat
   - HeadofSecurityArmorVest
 
+- type: loadoutGroup
+  id: HeadofSecurityShoes
+  name: loadout-group-security-shoes
+  loadouts:
+  - HeadofSecurityFunkyWinterBoots
+  - CombatBoots
+  - JackBoots
+  - SecurityWinterBoots
+
 - type: loadoutGroup #WizDen Weh Job Plush
   id: HeadofSecurityJobTrinkets
   name: loadout-group-jobtrinkets

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -468,7 +468,7 @@
   - SecurityBackpack
   - SecurityBelt
   - HeadofSecurityOuterClothing
-  - SecurityShoes
+  - HeadofSecurityShoes
   - SurvivalSecurity
   - Trinkets
   - HeadofSecurityJobTrinkets
@@ -561,7 +561,6 @@
   - SecurityGloves # Funky
   - SecurityShoes
   - SurvivalSecurity
-  - SecurityOuterClothing # Goobstation - Why not.
   - Trinkets
   - GroupSpeciesBreathToolSecurity
 

--- a/Resources/Prototypes/_Funkystation/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Clothing/Head/hats.yml
@@ -133,9 +133,9 @@
   description: A clean, white hat for the newly enlisted! Here's hoping it stays clean.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Head/Hats/cadet.rsi
+    sprite: Clothing/Head/Hats/beret_security.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Head/Hats/cadet.rsi
+    sprite: Clothing/Head/Hats/beret_security.rsi
   - type: Tag
     tags:
     - ClothMade

--- a/Resources/Prototypes/_Funkystation/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -263,9 +263,9 @@
   description: A uniform made of strong material, for day to day wear.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/security_dress.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/security.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/security_dress.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/security.rsi
 
 - type: entity
   parent: [ClothingUniformBase, BaseSecurityContraband]
@@ -274,9 +274,9 @@
   description: A uniform made of strong material, for day to day wear. Awarded to senior officers so they feel better about their time spent on the force.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/security_dress_senior.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/security_grey.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/security_dress_senior.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/security_grey.rsi
 
 - type: entity
   parent: [ClothingUniformBase, BaseSecurityContraband]
@@ -285,9 +285,9 @@
   description: A uniform made of strong material, for special occasions.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/security_mess.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/security.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/security_mess.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/security.rsi
 
 - type: entity
   parent: [ClothingUniformBase, BaseSecurityContraband]
@@ -296,9 +296,9 @@
   description: A uniform made of strong material, for day to day wear.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/hos_dress.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/hos_alt.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/hos_dress.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/hos_alt.rsi
 
 - type: entity
   parent: [ClothingUniformBase, BaseSecurityContraband]
@@ -307,6 +307,6 @@
   description: The head of security's formal uniform, for special occasions
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/hos_mess.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/hos_parade.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/hos_mess.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/hos_parade.rsi

--- a/Resources/Prototypes/_Funkystation/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -653,9 +653,9 @@
   description: A uniform issued to the Nanotrasen troops, usually it comes with a car.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/security.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/security.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/security.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/security.rsi
 
 - type: entity
   parent: [ClothingUniformBase, BaseSecurityContraband]
@@ -664,9 +664,9 @@
   description: A uniform made of strong material, for day to day wear.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/security_dress.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/security_blue.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/security_dress.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/security_blue.rsi
 
 - type: entity
   parent: [ClothingUniformBase, BaseSecurityContraband]
@@ -675,9 +675,9 @@
   description: A uniform made of strong material, for day to day wear. Awarded to senior officers so they feel better about their time spent on the force.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/security_dress_senior.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/security_grey.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/security_dress_senior.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/security_grey.rsi
 
 - type: entity
   parent: [ClothingUniformBase, BaseSecurityContraband]
@@ -686,9 +686,9 @@
   description: A uniform made of strong material, for special occasions.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/security_mess.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/security_trooper.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/security_mess.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/security_trooper.rsi
 
 # Head of security uniforms (Tea)
 
@@ -699,9 +699,9 @@
   description: The head of security's service uniform, for when you anticipate a war on mothroaches.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/hos.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/hos.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/hos.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/hos.rsi
 
 - type: entity
   parent: [ClothingUniformBase, BaseSecurityContraband]
@@ -710,9 +710,9 @@
   description: The head of security's dress uniform, for day to day wear.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/hos_dress.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/hos_alt.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/hos_dress.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/hos_alt.rsi
 
 - type: entity
   parent: [ClothingUniformBase, BaseSecurityContraband]
@@ -721,9 +721,9 @@
   description: The head of security's formal uniform, for special occasions
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/hos_mess.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/hos_parade.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/hos_mess.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/hos_parade.rsi
 
 # Cadet uniform (Tea)
 
@@ -734,6 +734,6 @@
   description: A uniform made of strong material, providing robust protection.
   components:
   - type: Sprite
-    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/cadet.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/security.rsi
   - type: Clothing
-    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/cadet.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/security.rsi

--- a/Resources/Prototypes/_Polonium/Entities/Clothing/security_funky_exclusive.yml
+++ b/Resources/Prototypes/_Polonium/Entities/Clothing/security_funky_exclusive.yml
@@ -1,0 +1,422 @@
+# Uniforms
+
+- type: entity
+  parent: ClothingUniformJumpsuitSecBase
+  id: ClothingUniformJumpsuitSecBaseFunkyExclusive
+  name: security service uniform
+  description: Exclusive security uniform. Not sold in SecDrobe or standard loadouts.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/security.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/security.rsi
+
+- type: entity
+  parent: ClothingUniformSecurityDressBase
+  id: ClothingUniformSecurityDressBaseFunkyExclusive
+  name: security dress uniform
+  description: Exclusive security dress uniform.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/security_dress.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/security_dress.rsi
+
+- type: entity
+  parent: ClothingUniformSecurityDressSenior
+  id: ClothingUniformSecurityDressSeniorFunkyExclusive
+  name: security senior dress uniform
+  description: Exclusive senior security dress uniform.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/security_dress_senior.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/security_dress_senior.rsi
+
+- type: entity
+  parent: ClothingUniformSecurityMessBase
+  id: ClothingUniformSecurityMessBaseFunkyExclusive
+  name: security mess uniform
+  description: Exclusive security mess uniform.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/security_mess.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/security_mess.rsi
+
+- type: entity
+  parent: ClothingUniformSecurityDressSkirtBase
+  id: ClothingUniformSecurityDressSkirtBaseFunkyExclusive
+  name: security dress uniform with skirt
+  description: Exclusive security dress skirt.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/security_dress.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/security_dress.rsi
+
+- type: entity
+  parent: ClothingUniformSecurityDressSkirtSenior
+  id: ClothingUniformSecurityDressSkirtSeniorFunkyExclusive
+  name: security senior dress uniform with skirt
+  description: Exclusive senior security dress skirt.
+  suffix: Funky Exclusive
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/security_dress_senior.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/security_dress_senior.rsi
+
+- type: entity
+  parent: ClothingUniformSecurityMessSkirtBase
+  id: ClothingUniformSecurityMessSkirtBaseFunkyExclusive
+  name: security mess uniform with skirt
+  description: Exclusive security mess skirt.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/security_mess.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/security_mess.rsi
+
+- type: entity
+  parent: ClothingUniformJumpsuitHosBase
+  id: ClothingUniformJumpsuitHosBaseFunkyExclusive
+  name: head of security's service uniform
+  description: Exclusive HoS service uniform.
+  suffix: Funky Exclusive
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/hos.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/hos.rsi
+
+- type: entity
+  parent: ClothingUniformDressHosBase
+  id: ClothingUniformDressHosBaseFunkyExclusive
+  name: head of security's dress uniform
+  description: Exclusive HoS dress uniform.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/hos_dress.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/hos_dress.rsi
+
+- type: entity
+  parent: ClothingUniformMessHosBase
+  id: ClothingUniformMessHosBaseFunkyExclusive
+  name: head of security's formal uniform
+  description: Exclusive HoS formal uniform.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/hos_mess.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/hos_mess.rsi
+
+- type: entity
+  parent: ClothingUniformHosDressSkirtBase
+  id: ClothingUniformHosDressSkirtBaseFunkyExclusive
+  name: head of security's dress uniform with skirt
+  description: Exclusive HoS dress skirt.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/hos_dress.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/hos_dress.rsi
+
+- type: entity
+  parent: ClothingUniformMessHosDressBase
+  id: ClothingUniformMessHosDressBaseFunkyExclusive
+  name: head of security's formal dress
+  description: Exclusive HoS formal dress.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/hos_mess.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Uniforms/Jumpskirt/hos_mess.rsi
+
+- type: entity
+  parent: ClothingUniformJumpsuitCadetBase
+  id: ClothingUniformJumpsuitCadetBaseFunkyExclusive
+  name: enlisted uniform
+  description: Exclusive security cadet uniform.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/cadet.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Uniforms/Jumpsuit/cadet.rsi
+
+# Headwear
+
+- type: entity
+  parent: ClothingHeadHatBeretSecurity
+  id: ClothingHeadHatBeretSecurityFunkyExclusive
+  name: security beret
+  description: Exclusive security beret.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Head/Hats/security_beret.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Head/Hats/security_beret.rsi
+
+- type: entity
+  parent: ClothingHeadHatSecurityTrooper
+  id: ClothingHeadHatSecurityTrooperFunkyExclusive
+  name: trooper hat
+  description: Exclusive trooper hat.
+  suffix: Funky Exclusive
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Head/Hats/security.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Head/Hats/security.rsi
+
+- type: entity
+  parent: ClothingHeadHatSecsoft
+  id: ClothingHeadHatSecsoftFunkyExclusive
+  name: security cap
+  description: Exclusive security cap.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Head/Hats/security_soft.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Head/Hats/security_soft.rsi
+
+- type: entity
+  parent: ClothingHeadHatBeretHoS
+  id: ClothingHeadHatBeretHoSFunkyExclusive
+  name: head of security's beret
+  description: Exclusive FunkyStation-issue HoS beret.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Head/Hats/hos_beret.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Head/Hats/hos_beret.rsi
+
+- type: entity
+  parent: ClothingHeadHatBeretWarden
+  id: ClothingHeadHatBeretWardenFunkyExclusive
+  name: warden's beret
+  description: Exclusive warden beret.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Head/Hats/warden_beret.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Head/Hats/warden_beret.rsi
+
+- type: entity
+  parent: ClothingHeadHatHoshat
+  id: ClothingHeadHatHoshatFunkyExclusive
+  name: head of security's hat
+  description: Exclusive HoS cap.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Head/Hats/hos.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Head/Hats/hos.rsi
+
+- type: entity
+  parent: ClothingHeadHatWarden
+  id: ClothingHeadHatWardenFunkyExclusive
+  name: warden's hat
+  description: Exclusive warden hat.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Head/Hats/warden.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Head/Hats/warden.rsi
+
+- type: entity
+  parent: ClothingHeadHatCadetSecurity
+  id: ClothingHeadHatCadetSecurityFunkyExclusive
+  name: cadet's white sailor hat
+  description: Exclusive cadet hat.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Head/Hats/cadet.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Head/Hats/cadet.rsi
+
+# Outer clothing
+
+- type: entity
+  parent: ClothingOuterArmorBasic
+  id: ClothingOuterArmorBasicFunkyExclusive
+  name: armor vest
+  description: Exclusive armor vest.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/OuterClothing/Vests/security.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/OuterClothing/Vests/security.rsi
+
+- type: entity
+  parent: ClothingOuterArmorBasicSlim
+  id: ClothingOuterArmorBasicSlimFunkyExclusive
+  name: armor vest
+  description: Exclusive slim armor vest.
+  suffix: Funky, Slim
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/OuterClothing/Vests/security.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/OuterClothing/Vests/security.rsi
+
+- type: entity
+  parent: ClothingOuterCoatHoSTrench
+  id: ClothingOuterCoatHoSTrenchFunkyExclusive
+  name: head of security's armored trenchcoat
+  description: Exclusive HoS trenchcoat.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/OuterClothing/Coats/hos.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/OuterClothing/Coats/hos.rsi
+
+- type: entity
+  parent: ClothingOuterCoatWarden
+  id: ClothingOuterCoatWardenFunkyExclusive
+  name: warden's armored jacket
+  description: Exclusive warden jacket.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/OuterClothing/Coats/warden.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/OuterClothing/Coats/warden.rsi
+
+- type: entity
+  parent: [ClothingOuterWinterCoatToggleable, BaseSecurityContraband, AllowBackStorageClothingCombat]
+  id: ClothingOuterWinterSecFunkyExclusive
+  name: security winter coat
+  description: Exclusive security winter coat.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/OuterClothing/WinterCoats/sec_wintercoat.rsi
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+      right:
+      - state: inhand-right
+  - type: Clothing
+    sprite: _Funkystation/Clothing/OuterClothing/WinterCoats/sec_wintercoat.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.85
+  - type: ExplosionResistance
+    damageCoefficient: 0.90
+  - type: StaminaResistance
+    damageCoefficient: 0.80
+  - type: ToggleableClothing
+    clothingPrototype: ClothingHeadHatHoodWinterSec
+
+- type: entity
+  parent: ClothingOuterWinterHoS
+  id: ClothingOuterWinterHoSFunkyExclusive
+  name: head of security's armored winter coat
+  description: Exclusive HoS winter coat.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/OuterClothing/WinterCoats/hos_wintercoat.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/OuterClothing/WinterCoats/hos_wintercoat.rsi
+
+- type: entity
+  parent: ClothingOuterWinterWarden
+  id: ClothingOuterWinterWardenFunkyExclusive
+  name: warden's armored winter coat
+  description: Exclusive warden winter coat.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/OuterClothing/WinterCoats/ward_wintercoat.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/OuterClothing/WinterCoats/ward_wintercoat.rsi
+
+# Belts & shoes
+
+- type: entity
+  parent: ClothingBeltSecurity
+  id: ClothingBeltSecurityFunkyExclusive
+  name: security belt
+  description: Exclusive security belt.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Belt/security_belt.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Belt/security_belt.rsi
+
+- type: entity
+  parent: ClothingBeltSecurityWebbing
+  id: ClothingBeltSecurityWebbingFunkyExclusive
+  name: security carrier
+  description: Exclusive security carrier.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Belt/security_webbing.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Belt/security_webbing.rsi
+
+- type: entity
+  parent: ClothingShoesBootsWinterSec
+  id: ClothingShoesBootsWinterSecFunkyExclusive
+  name: insulated jackboots
+  description: Exclusive security winter boots.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Shoes/Boots/insulatedjackboots.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Shoes/Boots/insulatedjackboots.rsi
+
+# HoS neck (loadout items)
+
+- type: entity
+  parent: ClothingNeckCloakHos
+  id: ClothingNeckCloakHosFunkyExclusive
+  name: head of security's cloak
+  description: Exclusive HoS cloak.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Neck/Cloaks/hos_cloak.rsi
+
+- type: entity
+  parent: ClothingNeckMantleHOS
+  id: ClothingNeckMantleHOSFunkyExclusive
+  name: head of security's mantle
+  description: Exclusive HoS mantle.
+  suffix: Funky
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Clothing/Neck/Mantle/hos_mantle.rsi
+  - type: Clothing
+    sprite: _Funkystation/Clothing/Neck/Mantle/hos_mantle.rsi


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR

Przywrócono **standardowe** sprite'y ubrań Security (`Clothing/...`) dla głównych prototypów ról: oficer, kadet, HoS, warden (mundury, głowy, płaszcze, zbroje, pasy, buty, peleryny itd.).

Warianty Funky wydzielono do osobnych prototypów `*FunkyExclusive` w `security_funky_exclusive.yml` — nie są w SecDrobe ani w standardowych loadoutach, można je dostać ręcznie lub z szaf (poza automatami).

Dodatkowo:
- **Kadet** — brak kamizelki przy spawnie i w loadoutach
- **HoS** — pozostawiono obuwie z Funky: `ClothingShoesBootsWinterSecFunkyExclusive` (loadout `HeadofSecurityShoes`).
- Szafa ochrony: `ClothingUniformJumpsuitSec` -> `ClothingUniformJumpsuitSecBase`.

## Powód / Balans

Wcześniej podstawowa odzież Sec korzystała ze spritów `_Funkystation/...`, ale uznaliśmy, że stare ciemne stroje były znacznie ładniejsze.

---

**Changelog**

:cl: Nikita_pl
- tweak: Główna odzież ochrony używa teraz standardowych sprite'ów zamiast Funky.
- add: Osobna odzież ochrony z Funky po prostu jako osobne przedmioty.
- remove: Kadet nie otrzymuje kamizelki kuloodpornej w loadoucie przy spawnie