### PR TITLE
Poprawiono bugi  w ostatnich kommitach #627 #633

### DIFF
--- a/Content.Client/Explosion/ExplosionShockwaveOverlay.cs
+++ b/Content.Client/Explosion/ExplosionShockwaveOverlay.cs
@@ -61,6 +61,9 @@ public sealed class ExplosionShockwaveOverlay : Overlay
                 continue;
 
             var elapsed = (float) Math.Max(0, now - wave.ServerStartSeconds);
+            if (wave.DurationSeconds <= 0f)
+                continue;
+
             var t = Math.Clamp(elapsed / wave.DurationSeconds, 0f, 1f);
 
             var radiusTiles = t * wave.MaxRadiusTiles;

--- a/Content.Client/Explosion/ExplosionShockwaveSystem.cs
+++ b/Content.Client/Explosion/ExplosionShockwaveSystem.cs
@@ -41,6 +41,14 @@ public sealed class ExplosionShockwaveSystem : EntitySystem
 
     private void OnShockwave(ExplosionShockwaveEvent ev)
     {
+        if (ev.DurationSeconds <= 0f ||
+            float.IsNaN(ev.DurationSeconds) ||
+            float.IsNaN(ev.MaxRadiusTiles) ||
+            float.IsNaN(ev.Intensity))
+        {
+            return;
+        }
+
         ActiveWaves.Add(new ShockwaveInstance
         {
             MapId = ev.MapId,

--- a/Content.Client/_RMC14/Weapons/Ranged/Prediction/GunPredictionSystem.cs
+++ b/Content.Client/_RMC14/Weapons/Ranged/Prediction/GunPredictionSystem.cs
@@ -319,7 +319,8 @@ public override void Update(float frameTime)
         RaiseNetworkEvent(ev);
 
         _projectile.ProjectileCollide((uid, projectile, physics), filteredContacts.First());
-        // Polonium - same ghost-bullet fix as StartCollide fallback path        FinishPredictedClientHit(uid, predicted, physics);
+        // Polonium - same ghost-bullet fix as StartCollide fallback path
+        FinishPredictedClientHit(uid, predicted, physics);
     }
 
     var predictedQuery = EntityQueryEnumerator<PredictedProjectileHitComponent, SpriteComponent, TransformComponent>();


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Przez przypadek wykomentowałem w GunPredictionSystem.cs wywołanie `FinishPredictedClientHit`, który miał usuwać pociski na kliencie.

Dodałem trochę zabezpieczeń do eksplozji na kliencie również

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
:cl: Nikita_pl
- fix: Poprawiono potencjalne bugi, które mogły prowadzić to crashów klientów
