### PR TITLE
Poprawki podkładki (clipboard)

### DIFF
--- a/Resources/Locale/pl-PL/prototypes/generated/entities/objects/misc/acquisition_slips.ftl
+++ b/Resources/Locale/pl-PL/prototypes/generated/entities/objects/misc/acquisition_slips.ftl
@@ -1,5 +1,5 @@
-ent-PaperAcquisitionSlip = paragon zakupu
-    .desc = Paragon z danymi zamówienia. Można ją przekazać firmie Cargo w celu realizacji zamówienia.
+ent-PaperAcquisitionSlip = zlecenie zakupu
+    .desc = Zlecenie zakupu z danymi zamówienia. Należy przekazać je departamentowi zaopatrzenia w celu realizacji zamówienia.
 ent-PaperAcquisitionSlipMedical = { ent-PaperAcquisitionSlip }
     .suffix = Medyczny
     .desc = { ent-PaperAcquisitionSlip.desc }

--- a/Resources/Prototypes/Entities/Objects/Misc/acquisition_slips.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/acquisition_slips.yml
@@ -24,6 +24,8 @@
   - type: Tag
     tags:
     - Trash
+    # POLONIUM CHANGE: Added Document tag, so the slip can be inserted into a clipboard.
+    - Document
   - type: Paper
     editingDisabled: true
   - type: PaperVisuals

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -586,7 +586,8 @@
         whitelist:
           tags:
             - Write
-        insertOnInteract: false
+        # POLONIUM CHANGE: Set insertOnInteract to true, so the pen can be inserted into a clipboard (it's a bug honestly - even the sprites are there! It should be true by default...).
+        insertOnInteract: true
   - type: Item
     sprite: Objects/Misc/clipboard.rsi
     size: Small


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Aktualnie podkładka oprócz trzymania podstawowych papierów nie pełni większej roli. PR ma na celu rozwinięcie jej funkcjonalności.

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
Closes #642 

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
Poprawiono prototypy i plik `.ftl`.

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->
_Brak_

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
<!--
:cl: nazwa_użytkownika
- add: Dodano zabawę!
- remove: Usunięto zabawę!
- tweak: Zmieniono zabawę!
- fix: Naprawiono zabawę!
-->
:cl: haze.
- tweak: Dodano możliwość wkładania zleceń zakupu do podkładki.
- tweak: Zmieniono tłumaczenie: `paragon zakupu` na `zlecenie zakupu`.
- fix: Długopis może teraz zostać odłożony do podkładki.

