### PR TITLE
[Forky] Podłączenie starych wpisów podręcznika

### DIFF
--- a/Resources/Prototypes/Guidebook/antagonist.yml
+++ b/Resources/Prototypes/Guidebook/antagonist.yml
@@ -1,59 +1,88 @@
+# SPDX-FileCopyrightText: 2023 Derby <Derby@ss14>
+# SPDX-FileCopyrightText: 2023 DerbyX <50932435+DerbyX@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 coolmankid12345 <55817627+coolmankid12345@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 deltanedas <39013340+deltanedas@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
+# SPDX-FileCopyrightText: 2023 dribblydrone <119393097+dribblydrone@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 BombasterDS <115770678+BombasterDS@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 John Space <bigdumb421@gmail.com>
+# SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
+# SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2024 UBlueberry <161545003+UBlueberry@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 fishbait <gnesse@gmail.com>
+# SPDX-FileCopyrightText: 2024 username <113782077+whateverusername0@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Skye <57879983+Rainbeon@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 Tyranex <bobthezombie4@gmail.com>
+# SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 kbarkevich <24629810+kbarkevich@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
 - type: guideEntry
   id: Antagonists
   name: guide-entry-antagonists
-  text: "/ServerInfo/Guidebook/Antagonist/Antagonists.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/Antagonists.xml"
   children:
+  - CosmicCult # impstation - cosmic cult
   - Traitors
-  - Thieves
-  - Revolutionaries
+  - Changelings # Goobstation - changelings
+  - Heretics # Goobstation - heretics
+  - Blob # Goobstation - Blob
+  - BloodCult # Funky Station - Blood Cult
   - NuclearOperatives
-  - SpaceNinja
   - Wizard
   - Zombies
-  - Xenoborgs
+  - Revolutionaries
   - MinorAntagonists
+  - SpaceNinja
+  - Thieves
+  - MalfunctioningAI
 
 - type: guideEntry
   id: Traitors
   name: guide-entry-traitors
-  text: "/ServerInfo/Guidebook/Antagonist/Traitors.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/Traitors.xml"
 
 - type: guideEntry
   id: NuclearOperatives
   name: guide-entry-nuclear-operatives
-  text: "/ServerInfo/Guidebook/Antagonist/Nuclear Operatives.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/Nuclear Operatives.xml"
 
 - type: guideEntry
   id: Zombies
   name: guide-entry-zombies
-  text: "/ServerInfo/Guidebook/Antagonist/Zombies.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/Zombies.xml"
 
 - type: guideEntry
   id: Revolutionaries
   name: guide-entry-revolutionaries
-  text: "/ServerInfo/Guidebook/Antagonist/Revolutionaries.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/Revolutionaries.xml" # goobstation
 
 - type: guideEntry
   id: MinorAntagonists
   name: guide-entry-minor-antagonists
-  text: "/ServerInfo/Guidebook/Antagonist/MinorAntagonists.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/MinorAntagonists.xml"
 
 - type: guideEntry
   id: SpaceNinja
   name: guide-entry-space-ninja
-  text: "/ServerInfo/Guidebook/Antagonist/SpaceNinja.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/SpaceNinja.xml"
 
 - type: guideEntry
   id: Thieves
   name: guide-entry-thieves
-  text: "/ServerInfo/Guidebook/Antagonist/Thieves.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/Thieves.xml"
 
 - type: guideEntry
   id: Wizard
   name: guide-entry-wizard
-  text: "/ServerInfo/Guidebook/Antagonist/Wizard.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/Wizard.xml"
 
 - type: guideEntry
-  id: Xenoborgs
-  name: guide-entry-xenoborgs
-  text: "/ServerInfo/Guidebook/Antagonist/Xenoborgs.xml"
+  id: MalfunctioningAI
+  name: guide-entry-malfunctioningai
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/MalfunctioningAI.xml"

--- a/Resources/Prototypes/Guidebook/cargo.yml
+++ b/Resources/Prototypes/Guidebook/cargo.yml
@@ -1,7 +1,17 @@
+# SPDX-FileCopyrightText: 2023 Nails+Tape <124523848+Nails-n-Tape@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 UBlueberry <161545003+UBlueberry@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
 - type: guideEntry
   id: Cargo
   name: guide-entry-cargo
-  text: "/ServerInfo/Guidebook/Cargo/Cargo.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Cargo/Cargo.xml"
   children:
   - CargoBounties
   - Salvage
@@ -9,9 +19,9 @@
 - type: guideEntry
   id: CargoBounties
   name: guide-entry-cargo-bounties
-  text: "/ServerInfo/Guidebook/Cargo/CargoBounties.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Cargo/CargoBounties.xml"
 
 - type: guideEntry
   id: Salvage
   name: guide-entry-salvage
-  text: "/ServerInfo/Guidebook/Cargo/Salvage.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Cargo/Salvage.xml"

--- a/Resources/Prototypes/Guidebook/chemicals.yml
+++ b/Resources/Prototypes/Guidebook/chemicals.yml
@@ -1,7 +1,21 @@
+# SPDX-FileCopyrightText: 2024 Ian <ignaz.k@live.de>
+# SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2024 f0x-n3rd <150924715+f0x-n3rd@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Fenn <162015305+TooSillyFennec@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Goomson <GoomsonCode@proton.me>
+# SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
 - type: guideEntry
   id: Chemicals
   name: guide-entry-chemicals
-  text: "/ServerInfo/Guidebook/Chemicals.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Chemicals.xml"
   children:
   - Elements
   - Medicine
@@ -13,58 +27,74 @@
   - Biological
   - Special
   - Others
+  - Exotic # funky
+  - Reactions # funky
   filterEnabled: True
 
 - type: guideEntry
   id: Elements
   name: guide-entry-elements
-  text: "/ServerInfo/Guidebook/ChemicalTabs/Elements.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/ChemicalTabs/Elements.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: Narcotics
   name: guide-entry-narcotics
-  text: "/ServerInfo/Guidebook/ChemicalTabs/Narcotics.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/ChemicalTabs/Narcotics.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: Pyrotechnic
   name: guide-entry-pyrotechnics
-  text: "/ServerInfo/Guidebook/ChemicalTabs/Pyrotechnic.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/ChemicalTabs/Pyrotechnic.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: Toxins
   name: guide-entry-toxins
-  text: "/ServerInfo/Guidebook/ChemicalTabs/Toxins.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/ChemicalTabs/Toxins.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: Foods
   name: guide-entry-foods
-  text: "/ServerInfo/Guidebook/ChemicalTabs/Foods.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/ChemicalTabs/Foods.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: Botanical
   name: guide-entry-botanical
-  text: "/ServerInfo/Guidebook/Medical/Botanicals.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/Botanicals.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: Biological
   name: guide-entry-biological
-  text: "/ServerInfo/Guidebook/ChemicalTabs/Biological.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/ChemicalTabs/Biological.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: Special
   name: guide-entry-special
-  text: "/ServerInfo/Guidebook/ChemicalTabs/Special.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/ChemicalTabs/Special.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: Others
   name: guide-entry-others
-  text: "/ServerInfo/Guidebook/ChemicalTabs/Other.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/ChemicalTabs/Others.xml"
   filterEnabled: True
+
+  # begin funky
+- type: guideEntry
+  id: Exotic
+  name: guide-entry-exotic
+  text: "/ServerInfo/_Polonium/Guidebook/ChemicalTabs/Exotic.xml"
+  filterEnabled: True
+
+- type: guideEntry
+  id: Reactions
+  name: guide-entry-reactions
+  text: "/ServerInfo/_Polonium/Guidebook/ChemicalTabs/Reactions.xml"
+  # end funky
+

--- a/Resources/Prototypes/Guidebook/engineering.yml
+++ b/Resources/Prototypes/Guidebook/engineering.yml
@@ -1,7 +1,29 @@
+# SPDX-FileCopyrightText: 2023 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Aru Moon <anton17082003@gmail.com>
+# SPDX-FileCopyrightText: 2023 Julian Giebel <juliangiebel@live.de>
+# SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Naive817 <31364560+Naive817@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+# SPDX-FileCopyrightText: 2023 chromiumboy <50505512+chromiumboy@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 end <72604018+laok233@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Ben Velie <veliebm@gmail.com>
+# SPDX-FileCopyrightText: 2024 username <113782077+whateverusername0@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 ArtisticRoomba <145879011+ArtisticRoomba@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 McBosserson <148172569+McBosserson@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 McBosserson <mcbosserson@hotmail.com>
+# SPDX-FileCopyrightText: 2025 Nikita (Nick) <174215049+nikitosych@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
 - type: guideEntry
   id: Engineering
   name: guide-entry-engineering
-  text: "/ServerInfo/Guidebook/Engineering/Engineering.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/Engineering.xml"
   children:
   - Construction
   - Power
@@ -12,7 +34,7 @@
 - type: guideEntry
   id: Construction
   name: guide-entry-construction
-  text: "/ServerInfo/Guidebook/Engineering/Construction.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/Construction.xml"
   children:
   - Airlocks
   - ExpandingRepairingStation
@@ -21,29 +43,29 @@
 - type: guideEntry
   id: ExpandingRepairingStation
   name: guide-entry-expandingrepairingstation
-  text: "/ServerInfo/Guidebook/Engineering/ExpandingRepairingStation.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/ExpandingRepairingStation.xml"
 
 - type: guideEntry
   id: Airlocks
   name: guide-entry-airlocks
-  text: "/ServerInfo/Guidebook/Engineering/Airlocks.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/Airlocks.xml"
   children:
   - AirlockSecurity
 
 - type: guideEntry
   id: WirePanels
   name: guide-entry-wirepanels
-  text: "/ServerInfo/Guidebook/Engineering/WirePanels.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/WirePanels.xml"
 
 - type: guideEntry
   id: AirlockSecurity
   name: guide-entry-airlock-security
-  text: "/ServerInfo/Guidebook/Engineering/AirlockSecurity.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/AirlockSecurity.xml"
 
 - type: guideEntry
   id: Atmospherics
   name: guide-entry-atmospherics
-  text: "/ServerInfo/Guidebook/Engineering/Atmospherics.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/Atmospherics.xml"
   children:
   - GasManipulation
   - AtmosphericsSystems
@@ -54,7 +76,7 @@
 - type: guideEntry
   id: GasManipulation
   name: guide-entry-gasmanipulation
-  text: "/ServerInfo/Guidebook/Engineering/GasManipulation.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/GasManipulation.xml"
   children:
   - AtmosphereInOut
   - Pipes
@@ -64,22 +86,21 @@
   - GasCanisters
   - Thermomachines
   - GasCondensing
-  - GasRecycling
 
 - type: guideEntry
   id: Pipes
   name: guide-entry-pipes
-  text: "/ServerInfo/Guidebook/Engineering/Pipes.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/Pipes.xml"
 
 - type: guideEntry
   id: Pumps
   name: guide-entry-pumps
-  text: "/ServerInfo/Guidebook/Engineering/Pumps.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/Pumps.xml"
 
 - type: guideEntry
   id: AtmosphereInOut
   name: guide-entry-atmosphereinout
-  text: "/ServerInfo/Guidebook/Engineering/AtmosphereInOut.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/AtmosphereInOut.xml"
   children:
   - AirVent
   - PassiveVent
@@ -90,32 +111,32 @@
 - type: guideEntry
   id: AirVent
   name: guide-entry-airvent
-  text: "/ServerInfo/Guidebook/Engineering/AirVent.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/AirVent.xml"
 
 - type: guideEntry
   id: PassiveVent
   name: guide-entry-passivevent
-  text: "/ServerInfo/Guidebook/Engineering/PassiveVent.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/PassiveVent.xml"
 
 - type: guideEntry
   id: AirInjector
   name: guide-entry-airinjector
-  text: "/ServerInfo/Guidebook/Engineering/AirInjector.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/AirInjector.xml"
 
 - type: guideEntry
   id: AirScrubber
   name: guide-entry-airscrubber
-  text: "/ServerInfo/Guidebook/Engineering/AirScrubber.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/AirScrubber.xml"
 
 - type: guideEntry
   id: PortableScrubber
   name: guide-entry-portablescrubber
-  text: "/ServerInfo/Guidebook/Engineering/PortableScrubber.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/PortableScrubber.xml"
 
 - type: guideEntry
   id: Valves
   name: guide-entry-valves
-  text: "/ServerInfo/Guidebook/Engineering/Valves.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/Valves.xml"
   children:
   - ManualValve
   - SignalValve
@@ -126,64 +147,59 @@
 - type: guideEntry
   id: ManualValve
   name: guide-entry-manualvalve
-  text: "/ServerInfo/Guidebook/Engineering/ManualValve.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/ManualValve.xml"
 
 - type: guideEntry
   id: SignalValve
   name: guide-entry-signalvalve
-  text: "/ServerInfo/Guidebook/Engineering/SignalValve.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/SignalValve.xml"
 
 - type: guideEntry
   id: PneumaticValve
   name: guide-entry-pneumaticvalve
-  text: "/ServerInfo/Guidebook/Engineering/PneumaticValve.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/PneumaticValve.xml"
 
 - type: guideEntry
   id: PassiveGate
   name: guide-entry-passivegate
-  text: "/ServerInfo/Guidebook/Engineering/PassiveGate.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/PassiveGate.xml"
 
 - type: guideEntry
   id: PressureRegulator
   name: guide-entry-ressureregulator
-  text: "/ServerInfo/Guidebook/Engineering/PressureRegulator.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/PressureRegulator.xml"
 
 - type: guideEntry
   id: MixingAndFiltering
   name: guide-entry-mixingandfiltering
-  text: "/ServerInfo/Guidebook/Engineering/MixingAndFiltering.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/MixingAndFiltering.xml"
 
 - type: guideEntry
   id: GasCanisters
   name: guide-entry-gascanisters
-  text: "/ServerInfo/Guidebook/Engineering/GasCanisters.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/GasCanisters.xml"
 
 - type: guideEntry
   id: Thermomachines
   name: guide-entry-thermomachines
-  text: "/ServerInfo/Guidebook/Engineering/Thermomachines.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/Thermomachines.xml"
   children:
   - Radiators
 
 - type: guideEntry
   id: GasCondensing
   name: guide-entry-gascondensing
-  text: "/ServerInfo/Guidebook/Engineering/GasCondensing.xml"
-
-- type: guideEntry
-  id: GasRecycling
-  name: guide-entry-gasrecycling
-  text: "/ServerInfo/Guidebook/Engineering/GasRecycling.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/GasCondensing.xml"
 
 - type: guideEntry
   id: Radiators
   name: guide-entry-radiators
-  text: "/ServerInfo/Guidebook/Engineering/Radiators.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/Radiators.xml"
 
 - type: guideEntry
   id: AtmosphericsSystems
   name: guide-entry-atmosphericssystems
-  text: "/ServerInfo/Guidebook/Engineering/AtmosphericsSystems.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/AtmosphericsSystems.xml"
   children:
   - PipeNetworks
   - DeviceMonitoringAndControl
@@ -193,12 +209,12 @@
 - type: guideEntry
   id: PipeNetworks
   name: guide-entry-pipenetworks
-  text: "/ServerInfo/Guidebook/Engineering/PipeNetworks.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/PipeNetworks.xml"
 
 - type: guideEntry
   id: DeviceMonitoringAndControl
   name: guide-entry-devicemonitoringandcontrol
-  text: "/ServerInfo/Guidebook/Engineering/DeviceMonitoringAndControl.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/DeviceMonitoringAndControl.xml"
   children:
   - AirAlarms
   - AtmosphericAlertsComputer
@@ -207,83 +223,77 @@
 - type: guideEntry
   id: AirAlarms
   name: guide-entry-airalarms
-  text: "/ServerInfo/Guidebook/Engineering/AirAlarms.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/AirAlarms.xml"
 
 - type: guideEntry
   id: AtmosphericAlertsComputer
   name: guide-entry-atmosphericalertscomputer
-  text: "/ServerInfo/Guidebook/Engineering/AtmosphericAlertsComputer.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/AtmosphericAlertsComputer.xml"
 
 - type: guideEntry
   id: AtmosphericNetworkMonitor
   name: guide-entry-atmosphericnetworkmonitor
-  text: "/ServerInfo/Guidebook/Engineering/AtmosphericNetworkMonitor.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/AtmosphericNetworkMonitor.xml"
 
 - type: guideEntry
   id: FireAndGasControl
   name: guide-entry-fireandgascontrol
-  text: "/ServerInfo/Guidebook/Engineering/FireAndGasControl.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/FireAndGasControl.xml"
 
 - type: guideEntry
   id: GasMiningAndStorage
   name: guide-entry-gasminingandstorage
-  text: "/ServerInfo/Guidebook/Engineering/GasMiningAndStorage.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/GasMiningAndStorage.xml"
 
 - type: guideEntry
   id: AtmosphericUpsets
   name: guide-entry-atmosphericupsets
-  text: "/ServerInfo/Guidebook/Engineering/AtmosphericUpsets.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/AtmosphericUpsets.xml"
   children:
   - Fires
   - Spacing
-  - DeltaPressure
 
 - type: guideEntry
   id: Fires
   name: guide-entry-fires
-  text: "/ServerInfo/Guidebook/Engineering/Fires.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/Fires.xml"
 
 - type: guideEntry
   id: Spacing
   name: guide-entry-spacing
-  text: "/ServerInfo/Guidebook/Engineering/Spacing.xml"
-
-- type: guideEntry
-  id: DeltaPressure
-  name: guide-entry-deltapressure
-  text: "/ServerInfo/Guidebook/Engineering/DeltaPressure.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/Spacing.xml"
 
 - type: guideEntry
   id: AtmosTools
   name: guide-entry-atmostools
-  text: "/ServerInfo/Guidebook/Engineering/AtmosTools.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/AtmosTools.xml"
 
 - type: guideEntry
   id: Gasses
   name: guide-entry-gasses
-  text: "/ServerInfo/Guidebook/Engineering/Gasses.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/Gasses.xml"
 
 - type: guideEntry
   id: ShuttleCraft
   name: guide-entry-shuttle-craft
-  text: "/ServerInfo/Guidebook/Engineering/Shuttlecraft.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/Shuttlecraft.xml"
 
 - type: guideEntry
   id: Networking
   name: guide-entry-networking
-  text: "/ServerInfo/Guidebook/Engineering/Networking.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/Networking.xml"
   children:
   - AccessConfigurator
 
 - type: guideEntry
   id: AccessConfigurator
   name: guide-entry-access-configurator
-  text: "/ServerInfo/Guidebook/Engineering/AccessConfigurator.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/AccessConfigurator.xml"
 
 - type: guideEntry
   id: Power
   name: guide-entry-power
-  text: "/ServerInfo/Guidebook/Engineering/Power.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/Power.xml"
   children:
     - Generators
     - InspectingPower
@@ -294,27 +304,27 @@
 - type: guideEntry
   id: InspectingPower
   name: guide-entry-inspectingpower
-  text: "/ServerInfo/Guidebook/Engineering/InspectingPower.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/InspectingPower.xml"
 
 - type: guideEntry
   id: PowerStorage
   name: guide-entry-powerstorage
-  text: "/ServerInfo/Guidebook/Engineering/PowerStorage.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/PowerStorage.xml"
 
 - type: guideEntry
   id: Ramping
   name: guide-entry-ramping
-  text: "/ServerInfo/Guidebook/Engineering/Ramping.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/Ramping.xml"
 
 - type: guideEntry
   id: VoltageNetworks
   name: guide-entry-voltagenetworks
-  text: "/ServerInfo/Guidebook/Engineering/VoltageNetworks.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/VoltageNetworks.xml"
 
 - type: guideEntry
   id: Generators
   name: guide-entry-generators
-  text: "/ServerInfo/Guidebook/Engineering/Generators.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/Generators.xml"
   children:
   - PortableGenerator
   - AME
@@ -323,16 +333,18 @@
   - TEG
   - RTG
   - SolarPanels
+  # Goobstation - Supermatter
+  - Supermatter
 
 - type: guideEntry
   id: AME
   name: guide-entry-ame
-  text: "/ServerInfo/Guidebook/Engineering/AME.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/AME.xml"
 
 - type: guideEntry
   id: SingularityTeslaEngine
   name: guide-entry-singularityteslaengine
-  text: "/ServerInfo/Guidebook/Engineering/SingularityTeslaEngine.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/SingularityTeslaEngine.xml"
   children:
   - SingularityEngine
   - TeslaEngine
@@ -340,29 +352,29 @@
 - type: guideEntry
   id: SingularityEngine
   name: guide-entry-singularityengine
-  text: "/ServerInfo/Guidebook/Engineering/SingularityEngine.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/SingularityEngine.xml"
 
 - type: guideEntry
   id: TeslaEngine
   name: guide-entry-teslaengine
-  text: "/ServerInfo/Guidebook/Engineering/TeslaEngine.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/TeslaEngine.xml"
 
 - type: guideEntry
   id: TEG
   name: guide-entry-teg
-  text: "/ServerInfo/Guidebook/Engineering/TEG.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/TEG.xml"
 
 - type: guideEntry
   id: RTG
   name: guide-entry-rtg
-  text: "/ServerInfo/Guidebook/Engineering/RTG.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/RTG.xml"
 
 - type: guideEntry
   id: PortableGenerator
   name: guide-entry-portable-generator
-  text: "/ServerInfo/Guidebook/Engineering/PortableGenerator.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/PortableGenerator.xml"
 
 - type: guideEntry
   id: SolarPanels
   name: guide-entry-solarpanels
-  text: "/ServerInfo/Guidebook/Engineering/SolarPanels.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/SolarPanels.xml"

--- a/Resources/Prototypes/Guidebook/medical.yml
+++ b/Resources/Prototypes/Guidebook/medical.yml
@@ -1,32 +1,50 @@
+# SPDX-FileCopyrightText: 2023 CrigCrag <137215465+CrigCrag@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Hebi <spiritbreakz@gmail.com>
+# SPDX-FileCopyrightText: 2023 Sir Winters <7543955+Owai-Seek@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 end <72604018+laok233@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2024 f0x-n3rd <150924715+f0x-n3rd@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
 - type: guideEntry
   id: Medical
   name: guide-entry-medical
-  text: "/ServerInfo/Guidebook/Medical/Medical.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/Medical.xml"
   children:
   - MedicalDoctor
   - Chemist
   - Cloning
   - Cryogenics
+  - Medicalpatches
+  - Surgery # Shitmed Change
 
 - type: guideEntry
   id: MedicalDoctor
   name: guide-entry-medicaldoctor
-  text: "/ServerInfo/Guidebook/Medical/MedicalDoctor.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/MedicalDoctor.xml"
 
 - type: guideEntry
   id: Cloning
   name: guide-entry-cloning
-  text: "/ServerInfo/Guidebook/Medical/Cloning.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/Cloning.xml"
 
 - type: guideEntry
   id: Cryogenics
   name: guide-entry-cryogenics
-  text: "/ServerInfo/Guidebook/Medical/Cryogenics.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/Cryogenics.xml"
 
 - type: guideEntry
   id: Chemist
   name: guide-entry-chemist
-  text: "/ServerInfo/Guidebook/Medical/Chemist.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/Chemist.xml"
   children:
   # - Medicine
   # Duplicate guide entries are currently not supported
@@ -37,16 +55,16 @@
 - type: guideEntry
   id: Medicine
   name: guide-entry-medicine
-  text: "/ServerInfo/Guidebook/Medical/Medicine.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/Medicine.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: Botanicals
   name: guide-entry-botanicals
-  text: "/ServerInfo/Guidebook/Medical/Botanicals.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/Botanicals.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: AdvancedBrute
   name: guide-entry-brute
-  text: "/ServerInfo/Guidebook/Medical/AdvancedBrute.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/AdvancedBrute.xml"

--- a/Resources/Prototypes/Guidebook/newplayer.yml
+++ b/Resources/Prototypes/Guidebook/newplayer.yml
@@ -1,8 +1,14 @@
+# SPDX-FileCopyrightText: 2024 UBlueberry <161545003+UBlueberry@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
 - type: guideEntry
   id: NewPlayer
   name: guide-entry-newplayer
   priority: 0
-  text: "/ServerInfo/Guidebook/NewPlayer/NewPlayer.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/NewPlayer/NewPlayer.xml"
   children:
   - Controls
   - CharacterCreation
@@ -10,19 +16,19 @@
 - type: guideEntry
   id: Controls
   name: guide-entry-controls
-  text: "/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/NewPlayer/Controls/Controls.xml"
   children:
   - Radio
 
 - type: guideEntry
   id: Radio
   name: guide-entry-radio
-  text: "/ServerInfo/Guidebook/NewPlayer/Controls/Radio.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/NewPlayer/Controls/Radio.xml"
 
 - type: guideEntry
   id: CharacterCreation
   name: guide-entry-charactercreation
-  text: "/ServerInfo/Guidebook/NewPlayer/CharacterCreation.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/NewPlayer/CharacterCreation.xml"
   children:
   - YourFirstCharacter
   - Species
@@ -30,4 +36,4 @@
 - type: guideEntry
   id: YourFirstCharacter
   name: guide-entry-yourfirstcharacter
-  text: "/ServerInfo/Guidebook/NewPlayer/YourFirstCharacter.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/NewPlayer/YourFirstCharacter.xml"

--- a/Resources/Prototypes/Guidebook/references.yml
+++ b/Resources/Prototypes/Guidebook/references.yml
@@ -1,25 +1,35 @@
+# SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 UBlueberry <161545003+UBlueberry@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Nikita (Nick) <174215049+nikitosych@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2026 Zergologist <114537969+Chedd-Error@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
 - type: guideEntry
   id: References
   name: guide-entry-references
   priority: 30
-  text: "/ServerInfo/Guidebook/References.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/References.xml"
   children:
   - Chemicals
   - Drinks
   - FoodRecipes
   - Writing
-  - Lawsets
 
 - type: guideEntry
   id: Drinks
   name: guide-entry-drinks
-  text: "/ServerInfo/Guidebook/ReferenceTables/Drinks.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/ReferenceTables/Drinks.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: FoodRecipes
   name: guide-entry-foodrecipes
-  text: "/ServerInfo/Guidebook/Service/FoodRecipes.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/FoodRecipes.xml"
   filterEnabled: True
   children:
   - PizzaRecipes
@@ -37,104 +47,104 @@
   - OtherRecipes
   - MedicinalRecipes
   - SecretRecipes
+  - IngredientReactions # Funk
 
 - type: guideEntry
   id: PizzaRecipes
   name: guide-entry-pizza-recipes
-  text: "/ServerInfo/Guidebook/Service/PizzaRecipes.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/PizzaRecipes.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: SavoryRecipes
   name: guide-entry-savory-recipes
-  text: "/ServerInfo/Guidebook/Service/SavoryRecipes.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/SavoryRecipes.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: BreadRecipes
   name: guide-entry-bread-recipes
-  text: "/ServerInfo/Guidebook/Service/BreadRecipes.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/BreadRecipes.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: BreakfastRecipes
   name: guide-entry-breakfast-recipes
-  text: "/ServerInfo/Guidebook/Service/BreakfastRecipes.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/BreakfastRecipes.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: MothRecipes
   name: guide-entry-moth-recipes
-  text: "/ServerInfo/Guidebook/Service/MothRecipes.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/MothRecipes.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: PastaRecipes
   name: guide-entry-pasta-recipes
-  text: "/ServerInfo/Guidebook/Service/PastaRecipes.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/PastaRecipes.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: DessertRecipes
   name: guide-entry-dessert-recipes
-  text: "/ServerInfo/Guidebook/Service/DessertRecipes.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/DessertRecipes.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: SoupRecipes
   name: guide-entry-soup-recipes
-  text: "/ServerInfo/Guidebook/Service/SoupRecipes.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/SoupRecipes.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: PieRecipes
   name: guide-entry-pie-recipes
-  text: "/ServerInfo/Guidebook/Service/PieRecipes.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/PieRecipes.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: BarsAndCookiesRecipes
   name: guide-entry-barsandcookies-recipes
-  text: "/ServerInfo/Guidebook/Service/BarsAndCookiesRecipes.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/BarsAndCookiesRecipes.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: CakeRecipes
   name: guide-entry-cake-recipes
-  text: "/ServerInfo/Guidebook/Service/CakeRecipes.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/CakeRecipes.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: SaladRecipes
   name: guide-entry-salad-recipes
-  text: "/ServerInfo/Guidebook/Service/SaladRecipes.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/SaladRecipes.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: OtherRecipes
   name: guide-entry-other-recipes
-  text: "/ServerInfo/Guidebook/Service/OtherRecipes.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/OtherRecipes.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: MedicinalRecipes
   name: guide-entry-medicinal-recipes
-  text: "/ServerInfo/Guidebook/Service/MedicinalRecipes.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/MedicinalRecipes.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: SecretRecipes
   name: guide-entry-secret-recipes
-  text: "/ServerInfo/Guidebook/Service/SecretRecipes.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/SecretRecipes.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: Writing
   name: guide-entry-writing
-  text: "/ServerInfo/Guidebook/Writing.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Writing.xml"
 
-- type: guideEntry
-  id: Lawsets
-  name: guide-entry-lawsets
-  text: "/ServerInfo/Guidebook/ReferenceTables/Lawsets.xml"
-  filterEnabled: True
+- type: guideEntry # Funk
+  id: IngredientReactions
+  name: guide-entry-ingredient-reactions
+  text: "/ServerInfo/_Polonium/Guidebook/Service/IngredientReactions.xml"

--- a/Resources/Prototypes/Guidebook/rules.yml
+++ b/Resources/Prototypes/Guidebook/rules.yml
@@ -1,44 +1,119 @@
+# SPDX-FileCopyrightText: 2024 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Aiden <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2024 Aidenkrz <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2024 Chief-Engineer <119664036+Chief-Engineer@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 DevilishMilk <michaellapjr@gmail.com>
+# SPDX-FileCopyrightText: 2024 Kira Gbedan <161087999+Verbalase@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Piras314 <92357316+Piras314@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2024 basic pack <159909786+packmore@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Icepick <122653407+Icepicked@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Icepick <icepickedcyanide@gmail.com>
+# SPDX-FileCopyrightText: 2025 JoulesBerg <104539820+JoulesBerg@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 JoulesBerg <thejoulesberg@gmail.com>
+# SPDX-FileCopyrightText: 2025 JustDecor <98410966+JustDecor@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Mish <bluscout78@yahoo.com>
+# SPDX-FileCopyrightText: 2025 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2025 PoquitoDondito <danielchristianstone@gmail.com>
+# SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Nikita (Nick) <174215049+nikitosych@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Sadie <sadiecmstone@gmail.com>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+- type: guideEntry
+  id: CommunityRules
+  name: guide-entry-rules-community
+  ruleEntry: false
+  priority: -10
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CommunityRules/CommunityRules.xml"
+  children:
+  - RuleS1
+  - RuleS2
+  - RuleS3
+  - RuleS4
+  - RuleS5
+  - RuleS6
+  - RuleS7
+
+- type: guideEntry
+  id: RuleS1
+  name: guide-entry-rules-s1
+  ruleEntry: true
+  priority: -9
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CommunityRules/RuleS1Respect.xml"
+
+- type: guideEntry
+  id: RuleS2
+  name: guide-entry-rules-s2
+  ruleEntry: true
+  priority: -8
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CommunityRules/RuleS2Spam.xml"
+
+- type: guideEntry
+  id: RuleS3
+  name: guide-entry-rules-s3
+  ruleEntry: true
+  priority: -7
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CommunityRules/RuleS3NSFW.xml"
+
+- type: guideEntry
+  id: RuleS4
+  name: guide-entry-rules-s4
+  ruleEntry: true
+  priority: -6
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CommunityRules/RuleS4QuetionableTopics.xml"
+
+- type: guideEntry
+  id: RuleS5
+  name: guide-entry-rules-s5
+  ruleEntry: true
+  priority: -5
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CommunityRules/RuleS5Safety.xml"
+
+- type: guideEntry
+  id: RuleS6
+  name: guide-entry-rules-s6
+  ruleEntry: true
+  priority: -4
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CommunityRules/RuleS6Evading.xml"
+
+- type: guideEntry
+  id: RuleS7
+  name: guide-entry-rules-s7
+  ruleEntry: true
+  priority: -3
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CommunityRules/RuleS7Loopholes.xml"
+
 - type: guideEntry # Default for forks and stuff. Should not be listed anywhere if the server is using a custom ruleset.
   id: DefaultRuleset
   name: guide-entry-rules
-  ruleEntry: true
-  priority: 10
-  text: "/ServerInfo/Guidebook/ServerRules/DefaultRules.xml"
-
-- type: guideEntry
-  id: CoreRuleset
-  name: guide-entry-rules-core-only
-  ruleEntry: true
-  priority: 10
-  text: "/ServerInfo/Guidebook/ServerRules/WizDenCoreOnlyRules.xml"
-
-- type: guideEntry
-  id: StandardRuleset
-  name: guide-entry-rules-lrp
-  ruleEntry: true
-  priority: 10
-  text: "/ServerInfo/Guidebook/ServerRules/WizDenLRPRules.xml"
-
-- type: guideEntry
-  id: MRPRuleset
-  name: guide-entry-rules-mrp
-  ruleEntry: true
-  priority: 10
-  text: "/ServerInfo/Guidebook/ServerRules/WizDenMRPRules.xml"
+  priority: -1
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/DefaultRules.xml"
+  children:
+  - CoreRules
+#  - RoleplayRules
+#  - SiliconRules
+  - RoleTypes
+  - BanTypes
+  - BanDurations
+  - Metashield
 
 - type: guideEntry
   id: RoleTypes
   name: guide-entry-rules-role-types
   ruleEntry: true
-  priority: 10
-  text: "/ServerInfo/Guidebook/ServerRules/RoleTypes.xml"
+  priority: 20
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/RoleTypes.xml"
 
 - type: guideEntry
   id: CoreRules
   name: guide-entry-rules-core
   ruleEntry: true
-  priority: 10
-  text: "/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC0.xml"
+  priority: 30
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CoreRules/RuleC0.xml"
   children:
   - RuleC1
   - RuleC2
@@ -52,325 +127,426 @@
   - RuleC10
   - RuleC11
   - RuleC12
-  - RuleC13
-  - RuleC14
+  #- RuleC13
+  # - RuleC14
+
+- type: guideEntry
+  id: RuleC00
+  name: guide-entry-rules-c00
+  ruleEntry: true
+  priority: 0
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CoreRules/RuleC00.xml"
 
 - type: guideEntry
   id: RuleC1
   name: guide-entry-rules-c1
   ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC1Admins.xml"
+  priority: 1
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CoreRules/RuleC1DBAA.xml"
 
 - type: guideEntry
   id: RuleC2
   name: guide-entry-rules-c2
   ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC2DBAD.xml"
+  priority: 2
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CoreRules/RuleC2PolishOnlyPolski.xml"
 
 - type: guideEntry
   id: RuleC3
   name: guide-entry-rules-c3
   ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC3NoHate.xml"
+  priority: 3
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CoreRules/RuleC3Age.xml"
 
 - type: guideEntry
   id: RuleC4
   name: guide-entry-rules-c4
   ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC4NoERP.xml"
+  priority: 4
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CoreRules/RuleC4AdminRulings.xml"
 
 - type: guideEntry
   id: RuleC5
   name: guide-entry-rules-c5
   ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC5Metacomms.xml"
+  priority: 5
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CoreRules/RuleC5Metagaming.xml"
 
 - type: guideEntry
   id: RuleC6
   name: guide-entry-rules-c6
   ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC6BanEvasion.xml"
+  priority: 6
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CoreRules/RuleC6PlayYourCharacter.xml"
 
 - type: guideEntry
   id: RuleC7
   name: guide-entry-rules-c7
   ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC7EnglishOnly.xml"
+  priority: 7
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CoreRules/RuleC7Names.xml"
 
 - type: guideEntry
   id: RuleC8
   name: guide-entry-rules-c8
   ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC8Exploits.xml"
+  priority: 8
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CoreRules/RuleC8UseProperEscalation.xml"
 
 - type: guideEntry
   id: RuleC9
   name: guide-entry-rules-c9
   ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC9Multikey.xml"
+  priority: 9
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CoreRules/RuleC9SecandCommand.xml"
 
 - type: guideEntry
   id: RuleC10
   name: guide-entry-rules-c10
   ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC10AHelp.xml"
+  priority: 10
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CoreRules/RuleC10SiliconPolicy.xml"
 
 - type: guideEntry
   id: RuleC11
   name: guide-entry-rules-c11
   ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC11AhelpThreats.xml"
+  priority: 11
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CoreRules/RuleC11Antag.xml"
+
+# - type: guideEntry
+#   id: RuleC13
+#   name: guide-entry-rules-c13
+#   ruleEntry: true
+#   priority: 13
+#   text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CoreRules/RuleC13NoEORG.xml"
 
 - type: guideEntry
   id: RuleC12
   name: guide-entry-rules-c12
   ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC12MinAge.xml"
+  priority: 12
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/CoreRules/RuleC12LOOC.xml"
+
+# - type: guideEntry
+#   id: RuleC15
+#   name: guide-entry-rules-c15
+#   ruleEntry: true
+#   priority: 15
+#   text: "/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC15Roles.xml"
 
 - type: guideEntry
-  id: RuleC13
-  name: guide-entry-rules-c13
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC13CharacterNames.xml"
+  id: Metashield
+  name: guide-entry-metashield
+  ruleEntry: false
+  priority: 4
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/Metashield.xml"
 
 - type: guideEntry
-  id: RuleC14
-  name: guide-entry-rules-c14
+  id: NamingScheme
+  name: guide-entry-namingscheme
   ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC14ICinOOC.xml"
+  priority: 4
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/NamingScheme.xml"
+
+#- type: guideEntry
+#  id: RuleC14
+#  name: guide-entry-rules-c14
+#  ruleEntry: true
+#  priority: 14
+#  text: "/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC14ICinOOC.xml"
+#
+#- type: guideEntry
+#  id: RoleplayRules
+#  name: guide-entry-rules-roleplay
+#  ruleEntry: true
+#  priority: 40
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR0.xml"
+#  children:
+#  - RuleR1
+#  - RuleR2
+#  - RuleR3
+#  - RuleR4
+#  - RuleR5
+#  - RuleR6
+#  - RuleR7
+#  - RuleR8
+#  - RuleR9
+#  - RuleR10
+#  - RuleR11
+#  - RuleR12
+#  - RuleR13
+#  - RuleR14
+#  - RuleR15
+#  - RuleR16
+#  - RuleR17
+#  - RuleR18
+#  - RuleR19
+#
+#- type: guideEntry
+#  id: RuleR1
+#  name: guide-entry-rules-r1
+#  ruleEntry: true
+#  priority: 1
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR1Silicons.xml"
+#
+#- type: guideEntry
+#  id: RuleR2
+#  name: guide-entry-rules-r2
+#  ruleEntry: true
+#  priority: 2
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR2Familiars.xml"
+#
+#- type: guideEntry
+#  id: RuleR3
+#  name: guide-entry-rules-r3
+#  ruleEntry: true
+#  priority: 3
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR3NormalRP.xml"
+#
+#- type: guideEntry
+#  id: RuleR4
+#  name: guide-entry-rules-r4
+#  ruleEntry: true
+#  priority: 4
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml"
+#
+#- type: guideEntry
+#  id: RuleR5
+#  name: guide-entry-rules-r5
+#  ruleEntry: true
+#  priority: 5
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR5Arrivals.xml"
+#
+#- type: guideEntry
+#  id: RuleR6
+#  name: guide-entry-rules-r6
+#  ruleEntry: true
+#  priority: 6
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR6SelfAntag.xml"
+#
+#- type: guideEntry
+#  id: RuleR7
+#  name: guide-entry-rules-r7
+#  ruleEntry: true
+#  priority: 7
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR7RoundStalling.xml"
+#
+#- type: guideEntry
+#  id: RuleR8
+#  name: guide-entry-rules-r8
+#  ruleEntry: true
+#  priority: 8
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR8NoFriendlyAntag.xml"
+#
+#- type: guideEntry
+#  id: RuleR9
+#  name: guide-entry-rules-r9
+#  ruleEntry: true
+#  priority: 9
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR9MassSabotage.xml"
+#
+#- type: guideEntry
+#  id: RuleR10
+#  name: guide-entry-rules-r10
+#  ruleEntry: true
+#  priority: 10
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR10Subordination.xml"
+#
+#- type: guideEntry
+#  id: RuleR11
+#  name: guide-entry-rules-r11
+#  ruleEntry: true
+#  priority: 11
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR11Escalation.xml"
+#  children:
+#  - RuleR11-1
+#  - RuleR11-2
+#
+#- type: guideEntry
+#  id: RuleR11-1
+#  name: guide-entry-rules-r11-1
+#  ruleEntry: true
+#  priority: 10
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR11-1AnimalEscalation.xml"
+#
+#- type: guideEntry
+#  id: RuleR11-2
+#  name: guide-entry-rules-r11-2
+#  ruleEntry: true
+#  priority: 10
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR11-2ConflictTypes.xml"
+#
+#- type: guideEntry
+#  id: RuleR12
+#  name: guide-entry-rules-r12
+#  ruleEntry: true
+#  priority: 12
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR12RoleAbandonment.xml"
+#
+#- type: guideEntry
+#  id: RuleR13
+#  name: guide-entry-rules-r13
+#  ruleEntry: true
+#  priority: 13
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR13PerformRole.xml"
+#
+#- type: guideEntry
+#  id: RuleR14
+#  name: guide-entry-rules-r14
+#  ruleEntry: true
+#  priority: 14
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR14SecComStandard.xml"
+#
+#- type: guideEntry
+#  id: RuleR15
+#  name: guide-entry-rules-r15
+#  ruleEntry: true
+#  priority: 15
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR15SpaceLaw.xml"
+#
+#- type: guideEntry
+#  id: RuleR16
+#  name: guide-entry-rules-r16
+#  priority: 16
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR16Blueshield.xml"
+#
+#- type: guideEntry
+#  id: RuleR17
+#  name: guide-entry-rules-r17
+#  priority: 17
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR17NTR.xml"
+#
+#- type: guideEntry
+#  id: RuleR18
+#  name: guide-entry-rules-r18
+#  priority: 18
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR18PG.xml"
+#
+#- type: guideEntry
+#  id: RuleR19
+#  name: guide-entry-rules-r19
+#  priority: 19
+#  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR19VH.xml"
+#
+#- type: guideEntry
+#  id: SiliconRules
+#  name: guide-entry-rules-silicon
+#  ruleEntry: true
+#  priority: 50
+#  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS0.xml"
+#  children:
+#  - RuleS1
+#  - RuleS2
+#  - RuleS3
+#  - RuleS4
+#  - RuleS5
+#  - RuleS6
+#  - RuleS7
+#  - RuleS8
+#  - RuleS9
+#  - RuleS10
+#
+#- type: guideEntry
+#  id: RuleS1
+#  name: guide-entry-rules-s1
+#  ruleEntry: true
+#  priority: 1
+#  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS1Laws.xml"
+#
+#- type: guideEntry
+#  id: RuleS2
+#  name: guide-entry-rules-s2
+#  ruleEntry: true
+#  priority: 2
+#  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS2LawPriority.xml"
+#
+#- type: guideEntry
+#  id: RuleS3
+#  name: guide-entry-rules-s3
+#  ruleEntry: true
+#  priority: 3
+#  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS3LawRedefinition.xml"
+#
+#- type: guideEntry
+#  id: RuleS4
+#  name: guide-entry-rules-s4
+#  ruleEntry: true
+#  priority: 4
+#  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS4RequestChanges.xml"
+#
+#- type: guideEntry
+#  id: RuleS5
+#  name: guide-entry-rules-s5
+#  ruleEntry: true
+#  priority: 5
+#  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS5FreeSilicon.xml"
+#
+#- type: guideEntry
+#  id: RuleS6
+#  name: guide-entry-rules-s6
+#  ruleEntry: true
+#  priority: 6
+#  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS6UnreasonableOrders.xml"
+#
+#- type: guideEntry
+#  id: RuleS7
+#  name: guide-entry-rules-s7
+#  ruleEntry: true
+#  priority: 7
+#  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS7Consistency.xml"
+#
+#- type: guideEntry
+#  id: RuleS8
+#  name: guide-entry-rules-s8
+#  ruleEntry: true
+#  priority: 8
+#  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS8DefaultCrewDefinition.xml"
+#
+#- type: guideEntry
+#  id: RuleS9
+#  name: guide-entry-rules-s9
+#  ruleEntry: true
+#  priority: 9
+#  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS9DefaultHarmDefinition.xml"
+#
+#- type: guideEntry
+#  id: RuleS10
+#  name: guide-entry-rules-s10
+#  ruleEntry: true
+#  priority: 10
+#  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS10OrderConflicts.xml"
 
 - type: guideEntry
-  id: RoleplayRules
-  name: guide-entry-rules-roleplay
-  ruleEntry: true
+  id: SpaceLaw
+  name: guide-entry-rules-space-law
+  priority: 1
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml"
+  children:
+  - SpaceLawCrimeList
+
+- type: guideEntry
+  id: RulesOfConduct
+  name: guide-entry-rules-of-conduct
   priority: 10
-  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR0.xml"
-  children:
-  - RuleR1
-  - RuleR2
-  - RuleR3
-  - RuleR4
-  - RuleR5
-  - RuleR6
-  - RuleR7
-  - RuleR8
-  - RuleR9
-  - RuleR10
-  - RuleR11
-  - RuleR12
-  - RuleR13
-  - RuleR14
-  - RuleR15
+  text: "/ServerInfo/_Polonium/Guidebook/Security/RulesOfConduct.xml"
 
 - type: guideEntry
-  id: RuleR1
-  name: guide-entry-rules-r1
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR1Silicons.xml"
-
-- type: guideEntry
-  id: RuleR2
-  name: guide-entry-rules-r2
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR2Familiars.xml"
-
-- type: guideEntry
-  id: RuleR3
-  name: guide-entry-rules-r3
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR3NormalRP.xml"
-
-- type: guideEntry
-  id: RuleR4
-  name: guide-entry-rules-r4
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml"
-
-- type: guideEntry
-  id: RuleR5
-  name: guide-entry-rules-r5
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR5Arrivals.xml"
-
-- type: guideEntry
-  id: RuleR6
-  name: guide-entry-rules-r6
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR6SelfAntag.xml"
-
-- type: guideEntry
-  id: RuleR7
-  name: guide-entry-rules-r7
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR7RoundStalling.xml"
-
-- type: guideEntry
-  id: RuleR8
-  name: guide-entry-rules-r8
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR8NoFriendlyAntag.xml"
-
-- type: guideEntry
-  id: RuleR9
-  name: guide-entry-rules-r9
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR9MassSabotage.xml"
-
-- type: guideEntry
-  id: RuleR10
-  name: guide-entry-rules-r10
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR10Subordination.xml"
-
-- type: guideEntry
-  id: RuleR11
-  name: guide-entry-rules-r11
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR11Escalation.xml"
-  children:
-  - RuleR11-1
-  - RuleR11-2
-
-- type: guideEntry
-  id: RuleR11-1
-  name: guide-entry-rules-r11-1
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR11-1AnimalEscalation.xml"
-
-- type: guideEntry
-  id: RuleR11-2
-  name: guide-entry-rules-r11-2
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR11-2ConflictTypes.xml"
-
-- type: guideEntry
-  id: RuleR12
-  name: guide-entry-rules-r12
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR12RoleAbandonment.xml"
-
-- type: guideEntry
-  id: RuleR13
-  name: guide-entry-rules-r13
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR13PerformRole.xml"
-
-- type: guideEntry
-  id: RuleR14
-  name: guide-entry-rules-r14
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR14SecComStandard.xml"
-
-- type: guideEntry
-  id: RuleR15
-  name: guide-entry-rules-r15
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR15SpaceLaw.xml"
-
-- type: guideEntry
-  id: SiliconRules
-  name: guide-entry-rules-silicon
-  ruleEntry: true
-  priority: 10
-  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS0.xml"
-  children:
-  - RuleS1
-  - RuleS2
-  - RuleS3
-  - RuleS4
-  - RuleS5
-  - RuleS6
-  - RuleS7
-  - RuleS8
-  - RuleS9
-  - RuleS10
-
-- type: guideEntry
-  id: RuleS1
-  name: guide-entry-rules-s1
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS1Laws.xml"
-
-- type: guideEntry
-  id: RuleS2
-  name: guide-entry-rules-s2
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS2LawPriority.xml"
-
-- type: guideEntry
-  id: RuleS3
-  name: guide-entry-rules-s3
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS3LawRedefinition.xml"
-
-- type: guideEntry
-  id: RuleS4
-  name: guide-entry-rules-s4
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS4RequestChanges.xml"
-
-- type: guideEntry
-  id: RuleS5
-  name: guide-entry-rules-s5
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS5FreeSilicon.xml"
-
-- type: guideEntry
-  id: RuleS6
-  name: guide-entry-rules-s6
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS6UnreasonableOrders.xml"
-
-- type: guideEntry
-  id: RuleS7
-  name: guide-entry-rules-s7
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS7Consistency.xml"
-
-- type: guideEntry
-  id: RuleS8
-  name: guide-entry-rules-s8
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS8DefaultCrewDefinition.xml"
-
-- type: guideEntry
-  id: RuleS9
-  name: guide-entry-rules-s9
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS9DefaultHarmDefinition.xml"
-
-- type: guideEntry
-  id: RuleS10
-  name: guide-entry-rules-s10
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS10OrderConflicts.xml"
-
-
-- type: guideEntry
-  id: MRPRules
-  name: guide-entry-rules-mrp-m0
-  ruleEntry: true
-  priority: 10
-  text: "/ServerInfo/Guidebook/ServerRules/MRPRules/RuleM0.xml"
-  children:
-  - RuleM1
-
-- type: guideEntry
-  id: RuleM1
-  name: guide-entry-rules-m1
-  ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/MRPRules/RuleM1DoNotPowergame.xml"
-
-# Ban-Related Guide Entries are used as hyperlinks in certain Ruleset Guide Entry explanations.
+  id: SpaceLawCrimeList
+  name: guide-entry-rules-sl-crime-list
+  priority: 5
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml"
 
 - type: guideEntry
   id: BanTypes
   name: guide-entry-rules-ban-types
   ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/BanTypes.xml"
+  priority: 90
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/BanTypes.xml"
 
 - type: guideEntry
   id: BanDurations
   name: guide-entry-rules-ban-durations
   ruleEntry: true
-  text: "/ServerInfo/Guidebook/ServerRules/BanDurations.xml"
+  priority: 100
+  text: "/ServerInfo/_Polonium/Guidebook/ServerRules/BanDurations.xml"

--- a/Resources/Prototypes/Guidebook/science.yml
+++ b/Resources/Prototypes/Guidebook/science.yml
@@ -1,7 +1,18 @@
+# SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 M3739 <47579354+M3739@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 OttoMaticode <124523848+OttoMaticode@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Hannah Giovanna Dawson <karakkaraz@gmail.com>
+# SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: MIT
+
 - type: guideEntry
   id: Science
   name: guide-entry-science
-  text: "/ServerInfo/Guidebook/Science/Science.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Science/Science.xml"
   children:
   - Technologies
   - AnomalousResearch
@@ -11,13 +22,13 @@
 - type: guideEntry
   id: Technologies
   name: guide-entry-technologies
-  text: "/ServerInfo/Guidebook/Science/Technologies.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Science/Technologies.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: AnomalousResearch
   name: guide-entry-anomalous-research
-  text: "/ServerInfo/Guidebook/Science/AnomalousResearch.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Science/AnomalousResearch.xml"
   children:
   - APE
   - ScannersAndVessels
@@ -25,39 +36,38 @@
 - type: guideEntry
   id: ScannersAndVessels
   name: guide-entry-scanners-and-vessels
-  text: "/ServerInfo/Guidebook/Science/ScannersAndVessels.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Science/ScannersAndVessels.xml"
 
 - type: guideEntry
   id: APE
   name: guide-entry-ape
-  text: "/ServerInfo/Guidebook/Science/APE.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Science/APE.xml"
 
 - type: guideEntry
   id: Xenoarchaeology
   name: guide-entry-xenoarchaeology
-  text: "/ServerInfo/Guidebook/Science/Xenoarchaeology.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Science/Xenoarchaeology.xml"
   children:
-    - AnalysisConsole
-    - XenoarchaeologyUnlockingNodes
-
-- type: guideEntry
-  id: XenoarchaeologyUnlockingNodes
-  name: guide-entry-xenoarchaeologyunlockingnodes
-  text: "/ServerInfo/Guidebook/Science/UnlockingNodes.xml"
-
-- type: guideEntry
-  id: AnalysisConsole
-  name: guide-entry-analysisconsole
-  text: "/ServerInfo/Guidebook/Science/AnalysisConsole.xml"
+  - ArtifactReports
 
 - type: guideEntry
   id: Robotics
   name: guide-entry-robotics
-  text: "/ServerInfo/Guidebook/Science/Robotics.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Science/Robotics.xml"
   children:
   - Cyborgs
 
 - type: guideEntry
+  id: ArtifactReports
+  name: guide-entry-artifact-reports
+  text: "/ServerInfo/_Polonium/Guidebook/Science/ArtifactReports.xml"
+
+- type: guideEntry
   id: Cyborgs
   name: guide-entry-cyborgs
-  text: "/ServerInfo/Guidebook/Science/Cyborgs.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Science/Cyborgs.xml"
+
+# - type: guideEntry # Funkystation - Genetics
+#   id: Genetics
+#   name: guide-entry-genetics
+#   text: "/ServerInfo/_Polonium/Guidebook/Science/Genetics.xml"

--- a/Resources/Prototypes/Guidebook/security.yml
+++ b/Resources/Prototypes/Guidebook/security.yml
@@ -1,36 +1,42 @@
+# SPDX-FileCopyrightText: 2023 Chief-Engineer <119664036+Chief-Engineer@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Kara <lunarautomaton6@gmail.com>
+# SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 eclips_e <67359748+Just-a-Unity-Dev@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 faint <46868845+ficcialfaint@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Aidenkrz <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Nikita (Nick) <174215049+nikitosych@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2026 github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
 - type: guideEntry
   id: Security
   name: guide-entry-security
-  text: "/ServerInfo/Guidebook/Security/Security.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Security/Security.xml"
   children:
   - Forensics
   - Defusal
   - CriminalRecords
-  - SpaceLaw
+  - RulesOfConduct # Funkystation
+  - SpaceLaw # Goobstation
 
 - type: guideEntry
   id: Forensics
   name: guide-entry-forensics
-  text: "/ServerInfo/Guidebook/Security/Forensics.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Security/Forensics.xml"
 
 - type: guideEntry
   id: Defusal
   name: guide-entry-defusal
-  text: "/ServerInfo/Guidebook/Security/Defusal.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Security/Defusal.xml"
 
 - type: guideEntry
   id: CriminalRecords
   name: guide-entry-criminal-records
-  text: "/ServerInfo/Guidebook/Security/CriminalRecords.xml"
-
-- type: guideEntry
-  id: SpaceLaw
-  name: guide-entry-rules-space-law
-  text: "/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml"
-  children:
-  - SpaceLawCrimeList
-
-- type: guideEntry
-  id: SpaceLawCrimeList
-  name: guide-entry-rules-sl-crime-list
-  text: "/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Security/CriminalRecords.xml"

--- a/Resources/Prototypes/Guidebook/service.yml
+++ b/Resources/Prototypes/Guidebook/service.yml
@@ -1,31 +1,49 @@
+# SPDX-FileCopyrightText: 2023 AjexRose <112997230+AjexRose@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Hebi <spiritbreakz@gmail.com>
+# SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
+# SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Nails+Tape <124523848+Nails-n-Tape@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Sir Winters <7543955+Owai-Seek@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 end <72604018+laok233@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 faint <46868845+ficcialfaint@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 liltenhead <104418166+liltenhead@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 UBlueberry <161545003+UBlueberry@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 f0x-n3rd <150924715+f0x-n3rd@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
 - type: guideEntry
   id: Service
   name: guide-entry-service
-  text: "/ServerInfo/Guidebook/Service/Service.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/Service.xml"
   filterEnabled: True
   children:
   - Bartender
   - Botany
   - Chef
   - Janitorial
-  
+
 - type: guideEntry
   id: Bartender
   name: guide-entry-bartender
-  text: "/ServerInfo/Guidebook/Service/Bartender.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/Bartender.xml"
   filterEnabled: True
 
 - type: guideEntry
   id: Botany
   name: guide-entry-botany
-  text: "/ServerInfo/Guidebook/Service/Botany.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/Botany.xml"
 
 - type: guideEntry
   id: Chef
   name: guide-entry-chef
-  text: "/ServerInfo/Guidebook/Service/Chef.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/Chef.xml"
 
 - type: guideEntry
   id: Janitorial
   name: guide-entry-janitorial
-  text: "/ServerInfo/Guidebook/Service/Janitorial.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Service/Janitorial.xml"

--- a/Resources/Prototypes/Guidebook/shiftandcrew.yml
+++ b/Resources/Prototypes/Guidebook/shiftandcrew.yml
@@ -1,7 +1,26 @@
+# SPDX-FileCopyrightText: 2023 AjexRose <112997230+AjexRose@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Hebi <spiritbreakz@gmail.com>
+# SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
+# SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Nails+Tape <124523848+Nails-n-Tape@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Sir Winters <7543955+Owai-Seek@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 end <72604018+laok233@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 faint <46868845+ficcialfaint@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 liltenhead <104418166+liltenhead@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 UBlueberry <161545003+UBlueberry@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 f0x-n3rd <150924715+f0x-n3rd@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
 - type: guideEntry
   id: Jobs
   name: guide-entry-jobs
-  text: "/ServerInfo/Guidebook/Jobs.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Jobs.xml"
   children:
   - Service
   - Cargo

--- a/Resources/Prototypes/Guidebook/species.yml
+++ b/Resources/Prototypes/Guidebook/species.yml
@@ -1,59 +1,109 @@
+# SPDX-FileCopyrightText: 2024 Aidenkrz <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2024 BeeRobynn <robynthewarcrime@proton.me>
+# SPDX-FileCopyrightText: 2024 Errant <35878406+Errant-4@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Fishbait <Fishbait@git.ml>
+# SPDX-FileCopyrightText: 2024 John Space <bigdumb421@gmail.com>
+# SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
+# SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 ATDoop <bug@bug.bug>
+# SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Nikita (Nick) <174215049+nikitosych@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
 - type: guideEntry
   id: Species
   name: guide-entry-species
-  text: "/ServerInfo/Guidebook/Mobs/Species.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Mobs/Species.xml"
   children:
-  - Arachnid
-  - Diona
-  - Dwarf
-  - Human
-  - Moth
-  - Reptilian
-  - SlimePerson
-  - Vox
-  - Vulpkanin
+    - Arachnid
+    - Diona
+    - Dwarf
+    - Human
+    - Moth
+    - Reptilian
+    - SlimePerson
+    # Goobstation
+    - Felinid
+    - Gingerbread
+    - Harpy
+    - Vox
+    - Vulpkanin
+    - Rodentia
+    # - IPC
+    # ImpStation additions
+    - Thaven
 
 - type: guideEntry
   id: Arachnid
   name: species-name-arachnid
-  text: "/ServerInfo/Guidebook/Mobs/Arachnid.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Mobs/Arachnid.xml"
 
 - type: guideEntry
   id: Diona
   name: species-name-diona
-  text: "/ServerInfo/Guidebook/Mobs/Diona.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Mobs/Diona.xml"
 
 - type: guideEntry
   id: Dwarf
   name: species-name-dwarf
-  text: "/ServerInfo/Guidebook/Mobs/Dwarf.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Mobs/Dwarf.xml"
 
 - type: guideEntry
   id: Human
   name: species-name-human
-  text: "/ServerInfo/Guidebook/Mobs/Human.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Mobs/Human.xml"
 
 - type: guideEntry
   id: Moth
   name: species-name-moth
-  text: "/ServerInfo/Guidebook/Mobs/Moth.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Mobs/Moth.xml"
 
 - type: guideEntry
   id: Reptilian
   name: species-name-reptilian
-  text: "/ServerInfo/Guidebook/Mobs/Reptilian.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Mobs/Reptilian.xml"
 
 - type: guideEntry
   id: SlimePerson
   name: species-name-slime
-  text: "/ServerInfo/Guidebook/Mobs/SlimePerson.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Mobs/SlimePerson.xml"
+
+# Goobstation
+- type: guideEntry
+  id: Felinid
+  name: species-name-felinid
+  text: "/ServerInfo/_Polonium/Guidebook/Mobs/Felinid.xml"
+
+- type: guideEntry
+  id: Gingerbread
+  name: species-name-gingerbread
+  text: "/ServerInfo/_Polonium/Guidebook/Mobs/Gingerbread.xml"
+
+- type: guideEntry
+  id: Harpy
+  name: species-name-harpy
+  text: "/ServerInfo/_Polonium/Guidebook/Mobs/Harpy.xml"
 
 - type: guideEntry
   id: Vox
   name: species-name-vox
-  text: "/ServerInfo/Guidebook/Mobs/Vox.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Mobs/Vox.xml"
 
 - type: guideEntry
   id: Vulpkanin
   name: species-name-vulpkanin
-  text: "/ServerInfo/Guidebook/Mobs/Vulpkanin.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Mobs/Vulpkanin.xml"
+
+- type: guideEntry
+  id: Rodentia
+  name: species-name-rodentia
+  text: "/ServerInfo/_Polonium/Guidebook/Mobs/DeltaV/Rodentia.xml"
+
+#- type: guideEntry
+#  id: IPC
+#  name: species-name-ipc
+#  text: "/ServerInfo/Guidebook/Mobs/IPCs.xml"

--- a/Resources/Prototypes/Guidebook/station.yml
+++ b/Resources/Prototypes/Guidebook/station.yml
@@ -1,8 +1,27 @@
+# SPDX-FileCopyrightText: 2023 /ʊniɹɑː/ <onoira@psiko.zone>
+# SPDX-FileCopyrightText: 2023 2013HORSEMEATSCANDAL <146540817+2013HORSEMEATSCANDAL@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Nails+Tape <124523848+Nails-n-Tape@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 dribblydrone <119393097+dribblydrone@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 end <72604018+laok233@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Aidenkrz <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2024 Chief-Engineer <119664036+Chief-Engineer@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Errant <35878406+Errant-4@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 UBlueberry <161545003+UBlueberry@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
 - type: guideEntry
   id: SS14
   name: guide-entry-ss14
   priority: 20
-  text: "/ServerInfo/Guidebook/SpaceStation14.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/SpaceStation14.xml"
   children:
   - Jobs
   - Survival
@@ -12,9 +31,9 @@
 - type: guideEntry
   id: Glossary
   name: guide-entry-glossary
-  text: "/ServerInfo/Guidebook/Glossary.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Glossary.xml"
 
 - type: guideEntry
   id: Survival
   name: guide-entry-survival
-  text: "/ServerInfo/Guidebook/Survival.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Survival.xml"

--- a/Resources/Prototypes/_DV/CosmicCult/Guidebook/antagonist.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Guidebook/antagonist.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 Nikita (Nick) <174215049+nikitosych@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+- type: guideEntry
+  id: CosmicCult
+  name: guide-entry-cosmiccult
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/CosmicCult.xml"
+  children:
+  - CosmicCultMonument
+  - CosmicCultMalignRifts
+  - CosmicCultInfluences
+  - CosmicCultDeconversion
+  - CosmicColossus
+
+- type: guideEntry
+  id: CosmicCultMonument
+  name: guide-entry-cosmiccult-monument
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/CosmicCultMonument.xml"
+
+- type: guideEntry
+  id: CosmicCultMalignRifts
+  name: guide-entry-cosmiccult-rifts
+  text: "/ServerInfo/_DV/Guidebook/Antagonist/CosmicCultMalignRifts.xml"
+
+- type: guideEntry
+  id: CosmicCultInfluences
+  name: guide-entry-cosmiccult-influences
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/CosmicCultInfluences.xml"
+
+- type: guideEntry
+  id: CosmicCultDeconversion
+  name: guide-entry-cosmiccult-deconversion
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/CosmicCultDeconversion.xml"
+
+- type: guideEntry
+  id: CosmicColossus
+  name: guide-entry-cosmiccolossus
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/CosmicColossus.xml"

--- a/Resources/Prototypes/_FarHorizons/Guidebook/engineering.yml
+++ b/Resources/Prototypes/_FarHorizons/Guidebook/engineering.yml
@@ -1,11 +1,17 @@
+# SPDX-FileCopyrightText: 2025 Nikita (Nick) <174215049+nikitosych@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: guideEntry
   id: NuclearReactor
   name: guide-entry-nuclear-reactor
-  text: "/ServerInfo/_FarHorizons/Guidebook/Engineering/NuclearReactor.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/NuclearReactor.xml"
   children:
   - NuclearMaterials
 
 - type: guideEntry
   id: NuclearMaterials
   name: guide-entry-nuclear-materials
-  text: "/ServerInfo/_FarHorizons/Guidebook/Engineering/NuclearMaterials.xml"
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/NuclearMaterials.xml"

--- a/Resources/Prototypes/_Funkystation/Guidebook/antagonist.yml
+++ b/Resources/Prototypes/_Funkystation/Guidebook/antagonist.yml
@@ -1,4 +1,5 @@
-# SPDX-FileCopyrightText: 2024 UBlueberry <161545003+UBlueberry@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Skye <57879983+Rainbeon@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 kbarkevich <24629810+kbarkevich@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
 # SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
@@ -6,6 +7,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
 - type: guideEntry
-  id: Command
-  name: guide-entry-command
-  text: "/ServerInfo/_Polonium/Guidebook/Command.xml"
+  id: BloodCult
+  name: guide-entry-blood-cult
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/BloodCult.xml"

--- a/Resources/Prototypes/_Funkystation/Guidebook/corporate-secrets.yml
+++ b/Resources/Prototypes/_Funkystation/Guidebook/corporate-secrets.yml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: guideEntry
+  id: SecurityTrainingManual
+  name: guide-entry-training-manual-security
+  text: "/ServerInfo/_Polonium/Guidebook/Security/SecurityTrainingManual.xml"
+
+- type: guideEntry
+  id: CommandTrainingManual
+  name: guide-entry-training-manual-command
+  text: "/ServerInfo/_Polonium/Guidebook/Command/CommandTrainingManual.xml"

--- a/Resources/Prototypes/_Funkystation/Guidebook/sop-old.txt
+++ b/Resources/Prototypes/_Funkystation/Guidebook/sop-old.txt
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2024 DevilishMilk <bluscout78@yahoo.com>
+# SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 CMM <funkycmm>
+# SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 ferynn <witchy.girl.me@gmail.com>
+# SPDX-FileCopyrightText: 2025 kbarkevich <24629810+kbarkevich@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+- type: guideEntry
+  id: SOP101
+  name: SOP 101
+  text: "/ServerInfo/Funkystation/Guidebook/SOP/SOP101.xml"
+  children:
+  - CommandSOP
+  - SecuritySOP
+  - LegalSOP
+  - MedicalSOP
+  - ServiceSOP
+  - EngineeringSOP
+  - CargoSOP
+  - ScienceSOP
+  - AlertLevelsSOP
+
+- type: guideEntry
+  id: CommandSOP
+  name: guide-entry-command-sop
+  text: "/ServerInfo/Funkystation/Guidebook/Command/CommandStandardOperatingProcedure.xml"
+  children:
+  - CommandTrainingManual
+  - OrderOfSuccession
+
+- type: guideEntry
+  id: OrderOfSuccession
+  name: guide-entry-order-of-succession
+  text: "/ServerInfo/Funkystation/Guidebook/Command/OrderOfSuccession.xml"
+
+- type: guideEntry
+  id: AlertLevelsSOP
+  name: guide-entry-alert-sop
+  text: "/ServerInfo/Funkystation/Guidebook/Command/AlertLevels.xml"
+  children:
+  - GreenAlertSOP
+  - YellowAlertSOP
+  - BlueAlertSOP
+  - RedAlertSOP
+  - VioletAlertSOP
+  - GammaAlertSOP
+  - DeltaAlertSOP
+  - OctarineAlertSOP
+
+- type: guideEntry
+  id: SecuritySOP
+  name: guide-entry-security-sop
+  text: "/ServerInfo/Funkystation/Guidebook/Security/SecurityStandardOperatingProcedure.xml"
+  children:
+  - SecurityTrainingManual
+
+- type: guideEntry
+  id: LegalSOP
+  name: guide-entry-legal-sop
+  text: "/ServerInfo/Funkystation/Guidebook/Legal/LegalSOP.xml"
+
+- type: guideEntry
+  id: EngineeringSOP
+  name: guide-entry-engineering-sop
+  text: "/ServerInfo/Funkystation/Guidebook/Engineering/EngineeringSOP.xml"
+
+- type: guideEntry
+  id: CargoSOP
+  name: guide-entry-cargo-sop
+  text: "/ServerInfo/Funkystation/Guidebook/Cargo/CargoSOP.xml"
+
+- type: guideEntry
+  id: MedicalSOP
+  name: guide-entry-medical-sop
+  text: "/ServerInfo/Funkystation/Guidebook/Medical/MedicalStandardOperatingProcedure.xml"
+
+- type: guideEntry
+  id: ServiceSOP
+  name: guide-entry-service-sop
+  text: "/ServerInfo/Funkystation/Guidebook/Service/ServiceStandardOperatingProcedure.xml"
+
+- type: guideEntry
+  id: ScienceSOP
+  name: guide-entry-science-sop
+  text: "/ServerInfo/Funkystation/Guidebook/Science/ScienceStandardOperatingProcedure.xml"
+
+- type: guideEntry
+  id: GreenAlertSOP
+  name: guide-entry-alertlevel-green
+  priority: 10
+  text: "/ServerInfo/Funkystation/Guidebook/AlertLevel/GreenAlert.xml"
+
+- type: guideEntry
+  id: YellowAlertSOP
+  name: guide-entry-alertlevel-yellow
+  priority: 20
+  text: "/ServerInfo/Funkystation/Guidebook/AlertLevel/YellowAlert.xml"
+
+- type: guideEntry
+  id: BlueAlertSOP
+  name: guide-entry-alertlevel-blue
+  priority: 30
+  text: "/ServerInfo/Funkystation/Guidebook/AlertLevel/BlueAlert.xml"
+
+- type: guideEntry
+  id: RedAlertSOP
+  name: guide-entry-alertlevel-red
+  priority: 40
+  text: "/ServerInfo/Funkystation/Guidebook/AlertLevel/RedAlert.xml"
+
+- type: guideEntry
+  id: VioletAlertSOP
+  name: guide-entry-alertlevel-violet
+  priority: 50
+  text: "/ServerInfo/Funkystation/Guidebook/AlertLevel/VioletAlert.xml"
+
+- type: guideEntry
+  id: GammaAlertSOP
+  name: guide-entry-alertlevel-gamma
+  priority: 60
+  text: "/ServerInfo/Funkystation/Guidebook/AlertLevel/GammaAlert.xml"
+
+- type: guideEntry
+  id: DeltaAlertSOP
+  name: guide-entry-alertlevel-delta
+  priority: 70
+  text: "/ServerInfo/Funkystation/Guidebook/AlertLevel/DeltaAlert.xml"
+
+# impstation cosmic cult
+- type: guideEntry
+  id: OctarineAlertSOP
+  name: alert-level-octarine
+  priority: 70
+  text: "/ServerInfo/Funkystation/Guidebook/AlertLevel/OctarineAlert.xml"

--- a/Resources/Prototypes/_Funkystation/Guidebook/sop.yml
+++ b/Resources/Prototypes/_Funkystation/Guidebook/sop.yml
@@ -1,0 +1,367 @@
+# SPDX-FileCopyrightText: 2024 DevilishMilk <bluscout78@yahoo.com>
+# SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 CMM <funkycmm>
+# SPDX-FileCopyrightText: 2025 Colin Moore <funkycmm>
+# SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 YaraaraY <158123176+YaraaraY@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 ferynn <117872973+ferynn@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 ferynn <witchy.girl.me@gmail.com>
+# SPDX-FileCopyrightText: 2025 funkycmm <cmmaccounts@protonmail.com>
+# SPDX-FileCopyrightText: 2025 kbarkevich <24629810+kbarkevich@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Nikita (Nick) <174215049+nikitosych@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+- type: guideEntry
+  id: SOP101
+  name: SOP 101
+  text: "/ServerInfo/_Polonium/Guidebook/SOP/SOP101.xml"
+  children:
+  - CommandSOP
+  - CentralCommandSOP
+  - LegalSOP
+  - ServiceSOP
+  - SecuritySOP
+  - ScienceSOP
+  - MedicalSOP
+  - EngineeringSOP
+  - CargoSOP
+  - AlertLevelsSOP
+
+- type: guideEntry
+  id: LegalSOP
+  name: guide-entry-legal-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Legal/LegalSOP.xml"
+
+# ALERT LEVELS
+
+- type: guideEntry
+  id: AlertLevelsSOP
+  name: guide-entry-alert-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Command/AlertLevels.xml"
+  children:
+  - GreenAlertSOP
+  - YellowAlertSOP
+  - BlueAlertSOP
+  - RedAlertSOP
+  - VioletAlertSOP
+  - GammaAlertSOP
+  - DeltaAlertSOP
+  - OctarineAlertSOP
+
+- type: guideEntry
+  id: GreenAlertSOP
+  name: guide-entry-alertlevel-green
+  priority: 10
+  text: "/ServerInfo/_Polonium/Guidebook/AlertLevel/GreenAlert.xml"
+
+- type: guideEntry
+  id: YellowAlertSOP
+  name: guide-entry-alertlevel-yellow
+  priority: 20
+  text: "/ServerInfo/_Polonium/Guidebook/AlertLevel/YellowAlert.xml"
+
+- type: guideEntry
+  id: BlueAlertSOP
+  name: guide-entry-alertlevel-blue
+  priority: 30
+  text: "/ServerInfo/_Polonium/Guidebook/AlertLevel/BlueAlert.xml"
+
+- type: guideEntry
+  id: RedAlertSOP
+  name: guide-entry-alertlevel-red
+  priority: 40
+  text: "/ServerInfo/_Polonium/Guidebook/AlertLevel/RedAlert.xml"
+
+- type: guideEntry
+  id: VioletAlertSOP
+  name: guide-entry-alertlevel-violet
+  priority: 50
+  text: "/ServerInfo/_Polonium/Guidebook/AlertLevel/VioletAlert.xml"
+
+- type: guideEntry
+  id: GammaAlertSOP
+  name: guide-entry-alertlevel-gamma
+  priority: 60
+  text: "/ServerInfo/_Polonium/Guidebook/AlertLevel/GammaAlert.xml"
+
+- type: guideEntry
+  id: DeltaAlertSOP
+  name: guide-entry-alertlevel-delta
+  priority: 70
+  text: "/ServerInfo/_Polonium/Guidebook/AlertLevel/DeltaAlert.xml"
+
+# impstation cosmic cult
+- type: guideEntry
+  id: OctarineAlertSOP
+  name: alert-level-octarine
+  priority: 70
+  text: "/ServerInfo/_Polonium/Guidebook/AlertLevel/OctarineAlert.xml"
+
+# COMMAND
+
+- type: guideEntry
+  id: CommandSOP
+  name: guide-entry-command-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Command/GeneralCommandSOP.xml"
+  children:
+  - CommandTrainingManual
+  - OrderOfSuccession
+  - CaptainSOP
+  - RedPhoneSOP
+
+- type: guideEntry
+  id: CaptainSOP
+  name: guide-entry-captain-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Command/CaptainSOP.xml"
+
+- type: guideEntry
+  id: RedPhoneSOP
+  name: guide-entry-red-phone-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Command/RedPhone.xml"
+
+- type: guideEntry
+  id: OrderOfSuccession
+  name: guide-entry-order-of-succession
+  text: "/ServerInfo/_Polonium/Guidebook/Command/OrderOfSuccession.xml"
+
+# CC
+
+- type: guideEntry
+  id: CentralCommandSOP
+  name: guide-entry-central-command-sop
+  text: "/ServerInfo/_Polonium/Guidebook/CentralCommand/CCSOP.xml"
+  children:
+  - IAASOP
+  - NTRSOP
+  - MagistrateSOP
+
+- type: guideEntry
+  id: IAASOP
+  name: guide-entry-iaa-sop
+  text: "/ServerInfo/_Polonium/Guidebook/CentralCommand/IAASOP.xml"
+
+- type: guideEntry
+  id: NTRSOP
+  name: guide-entry-ntr-sop
+  text: "/ServerInfo/_Polonium/Guidebook/CentralCommand/NTRSOP.xml"
+
+- type: guideEntry
+  id: MagistrateSOP
+  name: guide-entry-magistrate-sop
+  text: "/ServerInfo/_Polonium/Guidebook/CentralCommand/MagistrateSOP.xml"
+
+# SERVICE
+
+- type: guideEntry
+  id: ServiceSOP
+  name: guide-entry-service-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Service/ServiceSOP.xml"
+  children:
+  - HoPSOP
+  - BartenderSOP
+  - BotanistSOP
+  - ChaplainSOP
+  - ChefSOP
+  - ClownSOP
+  - JanitorSOP
+  - MimeSOP
+  - ReporterSOP
+
+- type: guideEntry
+  id: HoPSOP
+  name: guide-entry-hop-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Service/HoPSOP.xml"
+
+- type: guideEntry
+  id: BartenderSOP
+  name: guide-entry-bartender-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Service/BartenderSOP.xml"
+
+- type: guideEntry
+  id: BotanistSOP
+  name: guide-entry-botanist-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Service/BotanistSOP.xml"
+
+- type: guideEntry
+  id: ChaplainSOP
+  name: guide-entry-chaplain-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Service/ChaplainSOP.xml"
+
+- type: guideEntry
+  id: ChefSOP
+  name: guide-entry-chef-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Service/ChefSOP.xml"
+
+- type: guideEntry
+  id: ClownSOP
+  name: guide-entry-clown-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Service/ClownSOP.xml"
+
+- type: guideEntry
+  id: JanitorSOP
+  name: guide-entry-janitor-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Service/JanitorSOP.xml"
+
+- type: guideEntry
+  id: MimeSOP
+  name: guide-entry-mime-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Service/MimeSOP.xml"
+
+- type: guideEntry
+  id: ReporterSOP
+  name: guide-entry-reporter-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Service/ReporterSOP.xml"
+
+# SEC
+
+- type: guideEntry
+  id: SecuritySOP
+  name: guide-entry-security-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Security/SecuritySOP.xml"
+  children:
+  - UseOfForceSOP
+  - HoSSOP
+  - SecurityOfficerSOP
+  - WardenSOP
+  - DetectiveSOP
+  - SecurityTrainingManual
+
+- type: guideEntry
+  id: UseOfForceSOP
+  name: guide-entry-use-of-force-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Security/UseOfForceSOP.xml"
+
+- type: guideEntry
+  id: HoSSOP
+  name: guide-entry-hos-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Security/HoSSOP.xml"
+
+- type: guideEntry
+  id: SecurityOfficerSOP
+  name: guide-entry-securityofficer-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Security/SecurityOfficerSOP.xml"
+
+- type: guideEntry
+  id: WardenSOP
+  name: guide-entry-warden-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Security/WardenSOP.xml"
+
+- type: guideEntry
+  id: DetectiveSOP
+  name: guide-entry-detective-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Security/DetectiveSOP.xml"
+
+# SCI
+
+- type: guideEntry
+  id: ScienceSOP
+  name: guide-entry-science-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Science/ScienceSOP.xml"
+  children:
+  - RDSOP
+  - ScientistSOP
+  - RoboticistSOP
+
+- type: guideEntry
+  id: RDSOP
+  name: guide-entry-rd-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Science/RDSOP.xml"
+
+- type: guideEntry
+  id: ScientistSOP
+  name: guide-entry-scientist-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Science/ScientistSOP.xml"
+
+- type: guideEntry
+  id: RoboticistSOP
+  name: guide-entry-roboticist-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Science/RoboticistSOP.xml"
+
+# MED
+
+- type: guideEntry
+  id: MedicalSOP
+  name: guide-entry-medical-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/MedicalSOP.xml"
+  children:
+  - CMOSOP
+  - DoctorSOP
+  - ChemistSOP
+  - ParamedicSOP
+  - PsychologistSOP
+
+- type: guideEntry
+  id: CMOSOP
+  name: guide-entry-cmo-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/CMOSOP.xml"
+
+- type: guideEntry
+  id: DoctorSOP
+  name: guide-entry-doctor-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/DoctorSOP.xml"
+
+- type: guideEntry
+  id: ChemistSOP
+  name: guide-entry-chemist-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/ChemistSOP.xml"
+
+- type: guideEntry
+  id: ParamedicSOP
+  name: guide-entry-paramedic-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/ParamedicSOP.xml"
+
+- type: guideEntry
+  id: PsychologistSOP
+  name: guide-entry-psychologist-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/PsychologistSOP.xml"
+
+# ENGI
+
+- type: guideEntry
+  id: EngineeringSOP
+  name: guide-entry-engineering-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/EngineeringSOP.xml"
+  children:
+  - CESOP
+  - StationEngineerSOP
+
+- type: guideEntry
+  id: CESOP
+  name: guide-entry-ce-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/CESOP.xml"
+
+- type: guideEntry
+  id: StationEngineerSOP
+  name: guide-entry-stationengineer-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/StationEngineerSOP.xml"
+
+# CARGO
+
+- type: guideEntry
+  id: CargoSOP
+  name: guide-entry-cargo-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Cargo/CargoSOP.xml"
+  children:
+  - QMSOP
+  - CargoTechnicianSOP
+  - SalvageSOP
+
+- type: guideEntry
+  id: QMSOP
+  name: guide-entry-qm-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Cargo/QMSOP.xml"
+
+- type: guideEntry
+  id: CargoTechnicianSOP
+  name: guide-entry-cargotechnician-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Cargo/CargoTechnicianSOP.xml"
+
+- type: guideEntry
+  id: SalvageSOP
+  name: guide-entry-salvage-sop
+  text: "/ServerInfo/_Polonium/Guidebook/Cargo/SalvageSOP.xml"

--- a/Resources/Prototypes/_Goobstation/Changeling/Entities/Guidebook/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Entities/Guidebook/changeling.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2024 Aidenkrz <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
+# SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2024 username <113782077+whateverusername0@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+- type: entity
+  id: GuidebookChangelingFluff
+  name: guidebook changeling
+  description: you shouldn't be seeing this normally.
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: Sprite
+      sprite: _Goobstation/Changeling/Guidebook/guidebook_changeling.rsi
+      state: icon

--- a/Resources/Prototypes/_Goobstation/Changeling/Guidebook/antagonist.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Guidebook/antagonist.yml
@@ -1,4 +1,5 @@
-# SPDX-FileCopyrightText: 2024 UBlueberry <161545003+UBlueberry@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
+# SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
 # SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
@@ -6,6 +7,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
 - type: guideEntry
-  id: Command
-  name: guide-entry-command
-  text: "/ServerInfo/_Polonium/Guidebook/Command.xml"
+  id: Changelings
+  name: guide-entry-changelings
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/Changelings.xml"

--- a/Resources/Prototypes/_Goobstation/Guidebook/blob.yml
+++ b/Resources/Prototypes/_Goobstation/Guidebook/blob.yml
@@ -1,4 +1,5 @@
-# SPDX-FileCopyrightText: 2024 UBlueberry <161545003+UBlueberry@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 John Space <bigdumb421@gmail.com>
+# SPDX-FileCopyrightText: 2024 fishbait <gnesse@gmail.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
 # SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
@@ -6,6 +7,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
 - type: guideEntry
-  id: Command
-  name: guide-entry-command
-  text: "/ServerInfo/_Polonium/Guidebook/Command.xml"
+  id: Blob
+  name: guide-entry-blob
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/Blob.xml"

--- a/Resources/Prototypes/_Goobstation/Guidebook/engineering.yml
+++ b/Resources/Prototypes/_Goobstation/Guidebook/engineering.yml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
+# SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 VMSolidus <evilexecutive@gmail.com>
+# SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+- type: guideEntry
+  id: Supermatter
+  name: guide-entry-sm
+  text: "/ServerInfo/_Polonium/Guidebook/Engineering/Supermatter.xml"

--- a/Resources/Prototypes/_Goobstation/Guidebook/patches.yml
+++ b/Resources/Prototypes/_Goobstation/Guidebook/patches.yml
@@ -1,4 +1,5 @@
-# SPDX-FileCopyrightText: 2024 UBlueberry <161545003+UBlueberry@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
+# SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
 # SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
@@ -6,6 +7,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
 - type: guideEntry
-  id: Command
-  name: guide-entry-command
-  text: "/ServerInfo/_Polonium/Guidebook/Command.xml"
+  id: Medicalpatches
+  name: guide-entry-medpatches
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/Medicalpatches.xml"

--- a/Resources/Prototypes/_Goobstation/Heretic/Guidebook/antagonist.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Guidebook/antagonist.yml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
+# SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 Amethyst <52829582+jackel234@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 V <97265903+formlessnameless@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+- type: guideEntry
+  id: Heretics
+  name: guide-entry-heretics
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/Heretics.xml" # given a consistency pass by dark, keeping in imp directory 4 now
+  children:
+  - HereticsKnowledge
+  - HereticsSpells
+  - HereticsRituals
+  - HereticsPaths
+  - HereticsSide
+
+- type: guideEntry
+  id: HereticsPaths
+  name: guide-entry-heretics-paths
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/HereticsPaths.xml"
+  children:
+    - HereticsAsh
+    - HereticsFlesh
+    - HereticsVoid
+
+- type: guideEntry
+  id: HereticsKnowledge
+  name: guide-entry-heretics-knowledge
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/HereticsKnowledge.xml"
+
+- type: guideEntry
+  id: HereticsSpells
+  name: guide-entry-heretics-spells
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/HereticsSpells.xml"
+
+- type: guideEntry
+  id: HereticsRituals
+  name: guide-entry-heretics-rituals
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/HereticsRituals.xml"
+
+- type: guideEntry
+  id: HereticsAsh
+  name: guide-entry-heretics-ash
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/HereticsAsh.xml"
+
+- type: guideEntry
+  id: HereticsFlesh
+  name: guide-entry-heretics-flesh
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/HereticsFlesh.xml"
+
+- type: guideEntry
+  id: HereticsVoid
+  name: guide-entry-heretics-void
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/HereticsVoid.xml"
+
+- type: guideEntry
+  id: HereticsSide
+  name: guide-entry-heretics-side
+  text: "/ServerInfo/_Polonium/Guidebook/Antagonist/HereticsSide.xml"

--- a/Resources/Prototypes/_Impstation/Guidebook/species.yml
+++ b/Resources/Prototypes/_Impstation/Guidebook/species.yml
@@ -1,4 +1,5 @@
-# SPDX-FileCopyrightText: 2024 UBlueberry <161545003+UBlueberry@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 ATDoop <bug@bug.bug>
+# SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
 # SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
@@ -6,6 +7,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
 - type: guideEntry
-  id: Command
-  name: guide-entry-command
-  text: "/ServerInfo/_Polonium/Guidebook/Command.xml"
+  id: Thaven
+  name: Thaven
+  text: "/ServerInfo/_Polonium/Guidebook/Mobs/Thaven.xml"

--- a/Resources/Prototypes/_Shitmed/Guidebook/medical.yml
+++ b/Resources/Prototypes/_Shitmed/Guidebook/medical.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Polonium-bot <admin@ss14.pl>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+
+- type: guideEntry
+  id: Surgery
+  name: guide-entry-surgery
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/Surgery.xml"
+  children:
+  - PartManipulation
+  - OrganManipulation
+  - UtilitySurgeries
+  - Autodoc
+
+- type: guideEntry
+  id: PartManipulation
+  name: guide-entry-partmanipulation
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/PartManipulation.xml"
+  filterEnabled: true
+
+- type: guideEntry
+  id: OrganManipulation
+  name: guide-entry-organmanipulation
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/OrganManipulation.xml"
+  filterEnabled: true
+
+- type: guideEntry
+  id: UtilitySurgeries
+  name: guide-entry-utilitysurgeries
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/UtilitySurgeries.xml"
+  filterEnabled: true
+
+- type: guideEntry
+  id: Autodoc
+  name: guide-entry-autodoc
+  text: "/ServerInfo/_Polonium/Guidebook/Medical/Autodoc.xml"


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Dla #694

Podłączono wszystkie wpisy z podręcznika w prototypach do gry. Zastąpiono w całym drzewie wiznenowskie wpisy naszymi. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Zaktualizowano i rozszerzono guidebook dla wielu działów, m.in. nauki, medycyny, inżynierii, bezpieczeństwa, cargo, usług i postaci.
  * Dodano nowe sekcje oraz wpisy dla dodatkowych tematów, w tym antagonistów, procedur SOP i kilku nowych kategorii poradników.

* **Bug Fixes**
  * Poprawiono odwołania do treści guidebooka, dzięki czemu sekcje powinny otwierać się z właściwych miejsc.
  * Uporządkowano strukturę niektórych kategorii i usunięto przestarzałe wpisy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->