### PR TITLE
Aghost pojawia się z omnihudem

### DIFF
--- a/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
@@ -29,6 +29,14 @@
       displayName: ID
 
     # For drip reasons.
+    # POLONIUM CHANGE: Added eyes slot.
+    - name: eyes
+      slotTexture: glasses
+      slotFlags: EYES
+      stripTime: 3
+      uiWindowPos: 0,3
+      strippingWindowPos: 0,0
+      displayName: Eyes
     - name: head
       slotTexture: head
       slotFlags: HEAD

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -201,6 +201,8 @@
 - type: startingGear
   id: MobAghostGear
   equipment:
+    # POLONIUM CHANGE: Added HUD glasses.
+    eyes: ClothingEyesGlassesCentComm
     back: ClothingBackpackSatchelHolding
     id: AdminPDA
   storage:


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Aghost zawsze pojawia się z omnihudem.

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
PR ma na celu ułatwienie moderowania rozgrywek poprzez umożliwienie założenia okularów HUD duchom administracyjnym (aghost).

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
Zmieniono 2 pliki prototypowe:
- `aghost_inventory_template.yml`
- `misc_startinggear.yml`

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->
<img width="969" height="807" alt="dotnet_CGcZlc90Fl" src="https://github.com/user-attachments/assets/3e38fc6e-c803-4b66-a621-a2b7f5784a2e" />

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
<!--
:cl: nazwa_użytkownika
- add: Dodano zabawę!
- remove: Usunięto zabawę!
- tweak: Zmieniono zabawę!
- fix: Naprawiono zabawę!
-->
:cl: haze.
- tweak: Dodano slot `eyes` w prototypie postaci aghost
- tweak: Dodano okulary omnihud do domyślnego wyposażenia aghost  