### PR TITLE
Podniesienie obrażeń bagnetu Mosina

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -136,7 +136,7 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Piercing: 12
+        Piercing: 15
     angle: 0
     animation: WeaponArcThrust
     soundHit:


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? --> Podbite obrażenia w walce wręcz mosina z 12 kłutych do 15 kłutych

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. --> 
Niższe ttk gównianego karabinu za 4 tc.  
Obrażenia zmienione na 15 kłutych ponieważ każda inna broń długa posiada jebnięcie z kolby za 12 blunta, i to z wide swingiem. Moim zdaniem jedyna broń z bagnetem (i to bez wideswinga!) zasługuje na przynajmniej obrażenia wzmocnionej włóczni (15). Bagnet istniejącego też muszkietu już zadaje 15 kłutych (i 2 bloodlossa ale to lekki szitcode żeby symulować krwotok który i tak sie dzieje więc bez niego pr)

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
zmieniony numerek obrażeń wręcz mosina w pliku polonium-station\Resources\Prototypes\Entities\Objects\Weapons\Guns\Snipers\snipers.yml

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->
<img width="324" height="218" alt="image" src="https://github.com/user-attachments/assets/982aa87f-ab26-4723-bbb6-5a97e03a01f1" />


---

**Changelog**

:cl: Alcovvhore
- tweak: Obrażenia bagnetu mosina zwiększone z 12 kłutych do 15 kłutych.

