### PR TITLE
Fiks zombiaków

### DIFF
--- a/Content.Server/NPC/Systems/NPCSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSystem.cs
@@ -26,6 +26,7 @@ using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.NPC;
 using Content.Shared.NPC.Systems;
+using Content.Shared.Zombies;
 using Robust.Server.GameObjects;
 using Robust.Shared.Configuration;
 using Robust.Shared.Player;
@@ -69,8 +70,11 @@ namespace Content.Server.NPC.Systems
             if (_mobState.IsIncapacitated(uid) || TerminatingOrDeleted(uid))
                 return;
 
-            // This NPC has an attached mind, so it should not wake up.
-            if (TryComp<MindContainerComponent>(uid, out var mindContainer) && mindContainer.HasMind)
+            // SSD crew should stay inactive until their player returns.
+            // Zombies resume AI when abandoned
+            if (TryComp<MindContainerComponent>(uid, out var mindContainer)
+                && mindContainer.HasMind
+                && !HasComp<ZombieComponent>(uid))
                 return;
 
             WakeNPC(uid, component);

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -312,6 +312,7 @@ public sealed partial class ZombieSystem
         }
         else
         {
+            _npc.SleepNPC(target, htn);
             _npc.WakeNPC(target, htn);
             _htn.Replan(htn);
         }

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -107,6 +107,7 @@ public sealed partial class ZombieSystem
     [Dependency] private readonly ServerInventorySystem _inventory = default!;
     [Dependency] private readonly MindSystem _mind = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeedModifier = default!;
+    [Dependency] private readonly HTNSystem _htn = default!;
     [Dependency] private readonly NPCSystem _npc = default!;
     [Dependency] private readonly SharedRoleSystem _roles = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
@@ -293,12 +294,13 @@ public sealed partial class ZombieSystem
         var htn = EnsureComp<HTNComponent>(target);
         htn.RootTask = new HTNCompoundTask() { Task = "SimpleHostileCompound" };
         htn.Blackboard.SetValue(NPCBlackboard.Owner, target);
-        _npc.SleepNPC(target, htn);
 
         //He's gotta have a mind
         var hasMind = _mind.TryGetMind(target, out var mindId, out _);
         if (hasMind && _mind.TryGetSession(mindId, out var session))
         {
+            _npc.SleepNPC(target, htn);
+
             //Zombie role for player manifest
             _roles.MindAddRole(mindId, "MindRoleZombie", mind: null, silent: true);
 
@@ -311,6 +313,7 @@ public sealed partial class ZombieSystem
         else
         {
             _npc.WakeNPC(target, htn);
+            _htn.Replan(htn);
         }
 
         if (!HasComp<GhostRoleMobSpawnerComponent>(target) && !hasMind) //this specific component gives build test trouble so pop off, ig


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Zombie z jakiegoś powody miały uśpione NPC zamiast odwrotnego zachowania

**Changelog**
:cl: Nikita_pl
- fix: Poprawiono zombiaków które nic nie robiły po zainfekowaniu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Poprawiono usypianie i wybudzanie NPC po odłączeniu gracza: NPC z „mind” pozostają uśpione w typowych sytuacjach, natomiast w przypadku zombie zachowanie jest wznowione zamiast pozostawania w stanie uśpienia.
  * Usprawniono logikę zombifikacji: przy braku poprawnie dostępnej sesji umysłu AI jest teraz odpowiednio ponownie zaplanowane, co zapewnia bardziej przewidywalne wznowienie działania.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->