### PR TITLE
Refactor telefonów

### DIFF
--- a/Content.Shared/_Polonium/CallablePhone/CallablePhoneComponent.cs
+++ b/Content.Shared/_Polonium/CallablePhone/CallablePhoneComponent.cs
@@ -3,8 +3,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using System.Collections.Generic;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._Polonium.CallablePhone;
 
@@ -17,35 +19,18 @@ public sealed partial class CallablePhoneComponent : Component
     public const string HandsetSlotId = "handset";
 
     /// <summary>
-    /// If true, this phone is on the public station directory (red, blue, banana).
+    /// Phone groups this line belongs to. Other phones may dial this one when their
+    /// <see cref="DialableGroups"/> overlaps this set. An empty set means unlisted.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public bool ListedInDirectory = true;
+    public HashSet<ProtoId<PhoneGroupPrototype>> PhoneGroups = new();
 
     /// <summary>
-    /// If true, may only dial listed public lines, not the private CentComm line (blue, banana).
+    /// Phone groups this line may dial into. A call is allowed when this set overlaps
+    /// the receiver's <see cref="PhoneGroups"/>.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public bool ExcludeCentCommFromDial;
-
-    /// <summary>
-    /// If true, may dial and see the private CentComm line (red phone).
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public bool IncludeCentCommInDirectory;
-
-    /// <summary>
-    /// If true, the handset directory lists only CentComm lines (station red phone).
-    /// Requires <see cref="IncludeCentCommInDirectory"/>.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public bool OnlyCentCommInDirectory;
-
-    /// <summary>
-    /// If true, this line is private but may dial any public listed line (blood-red phone).
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public bool PrivateLine;
+    public HashSet<ProtoId<PhoneGroupPrototype>> DialableGroups = new();
 
     /// <summary>
     /// If true, calling this phone opens an admin chat window (CentComm line).

--- a/Content.Shared/_Polonium/CallablePhone/PhoneGroupPrototype.cs
+++ b/Content.Shared/_Polonium/CallablePhone/PhoneGroupPrototype.cs
@@ -1,0 +1,21 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Polonium.CallablePhone;
+
+/// <summary>
+/// A callable phone network group. Phones dial each other when the caller's
+/// <see cref="CallablePhoneComponent.DialableGroups"/> overlaps the receiver's
+/// <see cref="CallablePhoneComponent.PhoneGroups"/>.
+/// </summary>
+[Prototype("phoneGroup")]
+public sealed partial class PhoneGroupPrototype : IPrototype
+{
+    [IdDataField, ViewVariables]
+    public string ID { get; private set; } = default!;
+
+    /// <summary>
+    /// Human-readable name for the group.
+    /// </summary>
+    [DataField("name")]
+    public LocId Name { get; private set; } = string.Empty;
+}

--- a/Content.Shared/_Polonium/CallablePhone/SharedCallablePhoneSystem.cs
+++ b/Content.Shared/_Polonium/CallablePhone/SharedCallablePhoneSystem.cs
@@ -196,21 +196,7 @@ public abstract class SharedCallablePhoneSystem : EntitySystem
         if (source.IsCentComm)
             return true;
 
-        if (source.OnlyCentCommInDirectory)
-            return receiver.IsCentComm && source.IncludeCentCommInDirectory;
-
-        if (receiver.ListedInDirectory)
-        {
-            if (source.ExcludeCentCommFromDial && receiver.IsCentComm)
-                return false;
-
-            return true;
-        }
-
-        if (receiver.IsCentComm && source.IncludeCentCommInDirectory)
-            return true;
-
-        return false;
+        return receiver.PhoneGroups.Overlaps(source.DialableGroups);
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/prototypes/_polonium/phoneGroups.ftl
+++ b/Resources/Locale/en-US/prototypes/_polonium/phoneGroups.ftl
@@ -1,0 +1,3 @@
+phone-group-public-station = Station
+phone-group-centcomm = CentComm
+phone-group-syndicate = Syndicate

--- a/Resources/Prototypes/_Polonium/Entities/Objects/Fun/Instruments/callable_phones.yml
+++ b/Resources/Prototypes/_Polonium/Entities/Objects/Fun/Instruments/callable_phones.yml
@@ -38,9 +38,10 @@
     guides:
     - RedPhoneSOP
   - type: CallablePhone
-    isCentComm: false
-    includeCentCommInDirectory: true
-    onlyCentCommInDirectory: true
+    phoneGroups:
+    - PublicStation
+    dialableGroups:
+    - CentComm
     # phoneName: callable-phone-example-bridge  # optional; also editable via View Variables at runtime
     pickupHandsetSound:
       path: /Audio/_Polonium/Machines/Telephone/handset_pickup.ogg
@@ -116,8 +117,8 @@
           OnHook: { state: blue_phone }
           OffHook: { state: blue_phone_no_handset }
   - type: CallablePhone
-    includeCentCommInDirectory: false
-    excludeCentCommFromDial: true
+    dialableGroups:
+    - PublicStation
   - type: Contraband
     severity: Restricted
     allowedDepartments: [ Command ]
@@ -153,9 +154,11 @@
           OnHook: { state: blood_red_phone }
           OffHook: { state: blood_red_phone_no_handset }
   - type: CallablePhone
-    listedInDirectory: false
-    includeCentCommInDirectory: false
-    privateLine: true
+    phoneGroups:
+    - Syndicate
+    dialableGroups:
+    - PublicStation
+    - Syndicate
   - type: Prayable
     sentMessage: prayer-popup-notify-syndicate-sent
     notificationPrefix: prayer-chat-notify-syndicate
@@ -184,8 +187,11 @@
   components:
   - type: CallablePhone
     isCentComm: true
-    listedInDirectory: false
-    includeCentCommInDirectory: false
+    phoneGroups:
+    - CentComm
+    dialableGroups:
+    - PublicStation
+    - CentComm
     adminChatPrefix: prayer-chat-notify-centcom
 
 - type: entity
@@ -229,9 +235,8 @@
         mask:
         - ItemMask
   - type: CallablePhone
-    listedInDirectory: true
-    includeCentCommInDirectory: false
-    excludeCentCommFromDial: true
+    dialableGroups:
+    - PublicStation
   - type: Prayable
     sentMessage: prayer-popup-notify-honkmother-sent
     notificationPrefix: prayer-chat-notify-honkmother

--- a/Resources/Prototypes/_Polonium/phoneGroups.yml
+++ b/Resources/Prototypes/_Polonium/phoneGroups.yml
@@ -1,0 +1,11 @@
+- type: phoneGroup
+  id: PublicStation
+  name: phone-group-public-station
+
+- type: phoneGroup
+  id: CentComm
+  name: phone-group-centcomm
+
+- type: phoneGroup
+  id: Syndicate
+  name: phone-group-syndicate


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Refactor czerwonych telefonów.

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
Obecna implementacja jest średnio konfigurowalna.

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
Komponent CallablePhoneComponent nie wykorzystuje już pięciu różnych zmiennych do kontrolowania kto może dzwonić do kogo. Widoczność numerów w katalogu jest teraz kontrolowana przez dwa sety prototypów:

- `phoneGroups` - grupy, do których należy ten telefon
- `dialableGroups` - grupy, do których ten telefon może dzwonić

Połączenie jest dozwolone, gdy receiver.phoneGroups pokrywa się z source.dialableGroups.

### Czerwony telefon (`CallablePhoneInstrument`)

**Przed zmianą:**

```yaml
- type: CallablePhone
  isCentComm: false
  includeCentCommInDirectory: true
  onlyCentCommInDirectory: true
```

**Po zmianie:**

```yaml
- type: CallablePhone
  phoneGroups:
  - PublicStation
  dialableGroups:
  - CentComm
```

### Krwistoczerwony telefon (`CallablePhoneInstrumentSyndicate`)

**Przed zmianą:**

```yaml
- type: CallablePhone
  listedInDirectory: false
  includeCentCommInDirectory: false
  privateLine: true
```

**Po zmianie:**

```yaml
- type: CallablePhone
  phoneGroups:
  - Syndicate
  dialableGroups:
  - PublicStation
  - Syndicate
```

### Czerwony telefon Centralnego Dowództwa (`CallablePhoneInstrumentCentComm`)

**Przed zmianą:**

```yaml
- type: CallablePhone
  isCentComm: true
  listedInDirectory: false
  includeCentCommInDirectory: false
```

**Po zmianie:**

```yaml
- type: CallablePhone
  isCentComm: true
  phoneGroups:
  - CentComm
  dialableGroups:
  - PublicStation
  - CentComm
```

### Bananowy telefon (`CallableBananaPhoneInstrument`)

**Przed zmianą:**

```yaml
- type: CallablePhone
  listedInDirectory: true
  includeCentCommInDirectory: false
  excludeCentCommFromDial: true
```

**Po zmianie:**

```yaml
- type: CallablePhone
  dialableGroups:
  - PublicStation
```

Dziedziczy `phoneGroups: [PublicStation]`.

Zmiany nie wpływają na działanie telefonu poza zmianą, który telefon do którego może dzwonić. Przyszłe zmiany zostały ułatwione poprzez przeniesienie tej logiki do prototypu.

### Jak konfigurować grupy

| Cel | Konfiguracja |
|------|---------------|
| Telefon dostępny publicznie | `phoneGroups: [PublicStation]`, `dialableGroups: [PublicStation]` |
| Tylko do dzwonienia do CentCommu | `phoneGroups: [PublicStation]`, `dialableGroups: [CentComm]` |
| Niepubliczne połączenie wychodzące | `phoneGroups: [Syndicate]`, `dialableGroups: [PublicStation, Syndicate]` |
| Prywatna sieć | Nowe ID `phoneGroup` wspólne wyłącznie dla telefonów, które powinny się wzajemnie widzieć |
| Sieć CentComm | `isCentComm: true`, `phoneGroups: [CentComm]` |

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->
<img width="1280" height="720" alt="dotnet_egEuX7cn4g" src="https://github.com/user-attachments/assets/9cf0877b-ab57-41da-b03c-951655ac4d5e" />
<img width="1280" height="720" alt="dotnet_1WiBJ81TEa" src="https://github.com/user-attachments/assets/0e914a68-019e-4e95-8132-3a9b79788ec4" />
<img width="1280" height="720" alt="dotnet_Gc8KyXWyvM" src="https://github.com/user-attachments/assets/9fe0dbb4-6ddd-42b4-bbdc-cef90f894198" />
<img width="1280" height="720" alt="dotnet_6PHg6oqvSl" src="https://github.com/user-attachments/assets/1a613fde-f628-4cc6-b462-1a7193ee1d50" />


---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: haze
- tweak: Poprawiono logikę telefonów.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notatki do wydania

* **Nowe funkcjonalności**
  * Wprowadzono system oparty na grupach telefonów do zarządzania dostępem do połączeń między liniami telefonicznymi.
  * Dodano trzy grupy telefonów: Stacja Publiczna, CentComm i Syndykał.

* **Ulepszenia**
  * Uproszczono logikę określania, które telefony mogą się łączyć ze sobą, poprzez zastosowanie systemu grup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->