### PR TITLE
Naprawiono widmowe pociski

### DIFF
--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
@@ -385,8 +385,13 @@ public sealed partial class GunSystem : SharedGunSystem
         EntityUid? user = null,
         float speed = 20)
     {
-        EnsureComp<PredictedProjectileClientComponent>(uid);
-        _physics.UpdateIsPredicted(uid);
+        // Polonium - only mark projectiles as client-predicted when net.predict is enabled.
+        if (ClientSideGunPrediction)
+        {
+            EnsureComp<PredictedProjectileClientComponent>(uid);
+            _physics.UpdateIsPredicted(uid);
+        }
+
         base.ShootProjectile(uid, direction, gunVelocity, gunUid, user, speed);
     }
 }

--- a/Content.Client/_RMC14/Weapons/Ranged/Prediction/GunPredictionSystem.cs
+++ b/Content.Client/_RMC14/Weapons/Ranged/Prediction/GunPredictionSystem.cs
@@ -17,6 +17,7 @@ using Content.Shared.Projectiles;
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Client.GameObjects;
+using Robust.Client.GameStates;
 using Robust.Client.Physics;
 using Robust.Client.Player;
 using Robust.Shared.Map;
@@ -32,21 +33,21 @@ public sealed class GunPredictionSystem : SharedGunPredictionSystem
 {
     public const string ProjectileFixture = "projectile";
     [Dependency] private readonly SharedGunSystem _gun = default!;
+    [Dependency] private readonly IClientGameStateManager _gameState = default!;
     [Dependency] private readonly PhysicsSystem _physics = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly ProjectileSystem _projectile = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     private EntityQuery<IgnorePredictionHideComponent> _ignorePredictionHideQuery;
-    private EntityQuery<SpriteComponent> _spriteQuery;
 
     public override void Initialize()
     {
         base.Initialize();
 
         _ignorePredictionHideQuery = GetEntityQuery<IgnorePredictionHideComponent>();
-        _spriteQuery = GetEntityQuery<SpriteComponent>();
 
         SubscribeLocalEvent<PhysicsUpdateBeforeSolveEvent>(OnBeforeSolve);
         SubscribeLocalEvent<PhysicsUpdateAfterSolveEvent>(OnAfterSolve);
@@ -122,9 +123,7 @@ public sealed class GunPredictionSystem : SharedGunPredictionSystem
         return;
 
     // Check if contact is anchored for directional filtering
-    var isAnchored = false;
-    if (TryComp<TransformComponent>(args.OtherEntity, out var contactXform))
-        isAnchored = contactXform.Anchored;
+    var isAnchored = Transform(args.OtherEntity).Anchored;
 
     // Additional filtering for non-anchored entities - match Update() logic
     if (!isAnchored)
@@ -160,11 +159,31 @@ public sealed class GunPredictionSystem : SharedGunPredictionSystem
     RaiseNetworkEvent(ev);
 
     _projectile.ProjectileCollide((ent, projectile, physics), args.OtherEntity, predicted: true);
+    // Polonium - stop and hide predicted projectile on hit
+    FinishPredictedClientHit(ent, ent.Comp, physics);
 }
+
+    // Polonium - predicted ProjectileCollide does not delete or stop the client projectile, causing ghost bullets
+    private void FinishPredictedClientHit(
+        EntityUid uid,
+        PredictedProjectileClientComponent predicted,
+        PhysicsComponent physics)
+    {
+        if (predicted.Hit)
+            return;
+
+        predicted.Hit = true;
+
+        _physics.SetLinearVelocity(uid, Vector2.Zero, body: physics);
+
+        _sprite.SetVisible(uid, false);
+    }
 
     private void OnServerProjectileStartup(Entity<PredictedProjectileServerComponent> ent, ref ComponentStartup args)
     {
-        if (!GunPrediction)
+        // Polonium - keep server projectiles visible when net.predict is off
+        // Client relies on them instead of local ones.
+        if (!GunPrediction || !_gameState.IsPredictionEnabled)
             return;
 
         if (ent.Comp.ClientEnt != _player.LocalEntity)
@@ -173,8 +192,7 @@ public sealed class GunPredictionSystem : SharedGunPredictionSystem
         if (_ignorePredictionHideQuery.HasComp(ent))
             return;
 
-        if (_spriteQuery.TryComp(ent, out var sprite))
-            sprite.Visible = false;
+        _sprite.SetVisible(ent.Owner, false);
     }
 
 public override void Update(float frameTime)
@@ -232,9 +250,7 @@ public override void Update(float frameTime)
                 continue;
 
             // Check if contact is anchored
-            var isAnchored = false;
-            if (TryComp<TransformComponent>(contact, out var contactXform))
-                isAnchored = contactXform.Anchored;
+            var isAnchored = Transform(contact).Anchored;
 
             // Check if any of the contact's fixtures would collide with the projectile fixture
             var shouldCollide = false;
@@ -302,17 +318,19 @@ public override void Update(float frameTime)
         RaiseNetworkEvent(ev);
 
         _projectile.ProjectileCollide((uid, projectile, physics), filteredContacts.First());
+        // Polonium - same ghost-bullet fix as StartCollide fallback path        FinishPredictedClientHit(uid, predicted, physics);
     }
 
     var predictedQuery = EntityQueryEnumerator<PredictedProjectileHitComponent, SpriteComponent, TransformComponent>();
-    while (predictedQuery.MoveNext(out var hit, out var sprite, out var xform))
+    // Polonium - use entity uid from query; first out var was the component, not EntityUid
+    while (predictedQuery.MoveNext(out var uid, out var hit, out var sprite, out var xform))
     {
         var origin = hit.Origin;
         var coordinates = xform.Coordinates;
         if (!origin.TryDistance(EntityManager, _transform, coordinates, out var distance) ||
             distance >= hit.Distance)
         {
-            sprite.Visible = false;
+            _sprite.SetVisible((uid, sprite), false);
         }
     }
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -87,6 +87,7 @@ using Content.Shared.Weapons.Hitscan.Components;
 using Content.Shared.Weapons.Hitscan.Events;
 using Content.Shared.Weapons.Reflect;
 using Content.Shared.Whitelist;
+using Robust.Shared;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
@@ -149,6 +150,11 @@ public abstract partial class SharedGunSystem : EntitySystem
     public const string ModeExamineColor = "cyan";
     private const float DamagePitchVariation = 0.05f;
     public bool GunPrediction { get; private set; }
+
+    // Polonium - require both RMC gun prediction and client net.predict; without net.predict client-side
+    // projectiles never simulate physics while server sprites stay hidden, so nothing is visible.
+    protected bool ClientSideGunPrediction =>
+        GunPrediction && (!_netManager.IsClient || _config.GetCVar(CVars.NetPredict));
 
     public override void Initialize()
     {
@@ -577,7 +583,8 @@ public abstract partial class SharedGunSystem : EntitySystem
                 case CartridgeAmmoComponent cartridge:
                     if (!cartridge.Spent)
                     {
-                        if (_netManager.IsServer || GunPrediction)
+                        // Polonium - was GunPrediction, gate on ClientSideGunPrediction so client spawns nothing when net.predict is off
+                        if (_netManager.IsServer || ClientSideGunPrediction)
                         {
                             var uid = Spawn(cartridge.Prototype, fromEnt);
                             CreateAndFireProjectiles(uid, cartridge);
@@ -620,7 +627,7 @@ public abstract partial class SharedGunSystem : EntitySystem
                     break;
                 // Ammo shoots itself
                 case AmmoComponent newAmmo:
-                    if (_netManager.IsServer || GunPrediction)
+                    if (_netManager.IsServer || ClientSideGunPrediction)
                     {
                         CreateAndFireProjectiles(ent!.Value, newAmmo);
                     }
@@ -647,7 +654,7 @@ public abstract partial class SharedGunSystem : EntitySystem
                     if (ent == null)
                         break;
 
-                    if (_netManager.IsServer || GunPrediction)
+                    if (_netManager.IsServer || ClientSideGunPrediction)
                     {
                         var hitscanEv = new HitscanTraceEvent
                         {
@@ -852,7 +859,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         if (!HasComp<ProjectileComponent>(uid))
         {
             // Remove shootable components on client side for prediction, similar to AmmoComponent handling
-            if (_netManager.IsClient && !GunPrediction)
+            if (_netManager.IsClient && !ClientSideGunPrediction)
                 RemoveShootable(uid);
 
             // Ensure thrown items are removed from containers so they're visible


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Naprawiono predykcję pocisków po stronie klienta: widmowe pociski po trafieniu w ścianę nie znikały oraz brak widocznych pocisków przy wyłączonym `net.predict`.

Closes #629

## Szczegóły techniczne
- `SharedGunSystem` -- nowe `ClientSideGunPrediction` (wymaga `RMCGunPrediction` i `net.predict`)
- `GunPredictionSystem` — zatrzymanie i ukrycie przewidywanego pocisku po trafieniu; serwerowe pociski widoczne przy wyłączonej predykcji
- `GunSystem` — lokalna predykcja pocisków tylko gdy oba warunki są spełnione

---

**Changelog**
:cl: Nikita_pl
- fix: Naprawiono widmowe pociski przelatujące przez ściany przy włączonej predykcji.
- fix: Naprawiono niewidoczne pociski przy wyłączonej predykcji w ustawieniach sieci.