### PR TITLE
Włącz filtrowanie tekstury w lobby art "Drunkards' Spree"

### DIFF
--- a/Resources/Textures/LobbyScreens/DrunkardsSpree.webp.yml
+++ b/Resources/Textures/LobbyScreens/DrunkardsSpree.webp.yml
@@ -7,4 +7,4 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 sample:
-  filter: false
+  filter: true


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Włącz filtrowanie tekstury w lobby art "Drunkards' Spree".

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
> "Cholera, chyba zapomniałem."
> Bezimienny, Gothic

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
- [X] Włącz filtrowanie tekstury w lobby art "Drunkards' Spree".

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
:cl: Saver310
- fix: Włącz filtrowanie tekstury w lobby art "Drunkards' Spree".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Naprawy błędów**
  * Ulepszono filtrowanie wyświetlania jednej z tekstur ekranu lobby, co może poprawić wyrazistość i ogólną jakość obrazu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->