### PR TITLE
[Forky] Port zmian do DiscordManager oraz BanManager (+UI) (2)

### DIFF
--- a/Content.Client/Administration/UI/BanPanel/BanPanel.xaml
+++ b/Content.Client/Administration/UI/BanPanel/BanPanel.xaml
@@ -35,6 +35,11 @@
                     <Label Text="{Loc ban-panel-severity}" />
                     <OptionButton Name="SeverityOption" />
                 </BoxContainer>
+                <BoxContainer Orientation="Horizontal" Margin="4">
+                    <Label Text="{Loc ban-panel-situation-round}"/>
+                    <SpinBox Name="RoundSpinBox" MinWidth="150"/>
+                    <Button Name="ResetRoundButton" Text="{Loc admin-logs-reset}" HorizontalAlignment="Right"/>
+                </BoxContainer>
                 <cc:HSeparator Margin="1"/>
                 <TextEdit Name="ReasonTextEdit" MinHeight="100" VerticalExpand="True" HorizontalExpand="True" />
             </BoxContainer>

--- a/Content.Client/Administration/UI/BanPanel/BanPanel.xaml.cs
+++ b/Content.Client/Administration/UI/BanPanel/BanPanel.xaml.cs
@@ -542,6 +542,7 @@ public sealed partial class BanPanel : DefaultWindow
         CurrentRound = round;
         ResetRoundButton.Text = Loc.GetString("admin-logs-reset-with-id", ("id", round));
         UpdateResetButton();
+        UpdateSubmitEnabled();
     }
 
     public void SetRoundSpinBox(int round)

--- a/Content.Client/Administration/UI/BanPanel/BanPanel.xaml.cs
+++ b/Content.Client/Administration/UI/BanPanel/BanPanel.xaml.cs
@@ -33,6 +33,7 @@ public sealed partial class BanPanel : DefaultWindow
     private uint Multiplier { get; set; }
     private bool HasBanFlag { get; set; }
     private TimeSpan? ButtonResetOn { get; set; }
+    private int CurrentRound { get; set; }
 
     // This is less efficient than just holding a reference to the root control and enumerating children, but you
     // have to know how the controls are nested, which makes the code more complicated.
@@ -118,6 +119,11 @@ public sealed partial class BanPanel : DefaultWindow
             OnHwidChanged();
         };
         SubmitButton.OnPressed += SubmitButtonOnOnPressed;
+
+        RoundSpinBox.IsValid = i => i >= 0 && i <= CurrentRound;
+        RoundSpinBox.ValueChanged += RoundSpinBoxChanged;
+        RoundSpinBox.InitDefaultButtons();
+        ResetRoundButton.OnPressed += ResetRoundPressed;
 
         IpCheckbox.Pressed = _cfg.GetCVar(CCVars.ServerBanIpBanDefault);
         HwidCheckbox.Pressed = _cfg.GetCVar(CCVars.ServerBanHwidBanDefault);
@@ -526,7 +532,38 @@ public sealed partial class BanPanel : DefaultWindow
 
     private void UpdateSubmitEnabled()
     {
-        SubmitButton.Disabled = ErrorLevel != ErrorLevelEnum.None;
+        SubmitButton.Disabled = ErrorLevel != ErrorLevelEnum.None
+            || RoundSpinBox.IsValid == null
+            || !RoundSpinBox.IsValid(RoundSpinBox.Value);
+    }
+
+    public void SetCurrentRound(int round)
+    {
+        CurrentRound = round;
+        ResetRoundButton.Text = Loc.GetString("admin-logs-reset-with-id", ("id", round));
+        UpdateResetButton();
+    }
+
+    public void SetRoundSpinBox(int round)
+    {
+        RoundSpinBox.Value = round;
+        UpdateResetButton();
+    }
+
+    private void RoundSpinBoxChanged(ValueChangedEventArgs _)
+    {
+        UpdateResetButton();
+        UpdateSubmitEnabled();
+    }
+
+    private void UpdateResetButton()
+    {
+        ResetRoundButton.Disabled = RoundSpinBox.Value == CurrentRound;
+    }
+
+    private void ResetRoundPressed(BaseButton.ButtonEventArgs _)
+    {
+        RoundSpinBox.Value = CurrentRound;
     }
 
     private void OnPlayerNameChanged()
@@ -633,6 +670,9 @@ public sealed partial class BanPanel : DefaultWindow
         var useLastHwid = HwidCheckbox.Pressed && LastConnCheckbox.Pressed && Hwid is null;
         var severity = (NoteSeverity) SeverityOption.SelectedId;
         var erase = EraseCheckbox.Pressed;
+        var situationRound = RoundSpinBox.IsValid != null && RoundSpinBox.IsValid(RoundSpinBox.Value)
+            ? RoundSpinBox.Value
+            : 0;
 
         var ban = new Ban(
             player,
@@ -645,7 +685,8 @@ public sealed partial class BanPanel : DefaultWindow
             severity,
             jobs,
             antags,
-            erase
+            erase,
+            situationRound
         );
 
         BanSubmitted?.Invoke(ban);

--- a/Content.Client/Administration/UI/BanPanel/BanPanelEui.cs
+++ b/Content.Client/Administration/UI/BanPanel/BanPanelEui.cs
@@ -9,6 +9,7 @@ namespace Content.Client.Administration.UI.BanPanel;
 public sealed class BanPanelEui : BaseEui
 {
     private BanPanel BanPanel { get; }
+    private bool FirstState { get; set; } = true;
 
     public BanPanelEui()
     {
@@ -27,6 +28,13 @@ public sealed class BanPanelEui : BaseEui
 
         BanPanel.UpdateBanFlag(s.HasBan);
         BanPanel.UpdatePlayerData(s.PlayerName);
+        BanPanel.SetCurrentRound(s.RoundId);
+
+        if (!FirstState)
+            return;
+
+        FirstState = false;
+        BanPanel.SetRoundSpinBox(s.RoundId);
     }
 
     public override void Opened()

--- a/Content.Server/Administration/BanPanelEui.cs
+++ b/Content.Server/Administration/BanPanelEui.cs
@@ -4,6 +4,7 @@ using Content.Server.Administration.Managers;
 using Content.Server.Administration.Systems;
 using Content.Server.Chat.Managers;
 using Content.Server.EUI;
+using Content.Server.GameTicking;
 using Content.Shared.Administration;
 using Content.Shared.Database;
 using Content.Shared.Eui;
@@ -19,8 +20,10 @@ public sealed class BanPanelEui : BaseEui
     [Dependency] private readonly IPlayerLocator _playerLocator = default!;
     [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly IAdminManager _admins = default!;
+    [Dependency] private readonly IEntitySystemManager _sysMan = default!;
 
     private readonly ISawmill _sawmill;
+    private GameTicker? _ticker;
 
     private NetUserId? PlayerId { get; set; }
     private string PlayerName { get; set; } = string.Empty;
@@ -34,12 +37,13 @@ public sealed class BanPanelEui : BaseEui
         IoCManager.InjectDependencies(this);
 
         _sawmill = _log.GetSawmill("admin.bans_eui");
+        _sysMan.TryGetEntitySystem(out _ticker);
     }
 
     public override EuiStateBase GetNewState()
     {
         var hasBan = _admins.HasAdminFlag(Player, AdminFlags.Ban);
-        return new BanPanelEuiState(PlayerName, hasBan);
+        return new BanPanelEuiState(PlayerName, hasBan, _ticker?.RoundId ?? 0);
     }
 
     public override void HandleMessage(EuiMessageBase msg)
@@ -81,6 +85,9 @@ public sealed class BanPanelEui : BaseEui
         banInfo.WithSeverity(ban.Severity);
         if (ban.BanDurationMinutes > 0)
             banInfo.WithMinutes(ban.BanDurationMinutes);
+
+        if (ban.SituationRound > 0)
+            banInfo.WithSituationRound(ban.SituationRound);
 
         (IPAddress, int)? addressRange = null;
         if (ban.IpAddress is not null)

--- a/Content.Server/Administration/BanPanelEui.cs
+++ b/Content.Server/Administration/BanPanelEui.cs
@@ -86,7 +86,8 @@ public sealed class BanPanelEui : BaseEui
         if (ban.BanDurationMinutes > 0)
             banInfo.WithMinutes(ban.BanDurationMinutes);
 
-        if (ban.SituationRound > 0)
+        var currentRound = _ticker?.RoundId ?? 0;
+        if (ban.SituationRound > 0 && ban.SituationRound <= currentRound)
             banInfo.WithSituationRound(ban.SituationRound);
 
         (IPAddress, int)? addressRange = null;

--- a/Content.Server/Administration/Commands/DepartmentBanCommand.cs
+++ b/Content.Server/Administration/Commands/DepartmentBanCommand.cs
@@ -30,6 +30,7 @@ public sealed class DepartmentBanCommand : IConsoleCommand
         string department;
         string reason;
         uint minutes;
+        int round = 0;
         if (!Enum.TryParse(_cfg.GetCVar(CCVars.DepartmentBanDefaultSeverity), out NoteSeverity severity))
         {
             _sawmill ??= _log.GetSawmill("admin.department_ban");
@@ -75,6 +76,30 @@ public sealed class DepartmentBanCommand : IConsoleCommand
                 }
 
                 break;
+            case 6:
+                target = args[0];
+                department = args[1];
+                reason = args[2];
+
+                if (!uint.TryParse(args[3], out minutes))
+                {
+                    shell.WriteError(Loc.GetString("cmd-roleban-minutes-parse", ("time", args[3]), ("help", Help)));
+                    return;
+                }
+
+                if (!Enum.TryParse(args[4], ignoreCase: true, out severity))
+                {
+                    shell.WriteLine(Loc.GetString("cmd-roleban-severity-parse", ("severity", args[4]), ("help", Help)));
+                    return;
+                }
+
+                if (!int.TryParse(args[5], out round))
+                {
+                    shell.WriteLine(Loc.GetString("cmd-roleban-round-parse", ("round", args[5])));
+                    return;
+                }
+
+                break;
             default:
                 shell.WriteError(Loc.GetString("cmd-roleban-arg-count"));
                 shell.WriteLine(Help);
@@ -103,6 +128,8 @@ public sealed class DepartmentBanCommand : IConsoleCommand
         banInfo.WithBanningAdmin(shell.Player?.UserId);
         banInfo.AddHWId(targetHWid);
         banInfo.WithSeverity(severity);
+        if (round > 0)
+            banInfo.WithSituationRound(round);
 
         foreach (var job in departmentProto.Roles)
         {
@@ -141,6 +168,7 @@ public sealed class DepartmentBanCommand : IConsoleCommand
             3 => CompletionResult.FromHint(Loc.GetString("cmd-roleban-hint-3")),
             4 => CompletionResult.FromHintOptions(durOpts, Loc.GetString("cmd-roleban-hint-4")),
             5 => CompletionResult.FromHintOptions(severities, Loc.GetString("cmd-roleban-hint-5")),
+            6 => CompletionResult.FromHint(Loc.GetString("cmd-roleban-hint-round")),
             _ => CompletionResult.Empty
         };
     }

--- a/Content.Server/Administration/Commands/DepartmentBanCommand.cs
+++ b/Content.Server/Administration/Commands/DepartmentBanCommand.cs
@@ -93,7 +93,7 @@ public sealed class DepartmentBanCommand : IConsoleCommand
                     return;
                 }
 
-                if (!int.TryParse(args[5], out round))
+                if (!int.TryParse(args[5], out round) || round <= 0)
                 {
                     shell.WriteLine(Loc.GetString("cmd-roleban-round-parse", ("round", args[5])));
                     return;

--- a/Content.Server/Administration/Commands/RoleBanCommand.cs
+++ b/Content.Server/Administration/Commands/RoleBanCommand.cs
@@ -30,6 +30,7 @@ public sealed class RoleBanCommand : IConsoleCommand
         string role;
         string reason;
         uint minutes;
+        int round = 0;
 
         if (!Enum.TryParse(_cfg.GetCVar(CCVars.RoleBanDefaultSeverity), out NoteSeverity severity))
         {
@@ -79,6 +80,30 @@ public sealed class RoleBanCommand : IConsoleCommand
                 }
 
                 break;
+            case 6:
+                target = args[0];
+                role = args[1];
+                reason = args[2];
+
+                if (!uint.TryParse(args[3], out minutes))
+                {
+                    shell.WriteError(Loc.GetString("cmd-roleban-minutes-parse", ("time", args[3]), ("help", Help)));
+                    return;
+                }
+
+                if (!Enum.TryParse(args[4], ignoreCase: true, out severity))
+                {
+                    shell.WriteLine(Loc.GetString("cmd-roleban-severity-parse", ("severity", args[4]), ("help", Help)));
+                    return;
+                }
+
+                if (!int.TryParse(args[5], out round))
+                {
+                    shell.WriteLine(Loc.GetString("cmd-roleban-round-parse", ("round", args[5])));
+                    return;
+                }
+
+                break;
             default:
                 shell.WriteError(Loc.GetString("cmd-roleban-arg-count"));
                 shell.WriteLine(Help);
@@ -104,6 +129,8 @@ public sealed class RoleBanCommand : IConsoleCommand
         banInfo.WithBanningAdmin(shell.Player?.UserId);
         banInfo.AddHWId(targetHWid);
         banInfo.WithSeverity(severity);
+        if (round > 0)
+            banInfo.WithSituationRound(round);
 
         if (_proto.HasIndex<JobPrototype>(role))
         {
@@ -151,6 +178,7 @@ public sealed class RoleBanCommand : IConsoleCommand
             3 => CompletionResult.FromHint(Loc.GetString("cmd-roleban-hint-3")),
             4 => CompletionResult.FromHintOptions(durOpts, Loc.GetString("cmd-roleban-hint-4")),
             5 => CompletionResult.FromHintOptions(severities, Loc.GetString("cmd-roleban-hint-5")),
+            6 => CompletionResult.FromHint(Loc.GetString("cmd-roleban-hint-round")),
             _ => CompletionResult.Empty
         };
     }

--- a/Content.Server/Administration/Commands/RoleBanCommand.cs
+++ b/Content.Server/Administration/Commands/RoleBanCommand.cs
@@ -97,7 +97,7 @@ public sealed class RoleBanCommand : IConsoleCommand
                     return;
                 }
 
-                if (!int.TryParse(args[5], out round))
+                if (!int.TryParse(args[5], out round) || round <= 0)
                 {
                     shell.WriteLine(Loc.GetString("cmd-roleban-round-parse", ("round", args[5])));
                     return;

--- a/Content.Server/Administration/Managers/BanManager.cs
+++ b/Content.Server/Administration/Managers/BanManager.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Content.Server.Chat.Managers;
 using Content.Server.Database;
+using Content.Server.Discord.Managers;
 using Content.Server.GameTicking;
 using Content.Shared.CCVar;
 using Content.Shared.Database;
@@ -38,6 +39,7 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
     [Dependency] private readonly IEntitySystemManager _systems = default!;
     [Dependency] private readonly ITaskManager _taskManager = default!;
     [Dependency] private readonly UserDbDataManager _userDbData = default!;
+    [Dependency] private readonly DiscordBanNotifyManager _dc = default!;
 
     private ISawmill _sawmill = default!;
 
@@ -122,6 +124,10 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
     #region Server Bans
     public async void CreateServerBan(CreateServerBanInfo banInfo)
     {
+        var originalReason = banInfo.Reason;
+        var roundId = GetCurrentRoundId();
+        banInfo.WithReason(FormatBanReason(originalReason, banInfo.SituationRound, roundId));
+
         var (banDef, expires) = await CreateBanDef(banInfo, BanType.Server, null);
 
         await _db.AddBanAsync(banDef);
@@ -169,6 +175,22 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
         _chat.SendAdminAlert(logMessage);
 
         KickMatchingConnectedPlayers(banDef, "newly placed ban");
+
+        if (banInfo.NotifyDiscord)
+        {
+            var firstUser = banInfo.Users.FirstOrNull();
+            uint? minutes = banInfo.Duration != null ? (uint)banInfo.Duration.Value.TotalMinutes : null;
+
+            _ = _dc.SendBanNotification(
+                adminName,
+                firstUser?.UserName ?? targetName,
+                originalReason,
+                expires.GetValueOrDefault().ToUnixTimeSeconds(),
+                DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                roundId,
+                banInfo.SituationRound,
+                null);
+        }
     }
 
     private NoteSeverity GetSeverityForServerBan(CreateBanInfo banInfo, CVarDef<string> defaultCVar)
@@ -224,6 +246,10 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
 
     public async void CreateRoleBan(CreateRoleBanInfo banInfo)
     {
+        var originalReason = banInfo.Reason;
+        var roundId = GetCurrentRoundId();
+        banInfo.WithReason(FormatBanReason(originalReason, banInfo.SituationRound, roundId));
+
         ImmutableArray<BanRoleDef> roleDefs =
         [
             .. ToBanRoleDef(banInfo.JobPrototypes),
@@ -257,6 +283,43 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
             if (_playerManager.TryGetSessionById(userId, out var session))
                 SendRoleBans(session);
         }
+
+        if (banInfo.NotifyDiscord)
+        {
+            var firstUser = banInfo.Users.FirstOrNull();
+            uint? minutes = banInfo.Duration != null ? (uint)banInfo.Duration.Value.TotalMinutes : null;
+            var roleNames = banInfo.JobPrototypes.Select(p => p.ToString())
+                .Concat(banInfo.AntagPrototypes.Select(p => p.ToString()))
+                .ToList();
+
+            _dc.SendRoleBanNotification(
+                firstUser?.UserId,
+                firstUser?.UserName,
+                banInfo.BanningAdmin,
+                minutes,
+                originalReason,
+                banInfo.SituationRound,
+                roleNames);
+        }
+    }
+
+    private static string FormatBanReason(string reason, int? situationRound, int? currentRoundId)
+    {
+        if (situationRound is null or 0)
+        {
+            return currentRoundId != null
+                ? $"**#{currentRoundId}** | {reason}"
+                : reason;
+        }
+
+        return $"**#{situationRound}** | {reason}";
+    }
+
+    private int? GetCurrentRoundId()
+    {
+        return _systems.TryGetEntitySystem<GameTicker>(out var ticker) && ticker.RoundId != 0
+            ? ticker.RoundId
+            : null;
     }
 
     private async Task<(BanDef Ban, DateTimeOffset? Expires)> CreateBanDef(

--- a/Content.Server/Administration/Managers/BanManager.cs
+++ b/Content.Server/Administration/Managers/BanManager.cs
@@ -149,7 +149,7 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
             ? "null"
             : string.Join(", ", banInfo.Users.Select(u => $"{u.UserName} ({u.UserId})"));
 
-        var addressRangeString = banInfo.AddressRanges.Count != 0
+        var addressRangeString = banInfo.AddressRanges.Count == 0
             ? "null"
             : string.Join(", ", banInfo.AddressRanges.Select(a => $"{a.Address}/{a.Mask}"));
 

--- a/Content.Server/Administration/Managers/BanManager.cs
+++ b/Content.Server/Administration/Managers/BanManager.cs
@@ -179,13 +179,12 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
         if (banInfo.NotifyDiscord)
         {
             var firstUser = banInfo.Users.FirstOrNull();
-            uint? minutes = banInfo.Duration != null ? (uint)banInfo.Duration.Value.TotalMinutes : null;
 
             _ = _dc.SendBanNotification(
                 adminName,
                 firstUser?.UserName ?? targetName,
                 originalReason,
-                expires.GetValueOrDefault().ToUnixTimeSeconds(),
+                expires?.ToUnixTimeSeconds() ?? 0,
                 DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
                 roundId,
                 banInfo.SituationRound,

--- a/Content.Server/Administration/Managers/BanManager.cs
+++ b/Content.Server/Administration/Managers/BanManager.cs
@@ -126,7 +126,7 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
     {
         var originalReason = banInfo.Reason;
         var roundId = GetCurrentRoundId();
-        banInfo.WithReason(FormatBanReason(originalReason, banInfo.SituationRound, roundId));
+        var displayReason = FormatBanReasonForDisplay(originalReason, banInfo.SituationRound, roundId);
 
         var (banDef, expires) = await CreateBanDef(banInfo, BanType.Server, null);
 
@@ -169,7 +169,7 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
             ("name", targetName),
             ("ip", addressRangeString),
             ("hwid", hwidString),
-            ("reason", banInfo.Reason));
+            ("reason", displayReason));
 
         _sawmill.Info(logMessage);
         _chat.SendAdminAlert(logMessage);
@@ -182,7 +182,7 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
 
             _ = _dc.SendBanNotification(
                 adminName,
-                firstUser?.UserName ?? targetName,
+                firstUser?.UserName ?? GetDiscordBanTargetName(banInfo),
                 originalReason,
                 expires?.ToUnixTimeSeconds() ?? 0,
                 DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
@@ -247,7 +247,7 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
     {
         var originalReason = banInfo.Reason;
         var roundId = GetCurrentRoundId();
-        banInfo.WithReason(FormatBanReason(originalReason, banInfo.SituationRound, roundId));
+        var displayReason = FormatBanReasonForDisplay(originalReason, banInfo.SituationRound, roundId);
 
         ImmutableArray<BanRoleDef> roleDefs =
         [
@@ -274,7 +274,7 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
             "cmd-roleban-success",
             ("target", targetName),
             ("role", string.Join(", ", roleDefs)),
-            ("reason", banInfo.Reason),
+            ("reason", displayReason),
             ("length", length)));
 
         foreach (var (userId, _) in banInfo.Users)
@@ -302,16 +302,30 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
         }
     }
 
-    private static string FormatBanReason(string reason, int? situationRound, int? currentRoundId)
+    private static string FormatBanReasonForDisplay(string reason, int? situationRound, int? currentRoundId)
     {
         if (situationRound is null or 0)
         {
             return currentRoundId != null
-                ? $"**#{currentRoundId}** | {reason}"
+                ? $"#{currentRoundId} | {reason}"
                 : reason;
         }
 
-        return $"**#{situationRound}** | {reason}";
+        return $"#{situationRound} | {reason}";
+    }
+
+    private string GetDiscordBanTargetName(CreateBanInfo banInfo)
+    {
+        if (banInfo.Users.Count > 0)
+            return string.Join(", ", banInfo.Users.Select(u => $"{u.UserName} ({u.UserId})"));
+
+        if (banInfo.AddressRanges.Count > 0)
+            return string.Join(", ", banInfo.AddressRanges.Select(a => $"{a.Address}/{a.Mask}"));
+
+        if (banInfo.HWIds.Count > 0)
+            return string.Join(", ", banInfo.HWIds);
+
+        return Loc.GetString("ban-notify-ban-target-user-unknown");
     }
 
     private int? GetCurrentRoundId()

--- a/Content.Server/Administration/Managers/IBanManager.cs
+++ b/Content.Server/Administration/Managers/IBanManager.cs
@@ -135,6 +135,8 @@ public abstract class CreateBanInfo
     internal NoteSeverity? Severity;
     internal string Reason;
     internal NetUserId? BanningAdmin;
+    internal int? SituationRound;
+    internal bool NotifyDiscord = true;
 
     protected CreateBanInfo(string reason)
     {
@@ -327,6 +329,24 @@ public abstract class CreateBanInfo
     public CreateBanInfo WithBanningAdmin(NetUserId? banningAdmin)
     {
         BanningAdmin = banningAdmin;
+        return this;
+    }
+
+    /// <summary>
+    /// Specify the round in which the banned situation occurred, for display in ban reason and Discord notifications.
+    /// </summary>
+    public CreateBanInfo WithSituationRound(int situationRound)
+    {
+        SituationRound = situationRound;
+        return this;
+    }
+
+    /// <summary>
+    /// Whether to send a Discord notification when the ban is created.
+    /// </summary>
+    public CreateBanInfo WithDiscordNotification(bool notify)
+    {
+        NotifyDiscord = notify;
         return this;
     }
 }

--- a/Content.Server/Discord/DiscordLink/DiscordChatLink.cs
+++ b/Content.Server/Discord/DiscordLink/DiscordChatLink.cs
@@ -1,7 +1,7 @@
+using System.Threading.Tasks;
 using Content.Server.Chat.Managers;
 using Content.Shared.CCVar;
 using Content.Shared.Chat;
-using NetCord;
 using NetCord.Gateway;
 using Robust.Shared.Asynchronous;
 using Robust.Shared.Configuration;
@@ -25,10 +25,6 @@ public sealed class DiscordChatLink : IPostInjectInit
     {
         _discordLink.OnMessageReceived += OnMessageReceived;
 
-        #if DEBUG
-        _discordLink.RegisterCommandCallback(OnDebugCommandRun, "debug");
-        #endif
-
         _configurationManager.OnValueChanged(CCVars.OocDiscordChannelId, OnOocChannelIdChanged, true);
         _configurationManager.OnValueChanged(CCVars.AdminChatDiscordChannelId, OnAdminChannelIdChanged, true);
     }
@@ -40,14 +36,6 @@ public sealed class DiscordChatLink : IPostInjectInit
         _configurationManager.UnsubValueChanged(CCVars.OocDiscordChannelId, OnOocChannelIdChanged);
         _configurationManager.UnsubValueChanged(CCVars.AdminChatDiscordChannelId, OnAdminChannelIdChanged);
     }
-
-    #if DEBUG
-    private void OnDebugCommandRun(CommandReceivedEventArgs ev)
-    {
-        var args = string.Join('\n', ev.Arguments);
-        _sawmill.Info($"Provided arguments: \n{args}");
-    }
-    #endif
 
     private void OnOocChannelIdChanged(string channelId)
     {

--- a/Content.Server/Discord/DiscordLink/DiscordChatLink.cs
+++ b/Content.Server/Discord/DiscordLink/DiscordChatLink.cs
@@ -39,24 +39,24 @@ public sealed class DiscordChatLink : IPostInjectInit
 
     private void OnOocChannelIdChanged(string channelId)
     {
-        if (string.IsNullOrEmpty(channelId))
-        {
-            _oocChannelId = null;
-            return;
-        }
-
-        _oocChannelId = ulong.Parse(channelId);
+        _oocChannelId = TryParseChannelId(channelId, CCVars.OocDiscordChannelId.Name);
     }
 
     private void OnAdminChannelIdChanged(string channelId)
     {
-        if (string.IsNullOrEmpty(channelId))
-        {
-            _adminChannelId = null;
-            return;
-        }
+        _adminChannelId = TryParseChannelId(channelId, CCVars.AdminChatDiscordChannelId.Name);
+    }
 
-        _adminChannelId = ulong.Parse(channelId);
+    private ulong? TryParseChannelId(string channelId, string cvarName)
+    {
+        if (string.IsNullOrEmpty(channelId))
+            return null;
+
+        if (ulong.TryParse(channelId, out var id))
+            return id;
+
+        _sawmill.Error($"Invalid Discord channel ID in {cvarName}: '{channelId}'");
+        return null;
     }
 
     private void OnMessageReceived(Message message)

--- a/Content.Server/Discord/DiscordLink/DiscordLink.cs
+++ b/Content.Server/Discord/DiscordLink/DiscordLink.cs
@@ -1,11 +1,9 @@
-using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Content.Shared.CCVar;
 using NetCord;
 using NetCord.Gateway;
 using NetCord.Rest;
 using Robust.Shared.Configuration;
-using Robust.Shared.Utility;
 
 namespace Content.Server.Discord.DiscordLink;
 
@@ -20,15 +18,9 @@ public sealed class CommandReceivedEventArgs
     public string Command { get; init; } = string.Empty;
 
     /// <summary>
-    /// The raw arguments to the command. This is everything after the command
+    /// The arguments to the command. This is everything after the command
     /// </summary>
-    public string RawArguments { get; init; } = string.Empty;
-
-    /// <summary>
-    /// A list of arguments to the command.
-    /// This uses <see cref="CommandParsing.ParseArguments"/> mostly for maintainability.
-    /// </summary>
-    public List<string> Arguments { get; init; } = [];
+    public string Arguments { get; init; } = string.Empty;
 
     /// <summary>
     /// Information about the message that the command was received from. This includes the message content, author, etc.
@@ -190,28 +182,23 @@ public sealed class DiscordLink : IPostInjectInit
         var trimmedInput = content[BotPrefix.Length..].Trim();
         var firstSpaceIndex = trimmedInput.IndexOf(' ');
 
-        string command, rawArguments;
+        string command, arguments;
 
         if (firstSpaceIndex == -1)
         {
             command = trimmedInput;
-            rawArguments = string.Empty;
+            arguments = string.Empty;
         }
         else
         {
             command = trimmedInput[..firstSpaceIndex];
-            rawArguments = trimmedInput[(firstSpaceIndex + 1)..].Trim();
+            arguments = trimmedInput[(firstSpaceIndex + 1)..].Trim();
         }
 
-        var argumentList = new List<string>();
-        CommandParsing.ParseArguments(rawArguments, argumentList);
-
-        // Raise the event!
         OnCommandReceived?.Invoke(new CommandReceivedEventArgs
         {
             Command = command,
-            Arguments = argumentList,
-            RawArguments = rawArguments,
+            Arguments = arguments,
             Message = message,
         });
         return ValueTask.CompletedTask;

--- a/Content.Server/Discord/Managers/DiscordBanNotifyManager.cs
+++ b/Content.Server/Discord/Managers/DiscordBanNotifyManager.cs
@@ -1,0 +1,163 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Content.Server.GameTicking;
+using Content.Shared.CCVar;
+using Robust.Server.Player;
+using Robust.Shared;
+using Robust.Shared.Configuration;
+using Robust.Shared.Maths;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+
+namespace Content.Server.Discord.Managers;
+
+public sealed class DiscordBanNotifyManager
+{
+    [Dependency] private readonly DiscordWebhook _dc = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly ILogManager _log = default!;
+    [Dependency] private readonly ILocalizationManager _loc = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly IEntitySystemManager _systems = default!;
+
+    private ISawmill _logger = default!;
+
+    public void Initialize()
+    {
+        _logger = _log.GetSawmill("discord-ban-notify");
+    }
+
+    public async Task SendBanNotification(
+        string adminName,
+        string targetName,
+        string reason,
+        long expirationTime,
+        long issuanceTime,
+        int? issuanceRnd,
+        int? situationRnd,
+        List<string>? roleNames)
+    {
+        var isRoleBan = roleNames is { Count: > 0 };
+
+        List<WebhookEmbedField> fields =
+        [
+            new()
+            {
+                Inline = true,
+                Name = _loc.GetString("ban-notify-field-banned-user-title"),
+                Value = targetName,
+            },
+            new()
+            {
+                Inline = false,
+                Name = _loc.GetString("ban-notify-field-ban-reason-title"),
+                Value = situationRnd is null or 0
+                    ? (issuanceRnd != null
+                        ? $"**#{issuanceRnd}** | {reason}"
+                        : reason)
+                    : $"**#{situationRnd}** | {reason}",
+            },
+            new()
+            {
+                Inline = false,
+                Name = _loc.GetString("ban-notify-field-ban-issued-by-title"),
+                Value = adminName
+            },
+            new()
+            {
+                Inline = true,
+                Name = _loc.GetString("ban-notify-field-ban-issued-on-title"),
+                Value = issuanceRnd == null ? $"<t:{issuanceTime}:d>" : $"<t:{issuanceTime}:d>, #{issuanceRnd}",
+            },
+            new()
+            {
+                Inline = true,
+                Name = _loc.GetString("ban-notify-field-ban-expires-title"),
+                Value = expirationTime <= 0 ? _loc.GetString("ban-notify-ban-expires-never") : $"<t:{expirationTime}:R>",
+            },
+        ];
+
+        if (isRoleBan)
+        {
+            fields.Add(new WebhookEmbedField
+            {
+                Inline = false,
+                Name = _loc.GetString("ban-notify-banned-roles-title"),
+                Value = $"```{string.Join("", roleNames!.Select(r => $"- {r}\n"))}```",
+            });
+        }
+
+        await SendBanNotification(new WebhookEmbed
+        {
+            Title = isRoleBan ? _loc.GetString("ban-notify-role-ban-embed-title") : _loc.GetString("ban-notify-ban-embed-title"),
+            Fields = fields,
+            Footer = new()
+            {
+                Text = _loc.GetString("ban-notify-embed-footer", ("serverName", _cfg.GetCVar(CVars.GameHostName))),
+            },
+            Color = Color.Red.ToArgb() & 16777215,
+        });
+    }
+
+    public async Task SendBanNotification(WebhookEmbed embed)
+    {
+        var webhookUri = _cfg.GetCVar(CCVars.BanWebhook);
+
+        if (webhookUri == string.Empty)
+            return;
+
+        WebhookIdentifier? webhook = null;
+
+        if (await _dc.GetWebhook(webhookUri) is { } data)
+            webhook = data.ToIdentifier();
+
+        if (webhook == null)
+            return;
+
+        try
+        {
+            var payload = new WebhookPayload { Embeds = [embed] };
+            await _dc.CreateMessage(webhook.Value, payload);
+        }
+        catch (Exception)
+        {
+            _logger.Error(_loc.GetString("ban-notify-webhook-error-message"));
+        }
+    }
+
+    public void SendRoleBanNotification(
+        NetUserId? target,
+        string? targetUsername,
+        NetUserId? banningAdmin,
+        uint? minutes,
+        string reason,
+        int? situationRound,
+        List<string> roleNames)
+    {
+        DateTimeOffset? expires = null;
+        if (minutes > 0)
+            expires = DateTimeOffset.Now + TimeSpan.FromMinutes(minutes.Value);
+
+        _systems.TryGetEntitySystem(out GameTicker? ticker);
+        int? roundId = ticker == null || ticker.RoundId == 0 ? null : ticker.RoundId;
+
+        ICommonSession? session = null;
+        if (target != null)
+            _playerManager.TryGetSessionById(target.Value, out session);
+
+        var adminName = _loc.GetString("ban-notify-ban-admin-unknown");
+        if (banningAdmin != null && _playerManager.TryGetSessionById(banningAdmin.Value, out var adminSession))
+            adminName = adminSession.Name;
+
+        _ = SendBanNotification(
+            adminName,
+            targetUsername ?? (session != null ? session.Name : _loc.GetString("ban-notify-ban-target-user-unknown")),
+            reason,
+            expires.GetValueOrDefault().ToUnixTimeSeconds(),
+            DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            roundId,
+            situationRound,
+            roleNames
+        );
+    }
+}

--- a/Content.Server/Discord/Managers/DiscordBanNotifyManager.cs
+++ b/Content.Server/Discord/Managers/DiscordBanNotifyManager.cs
@@ -106,18 +106,14 @@ public sealed class DiscordBanNotifyManager
         if (webhookUri == string.Empty)
             return;
 
-        WebhookIdentifier? webhook = null;
-
-        if (await _dc.GetWebhook(webhookUri) is { } data)
-            webhook = data.ToIdentifier();
-
-        if (webhook == null)
-            return;
-
         try
         {
+            if (await _dc.GetWebhook(webhookUri) is not { } data)
+                return;
+
+            var webhook = data.ToIdentifier();
             var payload = new WebhookPayload { Embeds = [embed] };
-            await _dc.CreateMessage(webhook.Value, payload);
+            await _dc.CreateMessage(webhook, payload);
         }
         catch (Exception)
         {

--- a/Content.Server/Entry/EntryPoint.cs
+++ b/Content.Server/Entry/EntryPoint.cs
@@ -7,6 +7,7 @@ using Content.Server.Chat.Managers;
 using Content.Server.Connection;
 using Content.Server.Database;
 using Content.Server.Discord.DiscordLink;
+using Content.Server.Discord.Managers;
 using Content.Server.EUI;
 using Content.Server.FeedbackSystem;
 using Content.Server.GameTicking;
@@ -167,6 +168,7 @@ namespace Content.Server.Entry
             _euiManager.Initialize();
             _gameMap.Initialize();
             _entSys.GetEntitySystem<GameTicker>().PostInitialize();
+            IoCManager.Resolve<DiscordBanNotifyManager>().Initialize();
             _ban.Initialize();
             _connection.PostInit();
             _multiServerKick.Initialize();

--- a/Content.Server/IoC/ServerContentIoC.cs
+++ b/Content.Server/IoC/ServerContentIoC.cs
@@ -9,6 +9,7 @@ using Content.Server.Database;
 using Content.Server.Discord;
 using Content.Server.Discord.DiscordLink;
 using Content.Server.Discord.WebhookMessages;
+using Content.Server.Discord.Managers;
 using Content.Server.EUI;
 using Content.Server.FeedbackSystem;
 using Content.Server.GhostKick;
@@ -82,6 +83,7 @@ internal static class ServerContentIoC
         deps.Register<CVarControlManager>();
         deps.Register<DiscordLink>();
         deps.Register<DiscordChatLink>();
+        deps.Register<DiscordBanNotifyManager>();
         deps.Register<ServerFeedbackManager>();
         deps.Register<ISharedFeedbackManager, ServerFeedbackManager>();
     }

--- a/Content.Shared/Administration/BanPanelEuiState.cs
+++ b/Content.Shared/Administration/BanPanelEuiState.cs
@@ -12,11 +12,13 @@ public sealed class BanPanelEuiState : EuiStateBase
 {
     public string PlayerName { get; set; }
     public bool HasBan { get; set; }
+    public int RoundId { get; }
 
-    public BanPanelEuiState(string playerName, bool hasBan)
+    public BanPanelEuiState(string playerName, bool hasBan, int roundId)
     {
         PlayerName = playerName;
         HasBan = hasBan;
+        RoundId = roundId;
     }
 }
 
@@ -57,7 +59,8 @@ public sealed record Ban
         NoteSeverity severity,
         ProtoId<JobPrototype>[]? bannedJobs,
         ProtoId<AntagPrototype>[]? bannedAntags,
-        bool erase)
+        bool erase,
+        int situationRound = 0)
     {
         Target = target;
         IpAddress = ipAddressTuple?.Item1.ToString();
@@ -71,6 +74,7 @@ public sealed record Ban
         BannedJobs = bannedJobs;
         BannedAntags = bannedAntags;
         Erase = erase;
+        SituationRound = situationRound;
     }
 
     public readonly string? Target;
@@ -85,4 +89,5 @@ public sealed record Ban
     public readonly ProtoId<JobPrototype>[]? BannedJobs;
     public readonly ProtoId<AntagPrototype>[]? BannedAntags;
     public readonly bool Erase;
+    public readonly int SituationRound;
 }

--- a/Content.Shared/CCVar/CCVars.Discord.cs
+++ b/Content.Shared/CCVar/CCVars.Discord.cs
@@ -47,6 +47,9 @@ public sealed partial class CCVars
     public static readonly CVarDef<string> DiscordVotekickWebhook =
         CVarDef.Create("discord.votekick_webhook", string.Empty, CVar.SERVERONLY);
 
+    public static readonly CVarDef<string> BanWebhook =
+        CVarDef.Create("discord.ban_webhook", string.Empty, CVar.SERVERONLY | CVar.CONFIDENTIAL);
+
     /// <summary>
     ///     URL of the Discord webhook which will relay round restart messages.
     /// </summary>

--- a/Resources/Locale/en-US/info/ban.ftl
+++ b/Resources/Locale/en-US/info/ban.ftl
@@ -76,6 +76,7 @@ ban-panel-years = Years
 ban-panel-permanent = Permanent
 ban-panel-ip-hwid-tooltip = Leave empty and check the checkbox below to use last connection's details
 ban-panel-severity = Severity:
+ban-panel-situation-round = Situation round:
 ban-panel-erase = Erase chat messages and player from round
 ban-panel-expiry-error = err
 


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Dla #694

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nowe funkcje**
  * Dodano w panelu bana wybór „situation round” (SpinBox) oraz przycisk resetu.
  * Komendy banowania obsługują wariant z dodatkowym argumentem rundy (6 argumentów) i zapisują ją w banie.
  * Włączono powiadomienia o banach na Discordzie przez webhook, z uwzględnieniem numeru rundy.
* **Bug Fixes**
  * Usprawniono walidację formularza i wysyłki bana oraz bezpieczniej obsługiwane są błędne ustawienia ID kanałów Discord.
  * Poprawiono wyświetlanie zakresu adresów przy pustych danych.
* **Dokumentacja**
  * Dodano tłumaczenie etykiety „Situation round” w interfejsie.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->