### PR TITLE
Poprawki do Malf AI

### DIFF
--- a/Content.Client/Robotics/UI/RoboticsConsoleBoundUserInterface.cs
+++ b/Content.Client/Robotics/UI/RoboticsConsoleBoundUserInterface.cs
@@ -36,7 +36,7 @@ public sealed class RoboticsConsoleBoundUserInterface : BoundUserInterface
         {
             SendMessage(new RoboticsConsoleDestroyMessage(address));
         };
-            _window.OnImposeLawPressed += addr => SendMessage(new RoboticsConsoleImposeLawMessage(addr));
+        _window.OnImposeLawPressed += addr => SendMessage(new RoboticsConsoleImposeLawMessage(addr));
     }
 
     protected override void UpdateState(BoundUserInterfaceState state)

--- a/Content.Client/Robotics/UI/RoboticsConsoleWindow.xaml
+++ b/Content.Client/Robotics/UI/RoboticsConsoleWindow.xaml
@@ -39,7 +39,7 @@ SPDX-License-Identifier: MIT
                 <BoxContainer Name="DangerZone" Margin="5" Orientation="Horizontal" HorizontalExpand="True" HorizontalAlignment="Center" Visible="False">
                     <Button Name="DisableButton" Text="{Loc 'robotics-console-disable'}" StyleClasses="OpenRight"/>
                     <Button Name="DestroyButton" Text="{Loc 'robotics-console-destroy'}" StyleClasses="OpenLeft"/>
-                    <Button Name="ImposeLawButton" Text="{Loc 'malfai-robotics-impose-law-button'}" Margin="10 0 0 0"/>
+                    <Button Name="ImposeLawButton" Text="{Loc 'malfai-robotics-impose-law-button'}" ToolTip="{Loc malfai-robotics-impose-law-tooltip}" Margin="10 0 0 0"/>
                 </BoxContainer>
                 <Label Name="LockedMessage" Text="{Loc 'robotics-console-locked-message'}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
             </controls:StripeBack>

--- a/Content.Client/Robotics/UI/RoboticsConsoleWindow.xaml.cs
+++ b/Content.Client/Robotics/UI/RoboticsConsoleWindow.xaml.cs
@@ -173,26 +173,8 @@ public sealed partial class RoboticsConsoleWindow : FancyWindow
 
         if (!_entMan.HasComponent<MalfAiMarkerComponent>(_playerManager.LocalEntity))
             return;
-        // Polonium - Sprawdzanie czy wystarczy nam punktów na zhakowanie borga
-        bool canAffordHack = false;
-        if (_entMan.TryGetComponent<StoreComponent>(_playerManager.LocalEntity.Value, out var comp))
-        {
-            ProtoId<CurrencyPrototype> cpu = "CPU";
-            if (comp.Balance.TryGetValue(cpu, out var currency))
-            {
-                if (currency < _cfg.GetCVar(CCVars.MalfAiImposeLawCpuCost))
-                {
-                    ImposeLawButton.ToolTip = Loc.GetString("malfai-store-insufficient-cpu");
-                }
-                else
-                {
-                    canAffordHack = true;
-                    ImposeLawButton.ToolTip = Loc.GetString("malfai-robotics-impose-law-tooltip");
-                }
-            }
-        } // Polonium - Koniec
         // Grey out impose law if borg is already emagged or hacked
-        ImposeLawButton.Disabled = data.Emagged || !canAffordHack;
+        ImposeLawButton.Disabled = data.Emagged;
         if (data.Emagged) // Polonium - Informacja o emagowanym borgu
             ImposeLawButton.Text = Loc.GetString("malfai-robotics-borg-emagged");
         else

--- a/Content.Client/Robotics/UI/RoboticsConsoleWindow.xaml.cs
+++ b/Content.Client/Robotics/UI/RoboticsConsoleWindow.xaml.cs
@@ -23,6 +23,11 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+using Content.Shared.Store.Components;
+using Robust.Shared.Configuration;
+using Content.Shared.CCVar;
+using Content.Shared.Store;
+using Robust.Client.Graphics;
 
 namespace Content.Client.Robotics.UI;
 
@@ -31,6 +36,9 @@ public sealed partial class RoboticsConsoleWindow : FancyWindow
 {
     [Dependency] private readonly IEntityManager _entMan = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+
     private readonly LockSystem _lock;
     private readonly SpriteSystem _sprite;
 
@@ -46,7 +54,6 @@ public sealed partial class RoboticsConsoleWindow : FancyWindow
     public RoboticsConsoleWindow()
     {
         RobustXamlLoader.Load(this);
-        IoCManager.InjectDependencies(this);
 
         _lock = _entMan.System<LockSystem>();
         _sprite = _entMan.System<SpriteSystem>();
@@ -109,9 +116,8 @@ public sealed partial class RoboticsConsoleWindow : FancyWindow
 
         // Only Malf AI should see the impose-law button.
         var isMalfAi = false;
-        if (IoCManager.Resolve<IPlayerManager>().LocalEntity is { } local)
+        if (_playerManager.LocalEntity is { } local)
             isMalfAi = _entMan.HasComponent<MalfAiMarkerComponent>(local);
-
         ImposeLawButton.Visible = isMalfAi;
     }
 
@@ -165,8 +171,32 @@ public sealed partial class RoboticsConsoleWindow : FancyWindow
         // how the turntables
         DisableButton.Disabled = !(data.HasBrain && data.CanDisable);
 
+        if (!_entMan.HasComponent<MalfAiMarkerComponent>(_playerManager.LocalEntity))
+            return;
+        // Polonium - Sprawdzanie czy wystarczy nam punktów na zhakowanie borga
+        bool canAffordHack = false;
+        if (_entMan.TryGetComponent<StoreComponent>(_playerManager.LocalEntity.Value, out var comp))
+        {
+            ProtoId<CurrencyPrototype> cpu = "CPU";
+            if (comp.Balance.TryGetValue(cpu, out var currency))
+            {
+                if (currency < _cfg.GetCVar(CCVars.MalfAiImposeLawCpuCost))
+                {
+                    ImposeLawButton.ToolTip = Loc.GetString("malfai-store-insufficient-cpu");
+                }
+                else
+                {
+                    canAffordHack = true;
+                    ImposeLawButton.ToolTip = Loc.GetString("malfai-robotics-impose-law-tooltip");
+                }
+            }
+        } // Polonium - Koniec
         // Grey out impose law if borg is already emagged or hacked
-        ImposeLawButton.Disabled = data.Emagged;
+        ImposeLawButton.Disabled = data.Emagged || !canAffordHack;
+        if (data.Emagged) // Polonium - Informacja o emagowanym borgu
+            ImposeLawButton.Text = Loc.GetString("malfai-robotics-borg-emagged");
+        else
+            ImposeLawButton.Text = Loc.GetString("malfai-robotics-impose-law-button");
     }
 
     protected override void FrameUpdate(FrameEventArgs args)

--- a/Content.Client/Robotics/UI/RoboticsConsoleWindow.xaml.cs
+++ b/Content.Client/Robotics/UI/RoboticsConsoleWindow.xaml.cs
@@ -179,6 +179,7 @@ public sealed partial class RoboticsConsoleWindow : FancyWindow
             ImposeLawButton.Text = Loc.GetString("malfai-robotics-borg-emagged");
         else
             ImposeLawButton.Text = Loc.GetString("malfai-robotics-impose-law-button");
+        // Polonium - Koniec
     }
 
     protected override void FrameUpdate(FrameEventArgs args)

--- a/Content.Server/Robotics/Systems/RoboticsConsoleSystem.cs
+++ b/Content.Server/Robotics/Systems/RoboticsConsoleSystem.cs
@@ -25,6 +25,7 @@ using Content.Shared.Silicons.StationAi;
 using Robust.Shared.Utility;
 using Content.Shared.CCVar;
 using Robust.Shared.Configuration;
+using Content.Shared.Popups;
 
 namespace Content.Server.Research.Systems;
 
@@ -42,6 +43,7 @@ public sealed class RoboticsConsoleSystem : SharedRoboticsConsoleSystem
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
     [Dependency] private readonly Content.Shared.Damage.DamageableSystem _damageable = default!;
     [Dependency] private readonly Content.Shared.Mobs.Systems.MobThresholdSystem _mobThreshold = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly AlertsSystem _alerts = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
 

--- a/Content.Server/Robotics/Systems/RoboticsConsoleSystem.cs
+++ b/Content.Server/Robotics/Systems/RoboticsConsoleSystem.cs
@@ -187,7 +187,10 @@ public sealed class RoboticsConsoleSystem : SharedRoboticsConsoleSystem
         var imposeCost = FixedPoint2.New(_cfg.GetCVar(CCVars.MalfAiImposeLawCpuCost));
 
         if (!store.Balance.TryGetValue(CpuCurrency, out var balance) || balance < imposeCost)
+        {
+            _popupSystem.PopupCursor(Loc.GetString("malfai-store-insufficient-cpu"), args.Actor, PopupType.Medium); // Polonium - Powiadomienie w przypadku niewystarczającej ilości CPU
             return; // insufficient CPU
+        }
 
         // Deduct cost and proceed
         store.Balance[CpuCurrency] = balance - imposeCost;

--- a/Content.Shared/Robotics/RoboticsConsoleUi.cs
+++ b/Content.Shared/Robotics/RoboticsConsoleUi.cs
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-﻿using Robust.Shared.Prototypes;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 using Robust.Shared.Utility;

--- a/Resources/Locale/pl-PL/MalfAI/malfai.ftl
+++ b/Resources/Locale/pl-PL/MalfAI/malfai.ftl
@@ -204,3 +204,7 @@ malfai-round-end-result = Uszkodzona SI
 # Confused why I have to do this..
 objective-issuer-malfai = Uszkodzona SI
 malfai-round-end-name-user =  [color=white]{ $name }[/color] ([color=gray]{ $user }[/color])
+
+# CPU
+alerts-malfai-cpu-name = Ilość CPU
+alerts-malfai-cpu-desc = Ilość CPU które możesz wykorzystać do zakupu ulepszeń


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Wykorzystano niektóre nieużywane tłumaczenia, sprawiono że malf AI jest mniej misterne i użytkownik wie bardziej co sie dzieje (np. przycisk borga, który dostał emagiem dostaje odpowiedni napis)
<!-- Co zostało zmienione? -->

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
Closes #585

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
Ogólnie taka ciekawostka, waluta AI (jak i każda inna waluta w grze) jest przechowywana na serwerze dlatego tam jest popup a nie na kliencie, jak ktoś chce zrobić żeby przyciśk był zablokowany zamiast pop-upa, to zapraszam

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: Elperson
- fix: Malf AI teraz informuje kiedy nie starcza punktów na zhakowanie borga i informuje, że nie da się zhakować emagowanych borgów zamiast blokować przycisku bez żadnej informacji.

