### PR TITLE
Poprawki Dinozaurów

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/dino.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/dino.yml
@@ -142,7 +142,9 @@
   - type: Vocal
     sounds:
       Unsexed: DinoEmotes
-
+  - type: StandingState
+  - type: Pullable
+  
 - type: entity
   parent: BaseMobDinosaur
   id: BaseMobDinosaurSmall
@@ -241,7 +243,6 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      50: Critical
       75: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
@@ -294,7 +295,6 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      50: Critical
       75: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
@@ -379,7 +379,6 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      80: Critical
       120: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
@@ -428,7 +427,6 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      250: Critical
       350: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
@@ -475,7 +473,6 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      150: Critical
       250: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
@@ -535,7 +532,6 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      150: Critical
       225: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
@@ -581,7 +577,6 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      250: Critical
       450: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
@@ -641,8 +636,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      750: Dead
-      850: Critical
+      850: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
       600: 0.8
@@ -692,7 +686,6 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      400: Critical
       500: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
@@ -752,7 +745,6 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      350: Critical
       450: Dead
   - type: SlowOnDamage
     speedModifierThresholds:


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->
closes: #670
## Informacje o PR
<!-- Co zostało zmienione? -->
Dodany został brakujący komponent StandingState który odpowiada za to czy mob stoi czy leży, dzięki czemu działa komponent RequireProjectileTarget, dzięki czemu da się strzelać przez martwe ciała, dodano też możliwość ciągnięcia ciał oraz usunięto damage threshold do stanu krytycznego który nie był użyty do niczego, dzięki czemu poprawnie widać zdrowie dinozaurów
## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
Dodano te rzeczy do Parenta BaseMobDinosaur:
- type: StandingState
- type: Pullable
Usunięto stan critical z thresholdów każdego dinozaura
## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->

https://github.com/user-attachments/assets/daf6c48d-174b-4550-b008-859ce24788fc


---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
:cl: Czuat
- fix: Poprawiono Dinozaury z Amber alertu, ich martwe ciała już nie będą blokować strzałów, widać poprawnie ich zdrowie, oraz można je przesuwać

