### PR TITLE
Zmiany to przepływu rund

### DIFF
--- a/Content.Server/_Polonium/GameTicking/DelayedAnnouncementRuleSystem.cs
+++ b/Content.Server/_Polonium/GameTicking/DelayedAnnouncementRuleSystem.cs
@@ -1,0 +1,38 @@
+using Content.Server.Chat.Systems;
+using Content.Server.GameTicking.Rules;
+using Content.Shared._Polonium.GameTicking;
+using Content.Shared.GameTicking.Components;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Player;
+
+namespace Content.Server._Polonium.GameTicking;
+
+public sealed class DelayedAnnouncementRuleSystem : GameRuleSystem<DelayedAnnouncementRuleComponent>
+{
+    [Dependency] private readonly ChatSystem _chat = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+
+    protected override void Started(
+        EntityUid uid,
+        DelayedAnnouncementRuleComponent comp,
+        GameRuleComponent gameRule,
+        GameRuleStartedEvent args)
+    {
+        base.Started(uid, comp, gameRule, args);
+
+        var filter = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame);
+        var sender = comp.Sender != null ? Loc.GetString(comp.Sender) : null;
+
+        _chat.DispatchFilteredAnnouncement(
+            filter,
+            Loc.GetString(comp.Announcement),
+            sender: sender,
+            playSound: comp.Sound == null,
+            colorOverride: comp.Color);
+
+        if (comp.Sound != null)
+            _audio.PlayGlobal(comp.Sound, filter, true);
+
+        GameTicker.EndGameRule(uid, gameRule);
+    }
+}

--- a/Content.Shared/_Polonium/GameTicking/DelayedAnnouncementRuleComponent.cs
+++ b/Content.Shared/_Polonium/GameTicking/DelayedAnnouncementRuleComponent.cs
@@ -1,0 +1,23 @@
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Polonium.GameTicking;
+
+/// <summary>
+/// Announces a localized message when the gamerule starts (after any GameRule delay).
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class DelayedAnnouncementRuleComponent : Component
+{
+    [DataField(required: true)]
+    public LocId Announcement;
+
+    [DataField]
+    public LocId? Sender;
+
+    [DataField]
+    public Color Color = Color.Gold;
+
+    [DataField]
+    public SoundSpecifier? Sound;
+}

--- a/Resources/Locale/en-US/_Polonium/gamerules/dynamic-unforgiving.ftl
+++ b/Resources/Locale/en-US/_Polonium/gamerules/dynamic-unforgiving.ftl
@@ -1,0 +1,2 @@
+dynamic-unforgiving-briefing-sender = Central Command
+dynamic-unforgiving-briefing = Attention! Abnormal activity from multiple threats has been detected in your sector. Please remain vigilant and report any dangers to the appropriate personnel. Continue performing your duties in accordance with procedures. Glory to NT!

--- a/Resources/Locale/pl-PL/_Polonium/gamerules/dynamic-unforgiving.ftl
+++ b/Resources/Locale/pl-PL/_Polonium/gamerules/dynamic-unforgiving.ftl
@@ -1,0 +1,2 @@
+dynamic-unforgiving-briefing-sender = Centralne Dowodztwo
+dynamic-unforgiving-briefing = Uwaga! W waszym sektorze odnotowano nietypową aktywność wielu zagrożeń. Zaleca się zachowanie czujności i zgłaszanie wszelkich zagrożeń odpowiedniemu personelowi. Prosimy kontynuować wykonywanie swoich obowiązków zgodnie z procedurami. Chwała NT!

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -327,7 +327,7 @@
     duration: null
     earliestStart: 45
     reoccurrenceDelay: 60 # funkystation
-    minimumPlayers: 30
+    minimumPlayers: 25
     chaos: # Goobstation
       Hostile: 50
       Friend: 50
@@ -707,7 +707,7 @@
     startAudio:
       path: /Audio/_Polonium/Announcements/attention.ogg
     earliestStart: 30 # funkystation delay
-    minimumPlayers: 30 # DeltaV - was 20
+    minimumPlayers: 25
     weight: 1 # DeltaV - was 1.5
     duration: 30 # DeltaV: was 60, used as a delay now
     eventType: HostilesSpawn # Goobstation
@@ -734,7 +734,7 @@
     eventType: Chaotic # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 60
+    chaosScore: 50
   - type: VentCrittersRule
     table: # DeltaV: EntityTable instead of spawn entries
       id: MobHonkBot
@@ -745,7 +745,7 @@
   components:
   - type: StationEvent
     earliestStart: 60 # funkystation
-    minimumPlayers: 40
+    minimumPlayers: 35
     weight: 1.5 # Zombies was happening basically every single survival round, so now it's super rare
     duration: 1
     chaos: # Goobstation
@@ -915,12 +915,12 @@
     startAudio:
       path: /Audio/_Polonium/Announcements/attention.ogg
     weight: 5
-    minimumPlayers: 25
+    minimumPlayers: 20
     reoccurrenceDelay: 20
     eventType: Maintenance # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 160
+    chaosScore: 200
   - type: GreytideVirusRule
     accessGroups:
     - Cargo

--- a/Resources/Prototypes/_DV/CosmicCult/events.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/events.yml
@@ -13,7 +13,7 @@
     weight: 6 # Funky
     earliestStart: 30
     reoccurrenceDelay: 20
-    minimumPlayers: 35
+    minimumPlayers: 30
     duration: null
     occursDuringRoundEnd: false
     chaos:

--- a/Resources/Prototypes/_Goobstation/GameRules/Dynamic/dynamic.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/Dynamic/dynamic.yml
@@ -103,6 +103,21 @@
     - SpaceTrafficControlFriendlyEventScheduler
     - BasicRoundstartVariation
 
+- type: entity
+  parent: BaseGameRule
+  id: DynamicUnforgivingBriefing
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: GameRule
+    delay:
+      min: 180
+      max: 240
+  - type: DelayedAnnouncementRule
+    announcement: dynamic-unforgiving-briefing
+    sender: dynamic-unforgiving-briefing-sender
+    sound:
+      path: /Audio/_Polonium/Announcements/attention.ogg
+
 - type: gamePreset
   id: DynamicUnforgiving
   alias:
@@ -114,9 +129,9 @@
   showInVote: false # admeme only
   rules:
     - DynamicUnforgiving
+    - DynamicUnforgivingBriefing
     - BasicStationEventSchedulerNoAntag
     - DynamicStationEventScheduler
-#    - MeteorSwarmScheduler Goob Edit
     - SpaceTrafficControlEventScheduler
     - SpaceTrafficControlFriendlyEventScheduler
     - BasicRoundstartVariation

--- a/Resources/Prototypes/_Goobstation/GameRules/Dynamic/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/Dynamic/midround.yml
@@ -108,13 +108,13 @@
   - type: StationEvent
     earliestStart: 20
     weight: 3
-    minimumPlayers: 30
+    minimumPlayers: 25
     maxOccurrences: 1
     duration: null
     occursDuringRoundEnd: false
     eventType: HostilesSpawn
   - type: GameRule
-    chaosScore: 900
+    chaosScore: 800
   - type: AntagSelection
     selectionTime: PostPlayerSpawn
 
@@ -270,7 +270,7 @@
     highImpact: true
   - type: StationEvent
     earliestStart: 90
-    minimumPlayers: 40
+    minimumPlayers: 35
     weight: 1 # Zombies was happening basically every single survival round, so now it's super rare
     duration: 1
     eventType: HostilesSpawn # Goobstation

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -88,7 +88,7 @@
   - type: StationEvent
     earliestStart: 20
     weight: 3
-    minimumPlayers: 30
+    minimumPlayers: 25
     startAnnouncement: station-event-communication-interception
     startAudio:
       path: /Audio/Announcements/intercept.ogg
@@ -128,7 +128,7 @@
   - type: StationEvent
     earliestStart: 20
     weight: 3
-    minimumPlayers: 30
+    minimumPlayers: 25
     maxOccurrences: 1
     duration: null
     occursDuringRoundEnd: false

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -236,7 +236,7 @@
     weight: 5
     duration: 1
     earliestStart: 50
-    minimumPlayers: 25
+    minimumPlayers: 22
     maxOccurrences: 2
     chaos:
       Hostile: 150

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -121,7 +121,7 @@
       tableId: SpaceTrafficControlTable
     - !type:NestedSelector
       tableId: BasicGameRulesTable
-    - id: ReplicatorSpawn
+    - id: ReplicatorSpawnSecretPlus
 
 - type: entityTable
   id: SecretPlusMidHighTable
@@ -131,7 +131,7 @@
       tableId: SpaceTrafficControlTable
     - !type:NestedSelector
       tableId: BasicGameRulesTable
-    - id: ReplicatorSpawn
+    - id: ReplicatorSpawnSecretPlus
     - id: GreytideVirusSecretPlus
 
 - type: entityTable

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -23,14 +23,18 @@
   id: SecretPlus
   weights:
     # subgamemodes
-    Thief: 0.2
+    ThiefSecretPlus: 0.10
     # Shadowling: 0.02
     # normal
     Traitor: 0.1
     CalmTraitor: 0.15
     CalmLing: 0.05
     Changeling: 0.05
-    CalmHeretic: 0.11
+    CalmHeretic: 0.08
+    lowZombies: 0.008
+    medZombies: 0.008
+    BlobGameMode: 0.05
+    MalfAi: 0.05
     # CorporateAgent: 0.025
     # XenomorphsInfestationRoundstart: 0.02
 
@@ -46,16 +50,16 @@
     Traitor: 0.25
     CalmLing: 0.07
     Changeling: 0.07
-    CalmHeretic: 0.11
+    CalmHeretic: 0.08
     Nukeops: 0.05
+    LoneNukeopsRoundStart: 0.03
     Revolutionary: 0.05
-    lowZombies: 0.03
-    medZombies: 0.02
     BlobGameMode: 0.05
     Wizard: 0.025
     CosmicCult: 0.05
     BloodCult: 0.05
     MalfAi: 0.05
+    ThiefSecretPlus: 0.06
     # CorporateAgent: 0.025
     # XenomorphsInfestationRoundstart: 0.02
     # OopsAllThieves: 0.02
@@ -64,11 +68,11 @@
 - type: weightedRandom
   id: SecretPlusChaos
   weights:
-    Thief: 0.2
+    ThiefSecretPlus: 0.10
     # Shadowling: 0.09
     Traitor: 0.25
     Changeling: 0.10
-    Heretic: 0.11
+    CalmHeretic: 0.11
     Nukeops: 0.05
     Revolutionary: 0.05
     Zombie: 0.04
@@ -78,26 +82,67 @@
     BloodCult: 0.05
     MalfAi: 0.05
     # CorporateAgent: 0.025
-    # XenomorphsInfestationRoundstart: 0.02
+    # XenomorphsInfestationRoundstart: 0.02⠀⠀⠀⠀
 
+# Roundstart antag weights - Mid/MidHigh primary, zombies/blob/malf in SecretPlus secondary.
+- type: weightedRandom
+  id: SecretPlusPrimaryMid
+  weights:
+    Traitor: 0.25
+    CalmLing: 0.07
+    Changeling: 0.07
+    CalmHeretic: 0.08
+    Nukeops: 0.05
+    LoneNukeopsRoundStart: 0.03
+    Revolutionary: 0.05
+    Wizard: 0.025
+    CosmicCult: 0.05
+    BloodCult: 0.05
 
-# ⠀⠀⠀⠀⠀⠀⠀⢀⡀⠴⠤⠤⠴⠄⡄⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
-# ⠀⠀⠀⣠⠄⠒⠉⠀⠀⠀⠀⠀⠀⠀⠀⠁⠃⠆⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
-# ⠀⢀⡜⠁⠀⠀⠀⢠⡄⠀⣀⠀⠀⠀⠀⠀⠀⠀⠀⠑⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
-# ⠀⢈⠁⠀⠀⠠⣿⠿⡟⣀⡹⠆⡿⣃⣰⣆⣤⣀⠀⠀⠹⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
-# ⠀⣼⠀⠀⢀⣀⣀⣀⣀⡈⠁⠙⠁⠘⠃⠡⠽⡵⢚⠱⠂⠛⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
-# ⠀⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
-# ⠀⡆⠀⠀⠀⠀⢐⣢⣤⣵⡄⢀⠀⢀⢈⣉⠉⠉⠒⠤⠀⠿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
-# ⠘⡇⠀⠀⠀⠀⠀⠉⠉⠁⠁⠈⠀⠸⢖⣿⣿⣷⠀⠀⢰⡆⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
-# ⠀⡇⠀⠀⠀⠀⠀⠀⠀⠀⢀⠃⠀⡄⠀⠈⠉⠀⠀⠀⢴⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀ want more documentation? see:
-# ⢈⣇⠀⠀⠀⠀⠀⠀⠀⢰⠉⠀⠀⠱⠀⠀⠀⠀⠀⢠⡄⠀⠀⠀⠀⠀⣀⠔⠒⢒⡩⠃ Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusComponent.cs
-# ⣴⣿⣤⢀⠀⠀⠀⠀⠀⠈⠓⠒⠢⠔⠀⠀⠀⠀⠀⣶⠤⠄⠒⠒⠉⠁⠀⠀⠀⢸⡀⠀
-# ⠈⣿⣿⣽⣦⠀⢀⢀⠰⢰⣀⣲⣿⡐⣤⠀⠀⢠⡾⠃⠀⠀⠀⠀⠀⠀⠀⣀⡄⣠⣵⠀
-# ⠘⠏⢿⣿⡁⢐⠶⠈⣰⣿⣿⣿⣿⣷⢈⣣⢰⡞⠀⠀⠀⠀⠀⠀⢀⡴⠋⠁⠀⠀⠀⠀
-# ⠀⠀⠈⢿⣿⣍⠀⠀⠸⣿⣿⣿⣿⠃⢈⣿⡎⠁⠀⠀⠀⠀⣠⠞⠉⠀⠀⠀⠀⠀⠀⠀
-# ⠀⠀⠀⠈⢙⣿⣆⠀⠀⠈⠛⠛⢋⢰⡼⠁⠁⠀⠀⠀⢀⠔⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀
-# ⠀⠀⠀⠀⠀⠀⠚⣷⣧⣷⣤⡶⠎⠛⠁⠀⠀⠀⢀⡤⠊⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
-# ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠁⠈⠁⠀⠀⠀⠀⠀⠠⠊⠀⠀⠀⠀⠀⠀⠀⠀⠀
+- type: weightedRandom
+  id: SecretPlusPrimaryMidHigh
+  weights:
+    Traitor: 0.25
+    CalmLing: 0.07
+    Changeling: 0.07
+    CalmHeretic: 0.08
+    Nukeops: 0.05
+    LoneNukeopsRoundStart: 0.03
+    Revolutionary: 0.05
+    Wizard: 0.025
+    CosmicCult: 0.05
+    BloodCult: 0.05
+
+- type: entityTable
+  id: SecretPlusMidTable
+  table: !type:AllSelector
+    children:
+    - !type:NestedSelector
+      tableId: SpaceTrafficControlTable
+    - !type:NestedSelector
+      tableId: BasicGameRulesTable
+    - id: ReplicatorSpawn
+
+- type: entityTable
+  id: SecretPlusMidHighTable
+  table: !type:AllSelector
+    children:
+    - !type:NestedSelector
+      tableId: SpaceTrafficControlTable
+    - !type:NestedSelector
+      tableId: BasicGameRulesTable
+    - id: ReplicatorSpawn
+    - id: GreytideVirusSecretPlus
+
+- type: entityTable
+  id: SecretPlusSurvivalTable
+  table: !type:AllSelector
+    children:
+    - !type:NestedSelector
+      tableId: SpaceTrafficControlTable
+    - !type:NestedSelector
+      tableId: BasicGameRulesTable
+    - id: ZombieOutbreakSurvivalPlus
 
 # middle setting: supposed to be a "normal round" baseline setting
 - type: entity
@@ -118,10 +163,10 @@
     eventIntervalMin: 90
     eventIntervalMax: 400
     disallowedEvents: [ FriendlySpawn ]
-    # there's some misc variables in the comp if you want to try tweaking those
+    primaryAntagsWeightTable: SecretPlusPrimaryMid
   - type: SelectedGameRules
     scheduledGameRules: !type:NestedSelector
-      tableId: SecretPlusTable
+      tableId: SecretPlusMidTable
 
 - type: entity
   id: SecretPlusMidHigh
@@ -134,6 +179,10 @@
     livingChaosChange: -0.028
     deadChaosChange: 0.030
     chaosChangeVariationMin: 0.8
+    primaryAntagsWeightTable: SecretPlusPrimaryMidHigh
+  - type: SelectedGameRules
+    scheduledGameRules: !type:NestedSelector
+      tableId: SecretPlusMidHighTable
 
 # the Setting that Kills You
 - type: entity
@@ -181,3 +230,6 @@
     maxStartingChaos: 0
     noRoundstartAntags: true
     speedRamping: 0.0003 # ramps to 2x in about an hour, to 3x in ~2
+  - type: SelectedGameRules
+    scheduledGameRules: !type:NestedSelector
+      tableId: SecretPlusSurvivalTable

--- a/Resources/Prototypes/_Polonium/GameRules/events.yml
+++ b/Resources/Prototypes/_Polonium/GameRules/events.yml
@@ -52,7 +52,7 @@
 
 - type: entity
   parent: ReplicatorSpawn
-  id: ReplicatorSpawn
+  id: ReplicatorSpawnSecretPlus
   components:
   - type: StationEvent
     eventType: HostilesSpawn

--- a/Resources/Prototypes/_Polonium/GameRules/events.yml
+++ b/Resources/Prototypes/_Polonium/GameRules/events.yml
@@ -6,6 +6,14 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 - type: entity
+  parent: Thief
+  id: ThiefSecretPlus
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: GameRule
+    minPlayers: 12
+
+- type: entity
   parent: BaseGameRule
   id: CowiekMaupaSpawn
   components:
@@ -21,7 +29,36 @@
     eventType: HostilesSpawn # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 200
+    chaosScore: 250
   - type: RandomEntityStorageSpawnRule
     prototype: MobCowiekMaupa
     openStorageSound: /Audio/_Polonium/Effects/Jumpscare/jumpscare1.ogg
+
+- type: entity
+  parent: GreytideVirus
+  id: GreytideVirusSecretPlus
+  components:
+  - type: StationEvent
+    minimumPlayers: 15
+    weight: 4
+
+- type: entity
+  parent: ZombieOutbreak
+  id: ZombieOutbreakSurvivalPlus
+  components:
+  - type: StationEvent
+    minimumPlayers: 25
+    weight: 2.5
+
+- type: entity
+  parent: ReplicatorSpawn
+  id: ReplicatorSpawn
+  components:
+  - type: StationEvent
+    eventType: HostilesSpawn
+    weight: 4
+    minimumPlayers: 15
+    earliestStart: 25
+    reoccurrenceDelay: 45
+  - type: GameRule
+    chaosScore: 650

--- a/Resources/Prototypes/_Polonium/GameRules/lonenukeop.yml
+++ b/Resources/Prototypes/_Polonium/GameRules/lonenukeop.yml
@@ -1,0 +1,39 @@
+- type: entity
+  parent: BaseNukeopsRule
+  id: LoneNukeopsRoundStart
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: GameRule
+    minPlayers: 15
+    chaosScore: 500
+  - type: LoadMapRule
+    gridPath: /Maps/Shuttles/ShuttleEvent/striker.yml
+  - type: NukeopsRule
+    roundEndBehavior: Nothing
+    warDeclarationMinOps: 1
+    canEnableWarOps: true
+  - type: AntagSelection
+    selectionTime: PrePlayerSpawn
+    definitions:
+    - prefRoles: [ Nukeops ]
+      fallbackRoles: [ Nukeops ]
+      spawnerPrototype: SpawnPointLoneNukeOperative
+      min: 1
+      max: 1
+      startingGear: SyndicateLoneOperativeGearFullRoundStart
+      roleLoadout:
+      - RoleSurvivalNukie
+      components:
+      - type: NukeOperative
+      - type: RandomMetadata
+        nameSegments:
+        - NamesNukieFirstOperator
+        - NamesSyndicateElite
+      - type: NpcFactionMember
+        factions:
+        - Syndicate
+      mindRoles:
+      - MindRoleNukeops
+  - type: Tag
+    tags:
+    - RoundstartAntag

--- a/Resources/Prototypes/_Polonium/GameRules/secretpolonium.yml
+++ b/Resources/Prototypes/_Polonium/GameRules/secretpolonium.yml
@@ -1,0 +1,17 @@
+- type: weightedRandom
+  id: SecretPolonium
+  weights:
+    # Massacre (50%)
+    SecretPlusMid: 19
+    SecretPlusMidHigh: 19
+    SurvivalPlusMid: 12
+    # Calm (49%)
+    SecretPlusLow: 20
+    Traitor: 8
+    TheSleeper: 8
+    SecretExtended: 7
+    SecretGreenshift: 4
+    TheDrunkard: 2
+    # Rare spice (1%)
+    DynamicUnforgiving: 1
+

--- a/Resources/Prototypes/_Polonium/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/_Polonium/Roles/Antags/nukeops.yml
@@ -1,0 +1,6 @@
+- type: startingGear
+  id: SyndicateLoneOperativeGearFullRoundStart
+  parent: SyndicateLoneOperativeGearFull
+  storage:
+    back:
+    - NukeOpsDeclarationOfWar


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR

Dostosowanie trybów gry i systemu **Secret+** pod populację Polonium (~15–20 graczy) oraz wprowadzenie własnej puli losowania **Secret** (`SecretPolonium`).

**Nowa pula Secret (`SecretPolonium`):**
- **~50%** — aktywniejsze Secret+: `SecretPlusMid`, `SecretPlusMidHigh`, `SurvivalPlusMid`
- **~49%** — spokojne tryby, w tym `SecretPlusLow` jako najspokojniejszy wariant Secret+
- **~1%** — rzadki `DynamicUnforgiving`

**Secret+:**
- `SecretPlusLow` — bez roundstartowych antagów (greenshift z lekkim chaosem midround)
- `SecretPlusMid`/`MidHigh`: 
  - roundstart antagów od średniego poziomu
  - osobne tabele primary i midround
- Zombie, Blob i Malf AI przeniesione z primary do **dodatkowych** roundstartów (pula `SecretPlus`)
- `Wizard` tylko jako roundstart, usunięty z dedykowanych tabel midround Secret+
- `ThiefSecretPlus` — złodziej jako dodatkowy roundstart antag od 12 graczy
- `LoneNukeopsRoundStart` — roundstart lone nukeops z pełnym loadoutem i deklaracją wojny
- Mid/MidHigh: `ReplicatorSpawn` (od 15 graczy) MidHigh: `GreytideVirusSecretPlus`
- Survival+: `ZombieOutbreakSurvivalPlus` (od 25 graczy), bez roundstart antagów, z rampingiem chaosu
- `DynamicUnforgiving` — jedno opóźnione ogłoszenie po 180–240 s od startu rundy

**Drobne korekty progów populacji / chaosu** w globalnych eventach (m.in. zombie outbreak, replicator, cosmic cult, lone nukeops midround).

## Powód / Balans

Cele balansu:
- **Połowa rund Secret** ma być spokojniejsza (Extended, Sleeper, Greenshift, Drunkard, Secret+ Low)
- **Druga połowa** — dynamiczny Secret+ z antagami dopasowanymi do midpop
- Roundstart antagów **nie** na najniższym poziomie Secret+ — gracze dostają spokojny start, eskalacja od Mid wzwyż
- Cięższe zagrożenia (zombie outbreak na Survival+, blob/malf jako dodatek, nie główny tryb) rzadziej i przy wyższych progach graczy
- Złodziej i lone nukeops dostępni na typowej populacji serwera, ale z ograniczoną wagą
- `DynamicUnforgiving` pozostaje rzadkim „wild card”, z jednym briefingiem zamiast spamu ogłoszeń

## Szczegóły techniczne

### Nowe pliki (`_Polonium`)
| Plik | Opis |
|------|------|
| `GameRules/secretpolonium.yml` | Wagi losowania presetów Secret |
| `GameRules/lonenukeop.yml` | Gamerule `LoneNukeopsRoundStart` |
| `GameRules/events.yml` | `ThiefSecretPlus`, override'y `ReplicatorSpawn`, `GreytideVirusSecretPlus`, `ZombieOutbreakSurvivalPlus` |
| `Roles/Antags/nukeops.yml` | `SyndicateLoneOperativeGearFullRoundStart` (+ deklaracja wojny) |
| `Locale/*/gamerules/dynamic-unforgiving.ftl` | Tekst briefing DynamicUnforgiving (placeholder) |

### Nowy kod C#
- `DelayedAnnouncementRuleComponent` + `DelayedAnnouncementRuleSystem` — ogłoszenie po starcie gamerule (z uwzględnieniem `GameRule.delay`)
- Podpięte do `DynamicUnforgivingBriefing` w `dynamic.yml`

### `secretplus.yml` (Goob)
- Tabele `SecretPlusPrimaryMid`, `SecretPlusPrimaryMidHigh` — primary roundstart
- Tabele midround: `SecretPlusMidTable`, `SecretPlusMidHighTable`, `SecretPlusSurvivalTable`
- Pula dodatkowych roundstartów `SecretPlus`: `ThiefSecretPlus`, `lowZombies`, `medZombies`, `BlobGameMode`, `MalfAi`
- `SecretPlusLow`: `noRoundstartAntags: true`
- `SecretPlusRampingMid`: dedykowana tabela Survival+

### Inne zmiany YAML
- `GameRules/events.yml`: progi graczy (25/35 zamiast 30/40), korekty `chaosScore` (HonkBot, Greytide)
- `_Goobstation/.../midround.yml`, `Dynamic/midround.yml`: progi 30 → 25, zombie 40 → 35
- `_DV/CosmicCult/events.yml`: minimum 35 → 30
- `_Goobstation/roundstart.yml`: lone nuke midround 25 → 22

---

**Changelog**

:cl: nikitosych
- add: Własna pula losowania trybu Sekret - połowa rund spokojna, połowa aktywniejsza Secret+
- tweak: Złodziej może pojawić się jako dodatkowy antag w Secret+ od 12 graczy
- tweak: Samotny nuklearnik może wylosować się na starcie rundy w Secret+
- tweak: Czarodziej w Secret+ tylko na starcie rundy, nie w midround
- tweak: Zombie, Blob i Malf AI w Secret+ jako dodatkowi antagowie, nie główny tryb
- tweak: Survival+ - epidemia zombie jako rzadki midround od 25 graczy
- add: Dynamic Unforgiving - jedno opóźnione ogłoszenie ostrzegawcze w trakcie rundy (~3-4 min po starcie)
- tweak: Dostosowano progi graczy i koszty chaosu wielu eventów pod populację ~15-20 osób