### PR TITLE
Kałuże, stoły i duchy nie blokują już rozkładania flatpacków

### DIFF
--- a/Content.Shared/Construction/SharedFlatpackSystem.cs
+++ b/Content.Shared/Construction/SharedFlatpackSystem.cs
@@ -15,7 +15,9 @@ using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Database;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
+using Content.Shared.Maps;
 using Content.Shared.Materials;
+using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared.Tools.Systems;
 using Robust.Shared.Audio.Systems;
@@ -34,8 +36,8 @@ public abstract class SharedFlatpackSystem : EntitySystem
     [Dependency] protected readonly SharedAppearanceSystem Appearance = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
-    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
+    [Dependency] private readonly TurfSystem _turfs = default!;
     [Dependency] protected readonly MachinePartSystem MachinePart = default!;
     [Dependency] protected readonly SharedMaterialStorageSystem MaterialStorage = default!;
     [Dependency] private readonly MetaDataSystem _metaData = default!;
@@ -88,12 +90,8 @@ public abstract class SharedFlatpackSystem : EntitySystem
         }
 
         var buildPos = _map.TileIndicesFor(grid, gridComp, xform.Coordinates);
-        var coords = _map.ToCenterCoordinates(grid, buildPos);
 
-        // TODO FLATPAK
-        // Make this logic smarter. This should eventually allow for shit like building microwaves on tables and such.
-        // Also: make it ignore ghosts
-        if (_entityLookup.AnyEntitiesIntersecting(coords, LookupFlags.Dynamic | LookupFlags.Static))
+        if (_turfs.IsTileBlocked(grid, buildPos, CollisionGroup.Impassable))
         {
             // this popup is on the server because the predicts on the intersection is crazy
             if (_net.IsServer)


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Naprawia błąd z #630. **TRZEBA SIĘ ZASTANOWIĆ CZY WSZYSTKIE FLATPACKI POWINNY DAĆ SIĘ ROZPAKOWAĆ NA KRATCE ZE STOŁAMI I INNYMI KRZESŁAMI**

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
Używając multitoola na flatpacku stojącym na kałuży pojawiał się komunikat "No room to unpack!". System traktował kałużę jako istniejący blok znajdujący się na kafelku.
Closes #630 


## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
Zastąpiono sprawdzanie kolizji (`AnyEntitiesIntersecting`) w `SharedFlatpackSystem.cs` standardowym testem TurfSystem.IsTileBlocked z maską Impassable. Teraz rozpakowanie blokują tylko struktury "twarde" - ściany, maszyny itd., a nie kałuże, ponieważ ich `fixture` nie jest `Impassable`.

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->
<img width="812" height="609" alt="dotnet_Nj7sBjtNb9" src="https://github.com/user-attachments/assets/8d14ddca-f17b-45e4-8ce3-8530c678a833" />


---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: haze.
- fix: Kałuże, stoły i duchy nie blokują już rozkładania flatpacków
