### PR TITLE
Odczynniki są sortowane według localized name

### DIFF
--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -442,7 +442,7 @@ namespace Content.Client.Chemistry.UI
             };
             bufferHBox.AddChild(bufferVol);
 
-            var bufferReagents = state.BufferReagents.OrderBy(x => x.Reagent.Prototype);
+            var bufferReagents = state.BufferReagents.OrderBy(x => GetLocalizedReagentName(x.Reagent));
 
             if (_currentSortMethod == ReagentSortMethod.Amount)
                 bufferReagents = bufferReagents.OrderByDescending(x => x.Quantity);
@@ -475,12 +475,19 @@ namespace Content.Client.Chemistry.UI
             };
             bufferHBox.AddChild(bufferVol);
 
-            var bufferReagents = state.PillBufferReagents.OrderBy(x => x.Reagent.Prototype);
+            var bufferReagents = state.PillBufferReagents.OrderBy(x => GetLocalizedReagentName(x.Reagent));
 
             if (_currentSortMethod == ReagentSortMethod.Amount)
                 bufferReagents = bufferReagents.OrderByDescending(x => x.Quantity);
 
             HandleBuffer(_currentSortMethod == ReagentSortMethod.Time ? state.PillBufferReagents : bufferReagents, true);
+        }
+
+        private string GetLocalizedReagentName(ReagentId reagentId)
+        {
+            return _prototypeManager.TryIndex(reagentId.Prototype, out ReagentPrototype? proto)
+                ? proto.LocalizedName
+                : reagentId.Prototype;
         }
 
         private void HandleBuffer(IEnumerable<ReagentQuantity> reagents, bool pillBuffer)


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Lista odczynników w buforze ChemMaster sortuje się teraz według przetłumaczonych nazw widocznych w UI, a nie wewnętrznych identyfikatorów prototypów w języku angielskim.


## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
Closes #664 


## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->

- Plik: `Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs`
- Dodano metodę pomocniczą GetLocalizedReagentName(), która pobiera LocalizedName z prototypu odczynników.

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->
<img width="895" height="680" alt="dotnet_DxKViUXXbT" src="https://github.com/user-attachments/assets/62d3174e-b92c-4a4c-8d10-85992ce8f05c" />


---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: haze
- fix: ChemMaster sortuje odczynniki chemiczne alfabetycznie według przetłumaczonych nazw zamiast angielskich identyfikatorów prototypów.
