### PR TITLE
[Forky] system celu zmiany

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -131,6 +131,7 @@ namespace Content.Client.Entry
             _prototypeManager.RegisterIgnore("ghostRoleRaffleDecider");
             _prototypeManager.RegisterIgnore("codewordGenerator");
             _prototypeManager.RegisterIgnore("codewordFaction");
+            _prototypeManager.RegisterIgnore("stationGoal");
 
             _componentFactory.GenerateNetIds();
             _adminManager.Initialize();

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -440,6 +440,7 @@ namespace Content.Server.GameTicking
             AnnounceRound();
             UpdateInfoText();
             SendRoundStartedDiscordMessage();
+            RaiseLocalEvent(new RoundStartedEvent(RoundId));
 
 #if EXCEPTION_TOLERANCE
             }

--- a/Content.Server/_Corvax/StationGoal/StationGoalComponent.cs
+++ b/Content.Server/_Corvax/StationGoal/StationGoalComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Corvax.StationGoal;
+
+/// <summary>
+/// If attached to a station prototype, will send the station a random goal from the list.
+/// </summary>
+[RegisterComponent]
+public sealed partial class StationGoalComponent : Component
+{
+    [DataField]
+    public List<ProtoId<StationGoalPrototype>> Goals = new();
+}

--- a/Content.Server/_Corvax/StationGoal/StationGoalPaperComponent.cs
+++ b/Content.Server/_Corvax/StationGoal/StationGoalPaperComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server._Corvax.StationGoal;
+
+/// <summary>
+/// Paper with a written station goal in it.
+/// </summary>
+[RegisterComponent]
+public sealed partial class StationGoalPaperComponent : Component;

--- a/Content.Server/_Corvax/StationGoal/StationGoalPaperSystem.cs
+++ b/Content.Server/_Corvax/StationGoal/StationGoalPaperSystem.cs
@@ -1,0 +1,107 @@
+using Content.Server.Fax;
+using Content.Server.Station.Systems;
+using Content.Shared.CCVar;
+using Content.Shared.Fax.Components;
+using Content.Shared.GameTicking;
+using Content.Shared.Paper;
+using Robust.Server.Player;
+using Robust.Shared.Configuration;
+using Robust.Shared.Maths;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+
+namespace Content.Server._Corvax.StationGoal;
+
+/// <summary>
+/// System to spawn paper with station goal.
+/// </summary>
+public sealed class StationGoalPaperSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly FaxSystem _fax = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly StationSystem _station = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<RoundStartedEvent>(OnRoundStarted);
+    }
+
+    private void OnRoundStarted(RoundStartedEvent ev)
+    {
+        if (!_cfg.GetCVar(CCVars.StationGoal))
+            return;
+
+        var playerCount = _playerManager.PlayerCount;
+
+        var query = EntityQueryEnumerator<StationGoalComponent>();
+        while (query.MoveNext(out var uid, out var station))
+        {
+            var tempGoals = new List<ProtoId<StationGoalPrototype>>(station.Goals);
+            StationGoalPrototype? selGoal = null;
+            while (tempGoals.Count > 0)
+            {
+                var goalId = _random.Pick(tempGoals);
+                var goalProto = _proto.Index(goalId);
+
+                if (goalProto.MaxPlayers.HasValue && playerCount > goalProto.MaxPlayers.Value ||
+                    goalProto.MinPlayers.HasValue && playerCount < goalProto.MinPlayers.Value)
+                {
+                    tempGoals.Remove(goalId);
+                    continue;
+                }
+
+                selGoal = goalProto;
+                break;
+            }
+
+            if (selGoal is null)
+                continue;
+
+            if (SendStationGoal(uid, selGoal))
+            {
+                Log.Info($"Goal {selGoal.ID} has been sent to station {MetaData(uid).EntityName}");
+            }
+        }
+    }
+
+    public bool SendStationGoal(EntityUid ent, ProtoId<StationGoalPrototype> goal)
+    {
+        return SendStationGoal(ent, _proto.Index(goal));
+    }
+
+    /// <summary>
+    /// Send a station goal on selected station to all faxes which are authorized to receive it.
+    /// </summary>
+    /// <returns>True if at least one fax received paper</returns>
+    public bool SendStationGoal(EntityUid ent, StationGoalPrototype goal)
+    {
+        var printout = new FaxPrintout(
+            Loc.GetString(goal.Text, ("station", MetaData(ent).EntityName)),
+            Loc.GetString("station-goal-fax-paper-name"),
+            null,
+            null,
+            "paper_stamp-centcom",
+            [new() { StampedName = Loc.GetString("stamp-component-stamped-name-centcom"), StampedColor = Color.FromHex("#006600") }]
+        );
+
+        var wasSent = false;
+        var query = EntityQueryEnumerator<FaxMachineComponent>();
+        while (query.MoveNext(out var faxUid, out var fax))
+        {
+            if (!fax.ReceiveAllStationGoals && !(fax.ReceiveStationGoal && _station.GetOwningStation(faxUid) == ent))
+                continue;
+
+            _fax.Receive(faxUid, printout, null, fax);
+
+            foreach (var spawnEnt in goal.Spawns)
+                SpawnAtPosition(spawnEnt, Transform(faxUid).Coordinates);
+
+            wasSent |= fax.ReceiveStationGoal;
+        }
+
+        return wasSent;
+    }
+}

--- a/Content.Server/_Corvax/StationGoal/StationGoalPrototype.cs
+++ b/Content.Server/_Corvax/StationGoal/StationGoalPrototype.cs
@@ -1,0 +1,25 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Corvax.StationGoal;
+
+[Prototype]
+public sealed partial class StationGoalPrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    [DataField]
+    public string Text { get; set; } = string.Empty;
+
+    [DataField]
+    public int? MinPlayers;
+
+    [DataField]
+    public int? MaxPlayers;
+
+    /// <summary>
+    /// Goal may require certain items to complete. These items will appear near the receiving fax machine at the start of the round.
+    /// </summary>
+    [DataField]
+    public List<EntProtoId> Spawns = new();
+}

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -418,4 +418,11 @@ public sealed partial class CCVars
     /// </remarks>
     public static readonly CVarDef<int> TileStackLimit =
         CVarDef.Create("game.tile_stack_limit", 5, CVar.SERVER | CVar.REPLICATED);
+
+    // from Corvax to Polonium
+    /// <summary>
+    /// Send station goal on round start or not.
+    /// </summary>
+    public static readonly CVarDef<bool> StationGoal =
+        CVarDef.Create("game.station_goal", true, CVar.SERVERONLY);
 }

--- a/Content.Shared/Fax/Components/FaxMachineComponent.cs
+++ b/Content.Shared/Fax/Components/FaxMachineComponent.cs
@@ -135,6 +135,18 @@ public sealed partial class FaxMachineComponent : Component
     /// </summary>
     [DataField]
     public EntProtoId PrintOfficePaperId = "PaperOffice";
+
+    /// <summary>
+    /// Should that fax receive station goal info.
+    /// </summary>
+    [DataField]
+    public bool ReceiveStationGoal { get; set; }
+
+    /// <summary>
+    /// Should that fax receive station goals from other stations.
+    /// </summary>
+    [DataField]
+    public bool ReceiveAllStationGoals { get; set; }
 }
 
 [DataDefinition]

--- a/Content.Shared/GameTicking/RoundStartedEvent.cs
+++ b/Content.Shared/GameTicking/RoundStartedEvent.cs
@@ -1,0 +1,14 @@
+namespace Content.Shared.GameTicking;
+
+/// <summary>
+/// Raised after a round has fully started (players spawned, round in progress).
+/// </summary>
+public sealed class RoundStartedEvent : EntityEventArgs
+{
+    public int RoundId { get; }
+
+    public RoundStartedEvent(int roundId)
+    {
+        RoundId = roundId;
+    }
+}

--- a/Resources/Prototypes/Entities/Stations/nanotrasen.yml
+++ b/Resources/Prototypes/Entities/Stations/nanotrasen.yml
@@ -10,6 +10,7 @@
   id: StandardNanotrasenStation
   parent:
     - BaseStation
+    - BaseStationGoal
     - BaseStationNews
     - BaseStationCargo
     - BaseStationJobsSpawning

--- a/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
@@ -87,6 +87,7 @@
   - type: FaxMachine
     name: "Central Command"
     notifyAdmins: true
+    receiveAllStationGoals: true
 
 - type: entity
   parent: FaxMachineBase
@@ -115,5 +116,6 @@
     - type: FaxMachine
       name: "Captain's Office"
       receiveNukeCodes: true
+      receiveAllStationGoals: true
     - type: StealTarget
       stealGroup: FaxMachineCaptain

--- a/Resources/Prototypes/_Corvax/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_Corvax/Entities/Objects/Misc/paper.yml
@@ -1,0 +1,11 @@
+- type: entity
+  parent: Paper
+  id: StationGoalPaper
+  name: station goal centcomm message
+  description: It looks like you have a lot of work to do.
+  components:
+  - type: Paper
+    stampState: paper_stamp-centcom
+    stampedBy:
+    - stampedName: stamp-component-stamped-name-centcom
+      stampedColor: "#006600"

--- a/Resources/Prototypes/_Corvax/Entities/Stations/base.yml
+++ b/Resources/Prototypes/_Corvax/Entities/Stations/base.yml
@@ -1,0 +1,23 @@
+- type: entity
+  id: BaseStationGoal
+  abstract: true
+  components:
+  - type: StationGoal
+    goals:
+    - Singularity
+    - SolarPanels
+    - Artifacts
+    - Bank
+    - Zoo
+    - MiningOutpost
+    - Tesla
+    - SecurityTraining
+    - ShuttleMed
+    - ShuttleSec
+    - ShuttleRnd
+    - ShuttleSrv
+    - ShuttleEmergency
+    - Theatre
+    - CellAI
+    - Botany
+    - Bunker

--- a/Resources/Prototypes/_Corvax/Objectives/goals.yml
+++ b/Resources/Prototypes/_Corvax/Objectives/goals.yml
@@ -1,0 +1,80 @@
+# General goals
+- type: stationGoal
+  id: Singularity
+  text: station-goal-singularity
+  minPlayers: 15
+
+- type: stationGoal
+  id: SolarPanels
+  text: station-goal-solar-panels
+
+- type: stationGoal
+  id: Artifacts
+  text: station-goal-artifacts
+  minPlayers: 15
+
+- type: stationGoal
+  id: Bank
+  text: station-goal-bank
+  minPlayers: 15
+
+- type: stationGoal
+  id: Zoo
+  text: station-goal-zoo
+
+- type: stationGoal
+  id: MiningOutpost
+  text: station-goal-mining-outpost
+  minPlayers: 15
+
+- type: stationGoal
+  id: Tesla
+  text: station-goal-tesla
+  minPlayers: 15
+
+- type: stationGoal
+  id: SecurityTraining
+  text: station-goal-security
+  minPlayers: 15
+
+- type: stationGoal
+  id: ShuttleMed
+  text: station-goal-shuttle-med
+  minPlayers: 10
+
+- type: stationGoal
+  id: ShuttleSec
+  text: station-goal-shuttle-sec
+  minPlayers: 10
+
+- type: stationGoal
+  id: ShuttleRnd
+  text: station-goal-shuttle-rnd
+  minPlayers: 10
+
+- type: stationGoal
+  id: ShuttleSrv
+  text: station-goal-shuttle-srv
+  minPlayers: 10
+
+- type: stationGoal
+  id: ShuttleEmergency
+  text: station-goal-shuttle-emergency
+  minPlayers: 10
+
+- type: stationGoal
+  id: Theatre
+  text: station-goal-theatre
+
+- type: stationGoal
+  id: CellAI
+  text: station-goal-ai
+  minPlayers: 15
+
+- type: stationGoal
+  id: Botany
+  text: station-goal-botany
+
+- type: stationGoal
+  id: Bunker
+  text: station-goal-bunker


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Dla #694 
Port systemu celu zmiany 1:1 - bez różnic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nowe funkcje**
  * Dodano system losowania i wysyłania celów stacji na początku rundy.
  * Stacje mogą teraz otrzymywać przypisane cele, a wybrane urządzenia faksowe mogą je odbierać.
  * Dodano zestaw nowych celów stacji oraz powiązany dokument informacyjny.
  * Wprowadzono opcję włączania/wyłączania obsługi celów stacji w ustawieniach gry i urządzeń.
* **Bug Fixes**
  * Wybrane prototypy są teraz pomijane po stronie klienta zgodnie z konfiguracją ignorowania.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->