### PR TITLE
Dodanie funkcjonalności noszenia Trupiogłowego na... głowie

### DIFF
--- a/Resources/Prototypes/_Polonium/Entities/Objects/Fun/plushies.yml
+++ b/Resources/Prototypes/_Polonium/Entities/Objects/Fun/plushies.yml
@@ -107,3 +107,8 @@
     timeToMix: 0.5
     reactionTypes:
     - Stir
+  - type: Clothing
+    quickEquip: false
+    sprite: _Polonium/Objects/Fun/Plushies/deathshead.rsi
+    slots:
+    - HEAD


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Dodaje funkcjonalność noszenia pluszaka Trupiogłowego na głowie.

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
- [X] Dodanie funkcjonalności noszenia Trupiogłowego na głowie

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
:cl: Saver310
- tweak: Dodanie funkcjonalności noszenia Trupiogłowego na głowie


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nowe funkcje**
  * Dodano możliwość noszenia jednego z pluszaków jako nakrycia głowy.
  * Przedmiot ma teraz własny wygląd po założeniu i można go użyć wyłącznie w slocie głowy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->