### PR TITLE
[FORKY] gunpred

### DIFF
--- a/Content.Client/_RMC14/Movement/RMCLagCompensationSystem.cs
+++ b/Content.Client/_RMC14/Movement/RMCLagCompensationSystem.cs
@@ -1,0 +1,16 @@
+using Content.Shared._RMC14.Movement;
+using Robust.Client.Timing;
+using Robust.Shared.Network;
+using Robust.Shared.Timing;
+
+namespace Content.Client._RMC14.Movement;
+
+public sealed partial class RMCLagCompensationSystem : SharedRMCLagCompensationSystem
+{
+    [Dependency] private readonly IClientGameTiming _timing = default!;
+
+    public override GameTick GetLastRealTick(NetUserId? session)
+    {
+        return _timing.LastRealTick;
+    }
+}

--- a/Content.Client/_RMC14/Weapons/Ranged/Prediction/GunPredictionSystem.cs
+++ b/Content.Client/_RMC14/Weapons/Ranged/Prediction/GunPredictionSystem.cs
@@ -1,0 +1,303 @@
+using System.Linq;
+using System.Numerics;
+using Content.Client.Projectiles;
+using Content.Shared._RMC14.Weapons.Ranged.Prediction;
+using Content.Shared.Projectiles;
+using Content.Shared.Weapons.Ranged.Events;
+using Robust.Client.GameObjects;
+using Robust.Client.GameStates;
+using Robust.Client.Physics;
+using Robust.Client.Player;
+using Robust.Shared.Map;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Dynamics;
+using Robust.Shared.Physics.Events;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Timing;
+
+namespace Content.Client._RMC14.Weapons.Ranged.Prediction;
+
+public sealed class GunPredictionSystem : SharedGunPredictionSystem
+{
+    [Dependency] private readonly IClientGameStateManager _gameState = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly ProjectileSystem _projectile = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    private EntityQuery<IgnorePredictionHideComponent> _ignorePredictionHideQuery;
+    private EntityQuery<IgnorePredictionHitComponent> _ignorePredictionHitQuery;
+    private EntityQuery<PredictedProjectileClientComponent> _predictedClientQuery;
+    private EntityQuery<SpriteComponent> _spriteQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _ignorePredictionHideQuery = GetEntityQuery<IgnorePredictionHideComponent>();
+        _ignorePredictionHitQuery = GetEntityQuery<IgnorePredictionHitComponent>();
+        _predictedClientQuery = GetEntityQuery<PredictedProjectileClientComponent>();
+        _spriteQuery = GetEntityQuery<SpriteComponent>();
+
+        SubscribeLocalEvent<PhysicsUpdateBeforeSolveEvent>(OnBeforeSolve);
+        SubscribeLocalEvent<PhysicsUpdateAfterSolveEvent>(OnAfterSolve);
+        SubscribeLocalEvent<RequestShootEvent>(OnShootRequest);
+
+        SubscribeLocalEvent<PredictedProjectileClientComponent, UpdateIsPredictedEvent>(OnClientProjectileUpdateIsPredicted);
+        SubscribeLocalEvent<PredictedProjectileClientComponent, StartCollideEvent>(OnClientProjectileStartCollide);
+        SubscribeLocalEvent<PredictedProjectileClientComponent, ComponentShutdown>(OnClientProjectileShutdown);
+        SubscribeLocalEvent<PredictedProjectileClientComponent, EntityTerminatingEvent>(OnClientProjectileTerminating);
+
+        SubscribeLocalEvent<PredictedProjectileServerComponent, ComponentAdd>(OnServerProjectileAdd);
+        SubscribeLocalEvent<PredictedProjectileServerComponent, ComponentStartup>(OnServerProjectileStartup);
+
+        UpdatesBefore.Add(typeof(TransformSystem));
+    }
+
+    private void OnBeforeSolve(ref PhysicsUpdateBeforeSolveEvent ev)
+    {
+        var query = EntityQueryEnumerator<PredictedProjectileClientComponent>();
+        while (query.MoveNext(out var uid, out var predicted))
+        {
+            predicted.Coordinates = Transform(uid).Coordinates;
+        }
+    }
+
+    private void OnAfterSolve(ref PhysicsUpdateAfterSolveEvent ev)
+    {
+        if (_timing.IsFirstTimePredicted)
+            return;
+        var query = EntityQueryEnumerator<PredictedProjectileClientComponent>();
+        while (query.MoveNext(out var uid, out var predicted))
+        {
+            if (predicted.Coordinates is { } coordinates)
+                _transform.SetCoordinates(uid, coordinates);
+
+            predicted.Coordinates = null;
+        }
+    }
+
+    private void OnShootRequest(RequestShootEvent ev, EntitySessionEventArgs args)
+    {
+        if (_timing.IsFirstTimePredicted)
+            return;
+
+        ShootRequested(ev.Gun, ev.Coordinates, ev.Target, ev.Shot, args.SenderSession, ev.RearmSemiAuto);
+    }
+
+    private void OnClientProjectileUpdateIsPredicted(Entity<PredictedProjectileClientComponent> ent, ref UpdateIsPredictedEvent args)
+    {
+        args.IsPredicted = true;
+    }
+
+    private void OnClientProjectileStartCollide(Entity<PredictedProjectileClientComponent> ent, ref StartCollideEvent args)
+    {
+        if (ent.Comp.Hit)
+            return;
+
+        // Only the actual projectile fixture counts as a hit. Ignore the "fly-by" sound sensor and
+        // any soft/non-hard contacts (e.g. the ejected cartridge casing spawned at the muzzle),
+        // matching SharedProjectileSystem.OnStartCollide.
+        if (args.OurFixtureId != SharedProjectileSystem.ProjectileFixture || !args.OtherFixture.Hard)
+            return;
+
+        // Predicted hit effects (the red damage flash in particular) only apply during first-time
+        // prediction. If this collision fires while re-predicting, don't consume the hit here; let the
+        // Update loop (which always runs first-time-predicted) process it so the flash reliably shows.
+        if (!_timing.IsFirstTimePredicted)
+            return;
+
+        if (!TryComp(ent, out ProjectileComponent? projectile) ||
+            !TryComp(ent, out PhysicsComponent? physics) ||
+            _ignorePredictionHitQuery.HasComp(args.OtherEntity))
+        {
+            return;
+        }
+
+        var netEnt = GetNetEntity(args.OtherEntity);
+        var pos = _transform.GetMapCoordinates(args.OtherEntity);
+        var hit = new HashSet<(NetEntity, MapCoordinates)> { (netEnt, pos) };
+        var ev = new PredictedProjectileHitEvent(ent.Owner.Id, hit);
+        RaiseNetworkEvent(ev);
+
+        // Process hit effects but do NOT delete the projectile here (predicted: true). Deleting a
+        // client-side predicted projectile mid-flight leaves stale physics contacts that crash the
+        // engine's ResetContacts during prediction reset. It is stopped/hidden here and cleaned up
+        // safely in Update instead.
+        _projectile.ProjectileCollide((ent, projectile, physics), args.OtherEntity, predicted: true);
+        MarkClientHit(ent, ent.Comp, physics);
+    }
+
+    private void OnClientProjectileShutdown(Entity<PredictedProjectileClientComponent> ent, ref ComponentShutdown args)
+    {
+        // When the client-side predicted projectile is removed (hit or cleaned up), reveal the hidden
+        // authoritative server projectile so the shot stays visible for the rest of its flight.
+        ShowServerProjectileCounterpart(ent.Owner.Id);
+    }
+
+    private void OnClientProjectileTerminating(Entity<PredictedProjectileClientComponent> ent, ref EntityTerminatingEvent args)
+    {
+        ShowServerProjectileCounterpart(ent.Owner.Id);
+    }
+
+    private void OnServerProjectileAdd(Entity<PredictedProjectileServerComponent> ent, ref ComponentAdd args)
+    {
+        HideServerProjectile(ent);
+    }
+
+    private void OnServerProjectileStartup(Entity<PredictedProjectileServerComponent> ent, ref ComponentStartup args)
+    {
+        HideServerProjectile(ent);
+    }
+
+    private void HideServerProjectile(Entity<PredictedProjectileServerComponent> ent)
+    {
+        if (!GunPrediction || !_gameState.IsPredictionEnabled)
+            return;
+
+        // Never hide our own client-side prediction entity.
+        if (IsClientSide(ent) || _predictedClientQuery.HasComp(ent))
+            return;
+
+        if (ent.Comp.ClientEnt != _player.LocalEntity)
+            return;
+
+        if (_ignorePredictionHideQuery.HasComp(ent))
+            return;
+
+        if (_spriteQuery.TryComp(ent, out var sprite))
+            _sprite.SetVisible((ent, sprite), false);
+    }
+
+    private void ShowServerProjectileCounterpart(int clientId)
+    {
+        var query = EntityQueryEnumerator<PredictedProjectileServerComponent, SpriteComponent>();
+        while (query.MoveNext(out var uid, out var server, out var sprite))
+        {
+            if (server.ClientEnt != _player.LocalEntity || server.ClientId != clientId)
+                continue;
+
+            _sprite.SetVisible((uid, sprite), true);
+        }
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (!_timing.IsFirstTimePredicted)
+            return;
+
+        // TODO gun prediction remove this once the client reliably detects collisions
+        var projectiles = EntityQueryEnumerator<PredictedProjectileClientComponent, ProjectileComponent, PhysicsComponent>();
+        while (projectiles.MoveNext(out var uid, out var predicted, out var projectile, out var physics))
+        {
+            if (predicted.Hit)
+            {
+                // The projectile already registered a hit. Cleanly remove it from the physics contact
+                // graph (SetCanCollide false destroys its contacts on both sides) before deleting, so the
+                // engine's ResetContacts never dereferences a stale contact for a deleted entity.
+                _physics.SetCanCollide(uid, false, body: physics);
+                QueueDel(uid);
+                continue;
+            }
+
+            // Find a real hit: the projectile's own "projectile" fixture actually touching a hard
+            // fixture. Using raw contacts (not GetContactingEntities) avoids the large "fly-by" sound
+            // sensor reporting far-away walls (1-3 tiles ahead) as hits.
+            EntityUid? hitEntity = null;
+            var enumerator = _physics.GetContacts(uid);
+            while (enumerator.MoveNext(out var contact))
+            {
+                if (!contact.IsTouching)
+                    continue;
+
+                string ourFixtureId;
+                EntityUid other;
+                Fixture? otherFixture;
+                if (contact.EntityA == uid)
+                {
+                    ourFixtureId = contact.FixtureAId;
+                    other = contact.EntityB;
+                    otherFixture = contact.FixtureB;
+                }
+                else
+                {
+                    ourFixtureId = contact.FixtureBId;
+                    other = contact.EntityA;
+                    otherFixture = contact.FixtureA;
+                }
+
+                if (ourFixtureId != SharedProjectileSystem.ProjectileFixture)
+                    continue;
+
+                if (otherFixture is not { Hard: true })
+                    continue;
+
+                if (_ignorePredictionHitQuery.HasComp(other))
+                    continue;
+
+                hitEntity = other;
+                break;
+            }
+
+            if (hitEntity is not { } target)
+                continue;
+
+            var hit = new HashSet<(NetEntity, MapCoordinates)>
+            {
+                (GetNetEntity(target), _transform.GetMapCoordinates(target)),
+            };
+
+            var ev = new PredictedProjectileHitEvent(uid.Id, hit);
+            RaiseNetworkEvent(ev);
+
+            _projectile.ProjectileCollide((uid, projectile, physics), target, predicted: true);
+            MarkClientHit(uid, predicted, physics);
+        }
+
+        var predictedQuery = EntityQueryEnumerator<PredictedProjectileHitComponent, SpriteComponent, TransformComponent>();
+        while (predictedQuery.MoveNext(out var uid, out var hit, out var sprite, out var xform))
+        {
+            // Don't touch our own client-side prediction entity.
+            if (IsClientSide(uid) || _predictedClientQuery.HasComp(uid))
+                continue;
+
+            var origin = hit.Origin;
+            var coordinates = xform.Coordinates;
+            var visible = origin.TryDistance(EntityManager, _transform, coordinates, out var distance) &&
+                          distance < hit.Distance;
+
+            _sprite.SetVisible((uid, sprite), visible);
+        }
+    }
+
+    private void MarkClientHit(EntityUid uid, PredictedProjectileClientComponent predicted, PhysicsComponent physics)
+    {
+        if (predicted.Hit)
+            return;
+
+        // Freeze and hide the predicted projectile at the impact point. Actual deletion happens next
+        // tick in Update after its physics contacts are torn down, to avoid a mid-flight delete crash.
+        predicted.Hit = true;
+        _physics.SetLinearVelocity(uid, Vector2.Zero, body: physics);
+
+        if (_spriteQuery.TryComp(uid, out var sprite))
+            _sprite.SetVisible((uid, sprite), false);
+    }
+
+    public override void FrameUpdate(float frameTime)
+    {
+        base.FrameUpdate(frameTime);
+
+        // TODO bullet prediction remove this when lerping doesnt make the client's entity slightly slower
+        var projectiles = EntityQueryEnumerator<PredictedProjectileClientComponent, TransformComponent>();
+        while (projectiles.MoveNext(out _, out var xform))
+        {
+            xform.ActivelyLerping = false;
+        }
+    }
+}

--- a/Content.Server/_RMC14/Movement/RMCLagCompensationSystem.cs
+++ b/Content.Server/_RMC14/Movement/RMCLagCompensationSystem.cs
@@ -1,0 +1,45 @@
+using Content.Server.Movement.Systems;
+using Content.Shared._RMC14.CCVar;
+using Content.Shared._RMC14.Movement;
+using Robust.Shared.Configuration;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
+
+namespace Content.Server._RMC14.Movement;
+
+public sealed partial class RMCLagCompensationSystem : SharedRMCLagCompensationSystem
+{
+    [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly LagCompensationSystem _lagCompensation = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        Subs.CVar(_config,
+            RMCCVars.RMCLagCompensationMilliseconds,
+            v => _lagCompensation.BufferTime = TimeSpan.FromMilliseconds(v),
+            true);
+    }
+
+    public override (EntityCoordinates Coordinates, Angle Angle) GetCoordinatesAngle(
+        EntityUid uid,
+        ICommonSession? pSession,
+        TransformComponent? xform = null)
+    {
+        return _lagCompensation.GetCoordinatesAngle(uid, pSession, xform);
+    }
+
+    public override Angle GetAngle(EntityUid uid, ICommonSession? session, TransformComponent? xform = null)
+    {
+        return _lagCompensation.GetAngle(uid, session, xform);
+    }
+
+    public override EntityCoordinates GetCoordinates(
+        EntityUid uid,
+        ICommonSession? session,
+        TransformComponent? xform = null)
+    {
+        return _lagCompensation.GetCoordinates(uid, session, xform);
+    }
+}

--- a/Content.Server/_RMC14/Weapons/Ranged/Prediction/GunPredictionSystem.cs
+++ b/Content.Server/_RMC14/Weapons/Ranged/Prediction/GunPredictionSystem.cs
@@ -1,0 +1,267 @@
+using Content.Server._RMC14.Movement;
+using Content.Server.Movement.Components;
+using Content.Shared._RMC14.CCVar;
+using Content.Shared._RMC14.Weapons.Ranged.Prediction;
+using Content.Shared.GameTicking;
+using Content.Shared.Projectiles;
+using Content.Shared.Weapons.Ranged.Events;
+using Robust.Shared.Configuration;
+using Robust.Shared.Map;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Events;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+
+namespace Content.Server._RMC14.Weapons.Ranged.Prediction;
+
+public sealed partial class GunPredictionSystem : SharedGunPredictionSystem
+{
+    [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly SharedProjectileSystem _projectile = default!;
+    [Dependency] private readonly RMCLagCompensationSystem _rmcLagCompensation = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    private readonly Dictionary<(Guid, int), EntityUid> _predicted = new();
+    private readonly List<(PredictedProjectileHitEvent Event, ICommonSession Player)> _predictedHits = new();
+    private bool _preventCollision;
+    private bool _logHits;
+    private float _coordinateDeviation;
+    private float _lowestCoordinateDeviation;
+    private float _aabbEnlargement;
+
+    private EntityQuery<FixturesComponent> _fixturesQuery;
+    private EntityQuery<LagCompensationComponent> _lagCompensationQuery;
+    private EntityQuery<PhysicsComponent> _physicsQuery;
+    private EntityQuery<ProjectileComponent> _projectileQuery;
+    private EntityQuery<PredictedProjectileServerComponent> _predictedProjectileServerQuery;
+    private EntityQuery<TransformComponent> _transformQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _fixturesQuery = GetEntityQuery<FixturesComponent>();
+        _lagCompensationQuery = GetEntityQuery<LagCompensationComponent>();
+        _physicsQuery = GetEntityQuery<PhysicsComponent>();
+        _projectileQuery = GetEntityQuery<ProjectileComponent>();
+        _predictedProjectileServerQuery = GetEntityQuery<PredictedProjectileServerComponent>();
+        _transformQuery = GetEntityQuery<TransformComponent>();
+
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestartCleanup);
+        SubscribeNetworkEvent<RequestShootEvent>(OnShootRequest);
+        SubscribeNetworkEvent<PredictedProjectileHitEvent>(OnPredictedProjectileHit);
+
+        SubscribeLocalEvent<PredictedProjectileServerComponent, MapInitEvent>(OnPredictedMapInit);
+        SubscribeLocalEvent<PredictedProjectileServerComponent, ComponentRemove>(OnPredictedRemove);
+        SubscribeLocalEvent<PredictedProjectileServerComponent, EntityTerminatingEvent>(OnPredictedRemove);
+        SubscribeLocalEvent<PredictedProjectileServerComponent, PreventCollideEvent>(OnPredictedPreventCollide);
+
+        Subs.CVar(_config, RMCCVars.RMCGunPredictionPreventCollision, v => _preventCollision = v, true);
+        Subs.CVar(_config, RMCCVars.RMCGunPredictionLogHits, v => _logHits = v, true);
+        Subs.CVar(_config, RMCCVars.RMCGunPredictionCoordinateDeviation, v => _coordinateDeviation = v, true);
+        Subs.CVar(_config, RMCCVars.RMCGunPredictionLowestCoordinateDeviation, v => _lowestCoordinateDeviation = v, true);
+        Subs.CVar(_config, RMCCVars.RMCGunPredictionAabbEnlargement, v => _aabbEnlargement = v, true);
+    }
+
+    private void OnRoundRestartCleanup(RoundRestartCleanupEvent ev)
+    {
+        _predicted.Clear();
+    }
+
+    private void OnShootRequest(RequestShootEvent ev, EntitySessionEventArgs args)
+    {
+        _rmcLagCompensation.SetLastRealTick(args.SenderSession.UserId, ev.LastRealTick);
+        ShootRequested(ev.Gun, ev.Coordinates, ev.Target, ev.Shot, args.SenderSession, ev.RearmSemiAuto);
+    }
+
+    private void OnPredictedMapInit(Entity<PredictedProjectileServerComponent> ent, ref MapInitEvent args)
+    {
+        if (ent.Comp.Shooter == null)
+        {
+            Log.Warning($"{nameof(PredictedProjectileServerComponent)} map initialized with a null shooter session!");
+            return;
+        }
+
+        _predicted[(ent.Comp.Shooter.UserId, ent.Comp.ClientId)] = ent;
+    }
+
+    private void OnPredictedRemove<T>(Entity<PredictedProjectileServerComponent> ent, ref T args)
+    {
+        if (ent.Comp.Shooter == null)
+            return;
+
+        _predicted.Remove((ent.Comp.Shooter.UserId, ent.Comp.ClientId));
+    }
+
+    private void OnPredictedProjectileHit(PredictedProjectileHitEvent ev, EntitySessionEventArgs args)
+    {
+        _predictedHits.Add((ev, args.SenderSession));
+    }
+
+    private void OnPredictedPreventCollide(Entity<PredictedProjectileServerComponent> ent, ref PreventCollideEvent args)
+    {
+        if (!_preventCollision || args.Cancelled)
+            return;
+
+        var other = args.OtherEntity;
+        if (!_lagCompensationQuery.TryComp(other, out var otherLagComp) ||
+            !_fixturesQuery.TryComp(other, out var otherFixtures) ||
+            !_transformQuery.TryComp(other, out var otherTransform))
+        {
+            return;
+        }
+
+        if (!_physicsQuery.TryComp(ent, out var entPhysics))
+            return;
+
+        if (!Collides(
+                (ent, ent, entPhysics),
+                (other, otherLagComp, otherFixtures, args.OtherBody, otherTransform),
+                null))
+        {
+            args.Cancelled = true;
+        }
+    }
+
+    private bool Collides(
+        Entity<PredictedProjectileServerComponent, PhysicsComponent> projectile,
+        Entity<LagCompensationComponent, FixturesComponent, PhysicsComponent, TransformComponent> other,
+        MapCoordinates? clientCoordinates)
+    {
+        var projectileCoordinates = _transform.GetMapCoordinates(projectile);
+        var projectilePosition = projectileCoordinates.Position;
+
+        MapCoordinates lowestCoordinate = default;
+        var otherCoordinates = EntityCoordinates.Invalid;
+        var ping = projectile.Comp1.Shooter?.Channel.Ping ?? 0;
+        var sentTime = _timing.CurTime - TimeSpan.FromMilliseconds(ping * 1.5);
+        var pingTime = TimeSpan.FromMilliseconds(ping);
+
+        foreach (var pos in other.Comp1.Positions)
+        {
+            otherCoordinates = pos.Item2;
+            if (pos.Item1 >= sentTime)
+                break;
+
+            if (lowestCoordinate == default && pos.Item1 >= sentTime - pingTime)
+                lowestCoordinate = _transform.ToMapCoordinates(pos.Item2);
+        }
+
+        var otherMapCoordinates = otherCoordinates == default
+            ? _transform.GetMapCoordinates(other)
+            : _transform.ToMapCoordinates(otherCoordinates);
+
+        if (clientCoordinates != null &&
+            (clientCoordinates.Value.InRange(otherMapCoordinates, _coordinateDeviation) ||
+             clientCoordinates.Value.InRange(lowestCoordinate, _lowestCoordinateDeviation)))
+        {
+            otherMapCoordinates = clientCoordinates.Value;
+        }
+
+        var transform = new Transform(otherMapCoordinates.Position, 0);
+        var bounds = new Box2(transform.Position, transform.Position);
+
+        foreach (var fixture in other.Comp2.Fixtures.Values)
+        {
+            if ((fixture.CollisionLayer & projectile.Comp2.CollisionMask) == 0)
+                continue;
+
+            for (var i = 0; i < fixture.Shape.ChildCount; i++)
+            {
+                var boundy = fixture.Shape.ComputeAABB(transform, i);
+                bounds = bounds.Union(boundy);
+            }
+        }
+
+        bounds = bounds.Enlarged(_aabbEnlargement);
+        if (bounds.Contains(projectilePosition))
+            return true;
+
+        var projectileVelocity = _physics.GetLinearVelocity(projectile, projectile.Comp2.LocalCenter);
+        projectilePosition = projectileCoordinates.Position + projectileVelocity / _timing.TickRate / 1.5f;
+        return bounds.Contains(projectilePosition);
+    }
+
+    private void ProcessPredictedHit(PredictedProjectileHitEvent ev, ICommonSession player)
+    {
+        if (!_predicted.TryGetValue((player.UserId, ev.Projectile), out var projectile))
+            return;
+
+        if (!_predictedProjectileServerQuery.TryComp(projectile, out var predictedProjectile) ||
+            predictedProjectile.Hit)
+        {
+            return;
+        }
+
+        if (predictedProjectile.Shooter?.UserId != player.UserId)
+            return;
+
+        if (!_projectileQuery.TryComp(projectile, out var projectileComp) ||
+            !_physicsQuery.TryComp(projectile, out var projectilePhysics))
+        {
+            return;
+        }
+
+        predictedProjectile.Hit = true;
+        foreach (var (netEnt, clientPos) in ev.Hit)
+        {
+            if (GetEntity(netEnt) is not { Valid: true } hit)
+                continue;
+
+            if (!_lagCompensationQuery.TryComp(hit, out var otherLagComp) ||
+                !_fixturesQuery.TryComp(hit, out var otherFixtures) ||
+                !_physicsQuery.TryComp(hit, out var otherPhysics) ||
+                !_transformQuery.TryComp(hit, out var otherTransform))
+            {
+                continue;
+            }
+
+            if (!Collides(
+                    (projectile, predictedProjectile, projectilePhysics),
+                    (hit, otherLagComp, otherFixtures, otherPhysics, otherTransform),
+                    clientPos))
+            {
+                if (_logHits)
+                    Log.Info("missed");
+
+                continue;
+            }
+
+            if (_logHits)
+                Log.Info("hit");
+
+            _projectile.ProjectileCollide((projectile, projectileComp, projectilePhysics), hit, true);
+        }
+    }
+
+    public override void Update(float frameTime)
+    {
+        try
+        {
+            foreach (var ev in _predictedHits)
+            {
+                ProcessPredictedHit(ev.Event, ev.Player);
+            }
+        }
+        finally
+        {
+            _predictedHits.Clear();
+        }
+
+        var predicted = EntityQueryEnumerator<PredictedProjectileHitComponent, TransformComponent>();
+        while (predicted.MoveNext(out var uid, out var hit, out var xform))
+        {
+            var origin = hit.Origin;
+            var coordinates = xform.Coordinates;
+            if (!origin.TryDistance(EntityManager, _transform, coordinates, out var distance) ||
+                distance >= hit.Distance)
+            {
+                QueueDel(uid);
+            }
+        }
+    }
+}

--- a/Content.Shared/Projectiles/SharedProjectileSystem.Prediction.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.Prediction.cs
@@ -1,0 +1,216 @@
+using System.Linq;
+using System.Numerics;
+using Content.Shared._RMC14.Projectiles;
+using Content.Shared._RMC14.Weapons.Ranged.Prediction;
+using Content.Shared.Administration.Logs;
+using Content.Shared.Camera;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Systems;
+using Content.Shared.Database;
+using Content.Shared.Effects;
+using Content.Shared.FixedPoint;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Network;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Events;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Player;
+
+namespace Content.Shared.Projectiles;
+
+public abstract partial class SharedProjectileSystem
+{
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly SharedCameraRecoilSystem _sharedCameraRecoil = default!;
+    [Dependency] private readonly SharedColorFlashEffectSystem _color = default!;
+    [Dependency] private readonly DamageableSystem _damageableSystem = default!;
+    [Dependency] private readonly SharedGunSystem _guns = default!;
+
+    partial void InitializeProjectilePrediction()
+    {
+        SubscribeLocalEvent<ProjectileComponent, StartCollideEvent>(OnStartCollide);
+    }
+
+    private void OnStartCollide(EntityUid uid, ProjectileComponent component, ref StartCollideEvent args)
+    {
+        if (_net.IsClient && _guns.GunPrediction && HasComp<PredictedProjectileClientComponent>(uid))
+            return;
+
+        if (args.OurFixtureId != ProjectileFixture || !args.OtherFixture.Hard
+            || component.ProjectileSpent || component is { Weapon: null, OnlyCollideWhenShot: true })
+            return;
+
+        ProjectileCollide((uid, component, args.OurBody), args.OtherEntity);
+    }
+
+    public void ProjectileCollide(Entity<ProjectileComponent, PhysicsComponent> projectile, EntityUid target, bool predicted = false)
+    {
+        var (uid, component, ourBody) = projectile;
+        if (component.ProjectileSpent)
+        {
+            if (_net.IsServer && component.DeleteOnCollide)
+                QueueDel(uid);
+
+            return;
+        }
+
+        var attemptEv = new ProjectileReflectAttemptEvent(uid, component, false);
+        RaiseLocalEvent(target, ref attemptEv);
+        if (attemptEv.Cancelled)
+        {
+            SetShooter(uid, component, target);
+            return;
+        }
+
+        var ev = new ProjectileHitEvent(component.Damage * _damageableSystem.UniversalProjectileDamageModifier, target, component.Shooter);
+        RaiseLocalEvent(uid, ref ev);
+        if (ev.Handled)
+            return;
+
+        var coordinates = Transform(projectile).Coordinates;
+
+        DamageSpecifier? modifiedDamage;
+        if (_net.IsServer)
+        {
+            _damageableSystem.TryChangeDamage(
+                target,
+                ev.Damage,
+                out modifiedDamage,
+                component.IgnoreResistances,
+                origin: component.Shooter);
+        }
+        else
+        {
+            modifiedDamage = new DamageSpecifier(ev.Damage);
+            var modifyEvent = new DamageModifyEvent(ev.Damage, component.Shooter);
+            RaiseLocalEvent(target, modifyEvent);
+            modifiedDamage = modifyEvent.Damage;
+        }
+
+        var deleted = Deleted(target);
+        var otherName = ToPrettyString(target);
+
+        var filter = Filter.Pvs(coordinates, entityMan: EntityManager);
+
+        // The shooter predicts the hit effects client-side, so remove them from the server-side filter
+        // to avoid the flash/sound playing twice for them. Other players get the server-driven effect.
+        if (_guns.GunPrediction &&
+            TryComp(projectile, out PredictedProjectileServerComponent? serverProjectile) &&
+            serverProjectile.Shooter is { } shooter)
+        {
+            filter = filter.RemovePlayer(shooter);
+        }
+
+        if (modifiedDamage is not null &&
+            (EntityManager.EntityExists(component.Shooter) || EntityManager.EntityExists(component.Weapon)))
+        {
+            if (modifiedDamage.AnyPositive() && !deleted)
+                _color.RaiseEffect(Color.Red, new List<EntityUid> { target }, filter);
+
+            if (_net.IsServer)
+            {
+                var shooterOrWeapon = EntityManager.EntityExists(component.Shooter)
+                    ? component.Shooter!.Value
+                    : component.Weapon!.Value;
+
+                _adminLogger.Add(LogType.BulletHit,
+                    HasComp<MobStateComponent>(target) ? LogImpact.Medium : LogImpact.Low,
+                    $"Projectile {ToPrettyString(uid):projectile} shot by {ToPrettyString(shooterOrWeapon):source} hit {otherName:target} and dealt {modifiedDamage.GetTotal():damage} damage");
+            }
+        }
+
+        if (!deleted && filter.Count > 0)
+            _guns.PlayImpactSound(target, modifiedDamage, component.SoundHit, component.ForceSound, filter, uid);
+
+        // Kick the hit entity's camera in the direction the projectile was travelling.
+        if (_net.IsServer && !deleted && !ourBody.LinearVelocity.IsLengthZero())
+            _sharedCameraRecoil.KickCamera(target, ourBody.LinearVelocity.Normalized());
+
+        // Penetration is server-authoritative (it needs destructible thresholds). The client always
+        // spends the projectile on the first hit; the server decides whether it keeps going.
+        if (_net.IsServer &&
+            modifiedDamage is not null &&
+            modifiedDamage.AnyPositive() &&
+            EntityManager.EntityExists(component.Shooter))
+        {
+            component.ProjectileSpent = !TryPenetrate((uid, component), modifiedDamage, GetProjectileDamageRequired(target));
+        }
+        else
+        {
+            component.ProjectileSpent = true;
+        }
+
+        Dirty(uid, component);
+
+        var additionalHits = new AfterProjectileHitEvent(projectile, target);
+        RaiseLocalEvent(uid, ref additionalHits);
+
+        if ((_net.IsServer || IsClientSide(uid)) && component.ImpactEffect != null &&
+            TryComp(uid, out TransformComponent? xform))
+        {
+            var impactEffectEv = new ImpactEffectEvent(component.ImpactEffect, GetNetCoordinates(xform.Coordinates));
+            if (_net.IsServer)
+                RaiseNetworkEvent(impactEffectEv, filter);
+            else
+                RaiseLocalEvent(impactEffectEv);
+        }
+
+        if (!predicted && component.ProjectileSpent && component.DeleteOnCollide && (_net.IsServer || IsClientSide(uid)))
+        {
+            QueueDel(uid);
+        }
+        else if (_net.IsServer && component.ProjectileSpent && component.DeleteOnCollide)
+        {
+            var predictedComp = EnsureComp<PredictedProjectileHitComponent>(uid);
+            predictedComp.Origin = _transform.GetMoverCoordinates(coordinates);
+
+            var targetCoords = _transform.GetMoverCoordinates(target);
+            if (predictedComp.Origin.TryDistance(EntityManager, _transform, targetCoords, out var distance))
+                predictedComp.Distance = distance;
+
+            Dirty(uid, predictedComp);
+        }
+    }
+
+    /// <summary>
+    /// How much damage a projectile has to deal to a target to keep penetrating through it.
+    /// Server-only; the client cannot evaluate destructible thresholds.
+    /// </summary>
+    protected virtual FixedPoint2 GetProjectileDamageRequired(EntityUid target)
+    {
+        return FixedPoint2.Zero;
+    }
+
+    private bool TryPenetrate(Entity<ProjectileComponent> projectile, DamageSpecifier damage, FixedPoint2 damageRequired)
+    {
+        // No penetration configured -> the projectile stops on this hit.
+        if (projectile.Comp.PenetrationThreshold == 0)
+            return false;
+
+        // If a damage type is required, stop the projectile if it isn't dealing that type.
+        if (projectile.Comp.PenetrationDamageTypeRequirement != null)
+        {
+            foreach (var requiredDamageType in projectile.Comp.PenetrationDamageTypeRequirement)
+            {
+                if (!damage.DamageDict.Keys.Contains(requiredDamageType))
+                    return false;
+            }
+        }
+
+        // If the target wouldn't be destroyed, it "tanks" the shot and the projectile stops.
+        if (damage.GetTotal() < damageRequired)
+            return false;
+
+        if (!projectile.Comp.ProjectileSpent)
+        {
+            projectile.Comp.PenetrationAmount += damageRequired;
+            if (projectile.Comp.PenetrationAmount >= projectile.Comp.PenetrationThreshold)
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/Content.Shared/Weapons/Ranged/Components/RangedDamageSoundComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/RangedDamageSoundComponent.cs
@@ -1,0 +1,19 @@
+using Content.Shared.Damage.Prototypes;
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
+
+namespace Content.Shared.Weapons.Ranged.Components;
+
+/// <summary>
+/// Plays the specified sound upon receiving damage of that type.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class RangedDamageSoundComponent : Component
+{
+    [DataField(customTypeSerializer: typeof(PrototypeIdDictionarySerializer<SoundSpecifier, DamageGroupPrototype>))]
+    public Dictionary<string, SoundSpecifier>? SoundGroups;
+
+    [DataField(customTypeSerializer: typeof(PrototypeIdDictionarySerializer<SoundSpecifier, DamageTypePrototype>))]
+    public Dictionary<string, SoundSpecifier>? SoundTypes;
+}

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Shoot.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Shoot.cs
@@ -1,0 +1,556 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using Content.Shared.Camera;
+using Content.Shared._RMC14.CCVar;
+using Content.Shared._RMC14.Weapons.Ranged;
+using Content.Shared._RMC14.Weapons.Ranged.Prediction;
+using Content.Shared.CombatMode;
+using Content.Shared.Containers;
+using Content.Shared.Database;
+using Content.Shared.Projectiles;
+using Content.Shared.Weapons.Hitscan.Components;
+using Content.Shared.Weapons.Hitscan.Events;
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Events;
+using Robust.Shared.Configuration;
+using Robust.Shared.Localization;
+using Robust.Shared.Map;
+using Robust.Shared.Network;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Player;
+using Robust.Shared.Utility;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared;
+
+namespace Content.Shared.Weapons.Ranged.Systems;
+
+public abstract partial class SharedGunSystem
+{
+    [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly SharedCameraRecoilSystem _recoil = default!;
+
+    public bool GunPrediction { get; private set; }
+
+    protected bool ClientSideGunPrediction =>
+        GunPrediction && (!_netManager.IsClient || _config.GetCVar(CVars.NetPredict));
+
+    partial void InitializePrediction()
+    {
+        Subs.CVar(_config, RMCCVars.RMCGunPrediction, v => GunPrediction = v, true);
+    }
+
+    public void ResetShotCounter(Entity<GunComponent> gun)
+    {
+        if (gun.Comp.ShotCounter == 0)
+            return;
+
+        gun.Comp.ShotCounter = 0;
+        DirtyField(gun.AsNullable(), nameof(GunComponent.ShotCounter));
+    }
+
+    public List<EntityUid>? AttemptShoot(
+        EntityUid user,
+        Entity<GunComponent> gun,
+        List<int>? predictedProjectiles = null,
+        ICommonSession? userSession = null)
+    {
+        if (gun.Comp.FireRateModified <= 0f ||
+            !_actionBlockerSystem.CanAttack(user))
+        {
+            return null;
+        }
+
+        var toCoordinates = gun.Comp.ShootCoordinates;
+
+        if (toCoordinates == null)
+            return null;
+
+        var curTime = Timing.CurTime;
+
+        var prevention = new ShotAttemptedEvent
+        {
+            User = user,
+            Used = gun
+        };
+        RaiseLocalEvent(gun, ref prevention);
+        if (prevention.Cancelled)
+            return null;
+
+        RaiseLocalEvent(user, ref prevention);
+        if (prevention.Cancelled)
+            return null;
+
+        if (gun.Comp.NextFire > curTime)
+            return null;
+
+        var fireRate = TimeSpan.FromSeconds(1f / gun.Comp.FireRateModified);
+
+        if (gun.Comp.SelectedMode == SelectiveFire.Burst || gun.Comp.BurstActivated)
+            fireRate = TimeSpan.FromSeconds(1f / gun.Comp.BurstFireRate);
+
+        if (gun.Comp.NextFire < curTime - fireRate || gun.Comp.ShotCounter == 0 && gun.Comp.NextFire < curTime)
+            gun.Comp.NextFire = curTime;
+
+        var shots = 0;
+        var lastFire = gun.Comp.NextFire;
+
+        while (gun.Comp.NextFire <= curTime)
+        {
+            gun.Comp.NextFire += fireRate;
+            shots++;
+        }
+
+        DirtyField(gun.AsNullable(), nameof(GunComponent.NextFire));
+
+        if (!gun.Comp.BurstActivated)
+        {
+            switch (gun.Comp.SelectedMode)
+            {
+                case SelectiveFire.SemiAuto:
+                    shots = Math.Min(shots, 1 - gun.Comp.ShotCounter);
+                    break;
+                case SelectiveFire.Burst:
+                    shots = Math.Min(shots, gun.Comp.ShotsPerBurstModified - gun.Comp.ShotCounter);
+                    break;
+                case SelectiveFire.FullAuto:
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException($"No implemented shooting behavior for {gun.Comp.SelectedMode}!");
+            }
+        }
+        else
+        {
+            shots = Math.Min(shots, gun.Comp.ShotsPerBurstModified - gun.Comp.ShotCounter);
+        }
+
+        var originEntity = HasComp<GunUseGunOriginComponent>(gun) ? gun.Owner : user;
+        var fromCoordinates = Transform(originEntity).Coordinates;
+
+        var shotOriginEv = new BeforeAttemptShootEvent(fromCoordinates, gun.Comp.ShootOriginOffset);
+        RaiseLocalEvent(user, ref shotOriginEv);
+
+        if (shotOriginEv.Handled)
+            fromCoordinates = shotOriginEv.Origin;
+
+        var attemptEv = new AttemptShootEvent(user, null, fromCoordinates, toCoordinates);
+        RaiseLocalEvent(gun, ref attemptEv);
+
+        if (attemptEv.Cancelled)
+        {
+            if (attemptEv.Message != null)
+                PopupSystem.PopupClient(attemptEv.Message, gun, user);
+
+            gun.Comp.BurstActivated = false;
+            gun.Comp.BurstShotsCount = 0;
+            gun.Comp.NextFire = attemptEv.ResetCooldown
+                ? curTime
+                : TimeSpan.FromSeconds(Math.Max(lastFire.TotalSeconds + SafetyNextFire, gun.Comp.NextFire.TotalSeconds));
+            return null;
+        }
+
+        fromCoordinates = attemptEv.FromCoordinates;
+        toCoordinates = attemptEv.ToCoordinates;
+        if (toCoordinates == null)
+            return null;
+
+        var ev = new TakeAmmoEvent(shots, [], fromCoordinates, user);
+
+        if (shots > 0)
+            RaiseLocalEvent(gun, ev);
+
+        DebugTools.Assert(ev.Ammo.Count <= shots);
+        DebugTools.Assert(shots >= 0);
+        UpdateAmmoCount(gun);
+
+        gun.Comp.ShotCounter += shots;
+        DirtyField(gun.AsNullable(), nameof(GunComponent.ShotCounter));
+
+        if (ev.Ammo.Count <= 0)
+        {
+            var emptyGunShotEvent = new OnEmptyGunShotEvent(user);
+            RaiseLocalEvent(gun, ref emptyGunShotEvent);
+
+            gun.Comp.BurstActivated = false;
+            gun.Comp.BurstShotsCount = 0;
+            gun.Comp.NextFire += TimeSpan.FromSeconds(gun.Comp.BurstCooldown);
+
+            if (shots > 0)
+            {
+                PopupSystem.PopupCursor(ev.Reason ?? Loc.GetString("gun-magazine-fired-empty"), user);
+                gun.Comp.NextFire = TimeSpan.FromSeconds(Math.Max(lastFire.TotalSeconds + SafetyNextFire, gun.Comp.NextFire.TotalSeconds));
+                Audio.PlayPredicted(gun.Comp.SoundEmpty, gun, user);
+            }
+
+            return null;
+        }
+
+        if (gun.Comp.SelectedMode == SelectiveFire.Burst)
+            gun.Comp.BurstActivated = true;
+
+        if (gun.Comp.BurstActivated)
+        {
+            gun.Comp.BurstShotsCount += shots;
+            if (gun.Comp.BurstShotsCount >= gun.Comp.ShotsPerBurstModified)
+            {
+                gun.Comp.NextFire += TimeSpan.FromSeconds(gun.Comp.BurstCooldown);
+                gun.Comp.BurstActivated = false;
+                gun.Comp.BurstShotsCount = 0;
+            }
+        }
+
+        List<EntityUid>? projectiles = null;
+        var userImpulse = false;
+        if (Timing.IsFirstTimePredicted)
+        {
+            projectiles = Shoot(
+                gun,
+                ev.Ammo,
+                fromCoordinates,
+                toCoordinates.Value,
+                out userImpulse,
+                user,
+                throwItems: attemptEv.ThrowItems,
+                predictedProjectiles,
+                userSession);
+        }
+
+        var shotEv = new GunShotEvent(user, ev.Ammo, fromCoordinates, toCoordinates.Value);
+        RaiseLocalEvent(gun, ref shotEv);
+
+        if (userImpulse && TryComp<PhysicsComponent>(user, out var userPhysics))
+        {
+            var shooterEv = new ShooterImpulseEvent();
+            RaiseLocalEvent(user, ref shooterEv);
+
+            if (shooterEv.Push)
+                CauseImpulse(fromCoordinates, toCoordinates.Value, (user, userPhysics));
+        }
+
+        foreach (var (ent, _) in ev.Ammo)
+        {
+            if (ent == null)
+                continue;
+
+            if (IsClientSide(ent.Value) &&
+                (HasComp<GunIgnorePredictionComponent>(gun) || projectiles == null || !projectiles.Contains(ent.Value)))
+            {
+                Del(ent);
+            }
+        }
+
+        return projectiles;
+    }
+
+    public void Shoot(
+        Entity<GunComponent> gun,
+        EntityUid ammo,
+        EntityCoordinates fromCoordinates,
+        EntityCoordinates toCoordinates,
+        out bool userImpulse,
+        EntityUid? user = null,
+        bool throwItems = false)
+    {
+        var shootable = EnsureShootable(ammo);
+        Shoot(
+            gun,
+            new List<(EntityUid? Entity, IShootable Shootable)>(1) { (ammo, shootable) },
+            fromCoordinates,
+            toCoordinates,
+            out userImpulse,
+            user,
+            throwItems);
+    }
+
+    public List<EntityUid>? Shoot(
+        Entity<GunComponent> gun,
+        List<(EntityUid? Entity, IShootable Shootable)> ammo,
+        EntityCoordinates fromCoordinates,
+        EntityCoordinates toCoordinates,
+        out bool userImpulse,
+        EntityUid? user = null,
+        bool throwItems = false,
+        List<int>? predictedProjectiles = null,
+        ICommonSession? userSession = null)
+    {
+        userImpulse = true;
+
+        if (user != null)
+        {
+            var selfEvent = new SelfBeforeGunShotEvent(user.Value, gun, ammo);
+            RaiseLocalEvent(user.Value, selfEvent);
+            if (selfEvent.Cancelled)
+            {
+                userImpulse = false;
+                return null;
+            }
+        }
+
+        var fromMap = TransformSystem.ToMapCoordinates(fromCoordinates);
+        var toMap = TransformSystem.ToMapCoordinates(toCoordinates).Position;
+        var mapDirection = toMap - fromMap.Position;
+        var mapAngle = mapDirection.ToAngle();
+        var angle = GetRecoilAngle(Timing.CurTime, gun, mapDirection.ToAngle());
+
+        var fromEnt = Maps.TryFindGridAt(fromMap, out var gridUid, out _)
+            ? TransformSystem.WithEntityId(fromCoordinates, gridUid)
+            : new EntityCoordinates(Maps.GetMapOrInvalid(fromMap.MapId), fromMap.Position);
+
+        toMap = fromMap.Position + angle.ToVec() * mapDirection.Length();
+        mapDirection = toMap - fromMap.Position;
+        var gunVelocity = Physics.GetMapLinearVelocity(fromEnt);
+
+        var shotProjectiles = new List<EntityUid>(ammo.Count);
+
+        void MarkPredicted(EntityUid projectile, int index)
+        {
+            if (!_netManager.IsServer || !GunPrediction || predictedProjectiles == null || userSession == null)
+                return;
+
+            // Guns flagged to ignore prediction must render their projectiles server-authoritatively.
+            // Without this the server would tag the projectile as predicted, causing the client to hide
+            // it (expecting a client-side prediction that never exists), so the projectile is invisible.
+            if (HasComp<GunIgnorePredictionComponent>(gun))
+                return;
+
+            if (index >= predictedProjectiles.Count)
+                return;
+
+            if (!Exists(projectile))
+                return;
+
+            var predicted = predictedProjectiles[index];
+            var comp = new PredictedProjectileServerComponent
+            {
+                Shooter = userSession,
+                ClientId = predicted,
+                ClientEnt = user,
+            };
+            AddComp(projectile, comp, true);
+            Dirty(projectile, comp);
+        }
+
+        foreach (var (ent, shootable) in ammo)
+        {
+            if (throwItems && ent != null)
+            {
+                Recoil(user, mapDirection, gun.Comp.CameraRecoilScalarModified);
+                ShootOrThrow(ent.Value, mapDirection, gunVelocity, gun, user);
+                continue;
+            }
+
+            switch (shootable)
+            {
+                case CartridgeAmmoComponent cartridge:
+                    if (!cartridge.Spent)
+                    {
+                        if (_netManager.IsServer || ClientSideGunPrediction)
+                        {
+                            var uid = Spawn(cartridge.Prototype, fromEnt);
+                            CreateAndFireProjectiles(uid, cartridge);
+
+                            if (_netManager.IsClient && HasComp<GunIgnorePredictionComponent>(gun))
+                            {
+                                predictedProjectiles?.RemoveAll(i => i == uid.Id);
+                                QueueDel(uid);
+                            }
+
+                            RaiseLocalEvent(ent!.Value, new AmmoShotEvent
+                            {
+                                FiredProjectiles = shotProjectiles,
+                            });
+
+                            SetCartridgeSpent(ent.Value, cartridge, true);
+
+                            if (cartridge.DeleteOnSpawn &&
+                                (_netManager.IsServer || IsClientSide(ent.Value)))
+                            {
+                                Del(ent.Value);
+                            }
+                        }
+                        else
+                        {
+                            MuzzleFlash(gun, cartridge, mapDirection.ToAngle(), user);
+                            Audio.PlayPredicted(gun.Comp.SoundGunshotModified, gun, user);
+                        }
+                    }
+                    else
+                    {
+                        userImpulse = false;
+                        Audio.PlayPredicted(gun.Comp.SoundEmpty, gun, user);
+                    }
+
+                    Recoil(user, mapDirection, gun.Comp.CameraRecoilScalarModified);
+
+                    if (!cartridge.DeleteOnSpawn && !Containers.IsEntityInContainer(ent!.Value))
+                        EjectCartridge(ent.Value, angle);
+
+                    if (IsClientSide(ent!.Value))
+                        Del(ent.Value);
+                    else
+                        Dirty(ent!.Value, cartridge);
+
+                    break;
+                case AmmoComponent newAmmo:
+                    if (_netManager.IsServer || ClientSideGunPrediction)
+                    {
+                        CreateAndFireProjectiles(ent!.Value, newAmmo);
+                    }
+                    else
+                    {
+                        MuzzleFlash(gun, newAmmo, mapDirection.ToAngle(), user);
+                        Audio.PlayPredicted(gun.Comp.SoundGunshotModified, gun, user);
+                    }
+
+                    Recoil(user, mapDirection, gun.Comp.CameraRecoilScalarModified);
+
+                    if (Exists(ent!.Value) && !HasComp<ProjectileComponent>(ent.Value))
+                    {
+                        if (IsClientSide(ent.Value))
+                            Del(ent.Value);
+                        else if (_netManager.IsClient)
+                            RemoveShootable(ent.Value);
+                    }
+
+                    MarkPredicted(ent!.Value, 0);
+                    break;
+                case HitscanAmmoComponent:
+                    if (ent == null)
+                        break;
+
+                    if (_netManager.IsServer || ClientSideGunPrediction)
+                    {
+                        var hitscanEv = new HitscanTraceEvent
+                        {
+                            FromCoordinates = fromCoordinates,
+                            ShotDirection = mapDirection.Normalized(),
+                            Gun = gun,
+                            Shooter = user,
+                            Target = gun.Comp.Target,
+                        };
+                        RaiseLocalEvent(ent.Value, ref hitscanEv);
+                        Del(ent);
+                    }
+
+                    Audio.PlayPredicted(gun.Comp.SoundGunshotModified, gun, user);
+                    Recoil(user, mapDirection, gun.Comp.CameraRecoilScalarModified);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        RaiseLocalEvent(gun, new AmmoShotEvent
+        {
+            FiredProjectiles = shotProjectiles,
+        });
+
+        return shotProjectiles;
+
+        void CreateAndFireProjectiles(EntityUid ammoEnt, AmmoComponent ammoComp)
+        {
+            predictedProjectiles ??= new List<int>();
+            MarkPredicted(ammoEnt, 0);
+
+            if (TryComp<ProjectileSpreadComponent>(ammoEnt, out var ammoSpreadComp))
+            {
+                var spreadEvent = new GunGetAmmoSpreadEvent(ammoSpreadComp.Spread);
+                RaiseLocalEvent(gun, ref spreadEvent);
+
+                var angles = LinearSpread(
+                    mapAngle - spreadEvent.Spread / 2,
+                    mapAngle + spreadEvent.Spread / 2,
+                    ammoSpreadComp.Count);
+
+                ShootOrThrow(ammoEnt, angles[0].ToVec(), gunVelocity, gun, user);
+                shotProjectiles.Add(ammoEnt);
+
+                for (var i = 1; i < ammoSpreadComp.Count; i++)
+                {
+                    var newUid = Spawn(ammoSpreadComp.Proto, fromEnt);
+                    ShootOrThrow(newUid, angles[i].ToVec(), gunVelocity, gun, user);
+                    shotProjectiles.Add(newUid);
+                    MarkPredicted(newUid, i);
+                }
+            }
+            else
+            {
+                ShootOrThrow(ammoEnt, mapDirection, gunVelocity, gun, user);
+                shotProjectiles.Add(ammoEnt);
+            }
+
+            MuzzleFlash(gun, ammoComp, mapDirection.ToAngle(), user);
+            Audio.PlayPredicted(gun.Comp.SoundGunshotModified, gun, user);
+        }
+    }
+
+    private void ShootOrThrow(
+        EntityUid uid,
+        Vector2 mapDirection,
+        Vector2 gunVelocity,
+        Entity<GunComponent> gun,
+        EntityUid? user)
+    {
+        if (gun.Comp.Target is { } target && !TerminatingOrDeleted(target))
+        {
+            var targeted = EnsureComp<TargetedProjectileComponent>(uid);
+            targeted.Target = target;
+            Dirty(uid, targeted);
+        }
+
+        if (!HasComp<ProjectileComponent>(uid))
+        {
+            if (_netManager.IsClient && !ClientSideGunPrediction)
+                RemoveShootable(uid);
+
+            if (Containers.TryGetContainingContainer(uid, out var throwContainer))
+                Containers.Remove(uid, throwContainer);
+
+            ThrowingSystem.TryThrow(uid, mapDirection, gun.Comp.ProjectileSpeedModified, user);
+            return;
+        }
+
+        if (Containers.TryGetContainingContainer(uid, out var container))
+            Containers.Remove(uid, container);
+
+        ShootProjectile(uid, mapDirection, gunVelocity, gun, user, gun.Comp.ProjectileSpeedModified);
+    }
+
+    private Angle GetRecoilAngle(TimeSpan curTime, GunComponent component, Angle direction)
+    {
+        var timeSinceLastFire = (curTime - component.LastFire).TotalSeconds;
+        var newTheta = MathHelper.Clamp(
+            component.CurrentAngle.Theta + component.AngleIncreaseModified.Theta - component.AngleDecayModified.Theta * timeSinceLastFire,
+            component.MinAngleModified.Theta,
+            component.MaxAngleModified.Theta);
+        component.CurrentAngle = new Angle(newTheta);
+        component.LastFire = component.NextFire;
+
+        var random = Random.NextFloat(-0.5f, 0.5f);
+        var angle = new Angle(direction.Theta + component.CurrentAngle.Theta * random);
+        DebugTools.Assert(component.CurrentAngle.Theta * random <= component.MaxAngleModified.Theta);
+        return angle;
+    }
+
+    private Angle[] LinearSpread(Angle start, Angle end, int intervals)
+    {
+        var angles = new Angle[intervals];
+        DebugTools.Assert(intervals > 1);
+
+        for (var i = 0; i <= intervals - 1; i++)
+            angles[i] = new Angle(start + (end - start) * i / (intervals - 1));
+
+        return angles;
+    }
+
+    private void Recoil(EntityUid? user, Vector2 recoilDirection, float recoilScalar)
+    {
+        if (_netManager.IsServer)
+            return;
+
+        if (!Timing.IsFirstTimePredicted || user == null || recoilDirection == Vector2.Zero || recoilScalar == 0)
+            return;
+
+        _recoil.KickCamera(user.Value, recoilDirection.Normalized() * 0.5f * recoilScalar);
+    }
+}

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -1,0 +1,32 @@
+using Robust.Shared;
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._RMC14.CCVar;
+
+[CVarDefs]
+public sealed partial class RMCCVars : CVars
+{
+    public static readonly CVarDef<bool> RMCGunPrediction =
+        CVarDef.Create("rmc.gun_prediction", true, CVar.SERVER | CVar.REPLICATED);
+
+    public static readonly CVarDef<bool> RMCGunPredictionPreventCollision =
+        CVarDef.Create("rmc.gun_prediction_prevent_collision", false, CVar.SERVER | CVar.REPLICATED);
+
+    public static readonly CVarDef<bool> RMCGunPredictionLogHits =
+        CVarDef.Create("rmc.gun_prediction_log_hits", false, CVar.SERVER | CVar.REPLICATED);
+
+    public static readonly CVarDef<float> RMCGunPredictionCoordinateDeviation =
+        CVarDef.Create("rmc.gun_prediction_coordinate_deviation", 3f, CVar.SERVER | CVar.REPLICATED);
+
+    public static readonly CVarDef<float> RMCGunPredictionLowestCoordinateDeviation =
+        CVarDef.Create("rmc.gun_prediction_lowest_coordinate_deviation", 3f, CVar.SERVER | CVar.REPLICATED);
+
+    public static readonly CVarDef<float> RMCGunPredictionAabbEnlargement =
+        CVarDef.Create("rmc.gun_prediction_aabb_enlargement", 1.5f, CVar.SERVER | CVar.REPLICATED);
+
+    public static readonly CVarDef<int> RMCLagCompensationMilliseconds =
+        CVarDef.Create("rmc.lag_compensation_milliseconds", 750, CVar.REPLICATED | CVar.SERVER);
+
+    public static readonly CVarDef<float> RMCLagCompensationMarginTiles =
+        CVarDef.Create("rmc.lag_compensation_margin_tiles", 0.25f, CVar.REPLICATED | CVar.SERVER);
+}

--- a/Content.Shared/_RMC14/Movement/RMCSetLastRealTickEvent.cs
+++ b/Content.Shared/_RMC14/Movement/RMCSetLastRealTickEvent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._RMC14.Movement;
+
+[Serializable, NetSerializable]
+public sealed class RMCSetLastRealTickEvent(GameTick tick) : EntityEventArgs
+{
+    public readonly GameTick Tick = tick;
+}

--- a/Content.Shared/_RMC14/Movement/SharedRMCLagCompensationSystem.cs
+++ b/Content.Shared/_RMC14/Movement/SharedRMCLagCompensationSystem.cs
@@ -1,0 +1,174 @@
+using Content.Shared._RMC14.CCVar;
+using Robust.Shared;
+using Robust.Shared.Configuration;
+using Robust.Shared.Map;
+using Robust.Shared.Network;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._RMC14.Movement;
+
+public abstract class SharedRMCLagCompensationSystem : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    public float MarginTiles { get; private set; }
+
+    private EntityQuery<ActorComponent> _actorQuery;
+    private EntityQuery<FixturesComponent> _fixturesQuery;
+    private int _substeps;
+    private float _substepTime;
+
+    private readonly Dictionary<NetUserId, GameTick> _lastRealTicks = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _actorQuery = GetEntityQuery<ActorComponent>();
+        _fixturesQuery = GetEntityQuery<FixturesComponent>();
+
+        SubscribeNetworkEvent<RMCSetLastRealTickEvent>(OnSetLastRealTick);
+
+        Subs.CVar(_config, RMCCVars.RMCLagCompensationMarginTiles, v => MarginTiles = v, true);
+        Subs.CVar(_config, CVars.NetTickrate, UpdateSubsteps, true);
+        Subs.CVar(_config, CVars.TargetMinimumTickrate, UpdateSubsteps, true);
+    }
+
+    private void OnSetLastRealTick(RMCSetLastRealTickEvent msg, EntitySessionEventArgs args)
+    {
+        SetLastRealTick(args.SenderSession.UserId, msg.Tick - 1);
+    }
+
+    private void UpdateSubsteps(int _)
+    {
+        var targetMinTickrate = (float) _config.GetCVar(CVars.TargetMinimumTickrate);
+        var serverTickrate = (float) _config.GetCVar(CVars.NetTickrate);
+        _substeps = (int) Math.Ceiling(targetMinTickrate / serverTickrate);
+        _substepTime = 1.0f / serverTickrate / _substeps;
+    }
+
+    public virtual (EntityCoordinates Coordinates, Angle Angle) GetCoordinatesAngle(
+        EntityUid uid,
+        ICommonSession? pSession,
+        TransformComponent? xform = null)
+    {
+        if (!Resolve(uid, ref xform))
+            return (EntityCoordinates.Invalid, Angle.Zero);
+
+        return (xform.Coordinates, xform.LocalRotation);
+    }
+
+    public virtual Angle GetAngle(EntityUid uid, ICommonSession? session, TransformComponent? xform = null)
+    {
+        var (_, angle) = GetCoordinatesAngle(uid, session, xform);
+        return angle;
+    }
+
+    public virtual EntityCoordinates GetCoordinates(
+        EntityUid uid,
+        ICommonSession? session,
+        TransformComponent? xform = null)
+    {
+        var (coordinates, _) = GetCoordinatesAngle(uid, session, xform);
+        return coordinates;
+    }
+
+    public EntityCoordinates GetCoordinates(EntityUid uid, EntityUid? session, TransformComponent? xform = null)
+    {
+        if (!_actorQuery.TryComp(session, out var actor))
+            return GetCoordinates(uid, (ICommonSession?) null, xform);
+
+        return GetCoordinates(uid, actor.PlayerSession, xform);
+    }
+
+    public virtual GameTick GetLastRealTick(NetUserId? session)
+    {
+        return session == null ? _timing.CurTick : _lastRealTicks.GetValueOrDefault(session.Value, _timing.CurTick);
+    }
+
+    public void SetLastRealTick(NetUserId session, GameTick tick)
+    {
+        if (_net.IsClient)
+            return;
+
+        _lastRealTicks[session] = tick;
+    }
+
+    public void SendLastRealTick()
+    {
+        if (_net.IsServer)
+            return;
+
+        RaiseNetworkEvent(new RMCSetLastRealTickEvent(GetLastRealTick(null)));
+    }
+
+    public bool Collides(
+        Entity<FixturesComponent?> target,
+        Entity<PhysicsComponent?> projectile,
+        ICommonSession? perspectiveSession,
+        int substep = 0)
+    {
+        if (!Resolve(target, ref target.Comp, false) ||
+            !Resolve(projectile, ref projectile.Comp, false))
+        {
+            return false;
+        }
+
+        substep = Math.Clamp(substep, -_substeps, _substeps);
+
+        var projectileCoordinates = _transform.GetMapCoordinates(projectile);
+        var projectileVelocity = _physics.GetLinearVelocity(projectile, projectile.Comp.LocalCenter);
+        var substeppedProjectilePos = projectileCoordinates.Position +
+                                        (projectileVelocity / _timing.TickRate) * (substep / (float) _substeps);
+
+        var targetCoordinates = _transform.ToMapCoordinates(GetCoordinates(target, perspectiveSession));
+        var transform = new Transform(targetCoordinates.Position, 0);
+        var targetBounds = new Box2(transform.Position, transform.Position);
+
+        foreach (var fixture in target.Comp.Fixtures.Values)
+        {
+            if ((fixture.CollisionLayer & projectile.Comp.CollisionMask) == 0)
+                continue;
+
+            for (var i = 0; i < fixture.Shape.ChildCount; i++)
+            {
+                var boundy = fixture.Shape.ComputeAABB(transform, i);
+                targetBounds = targetBounds.Union(boundy);
+            }
+        }
+
+        var projectileTransform = new Transform(substeppedProjectilePos, 0);
+        var projectileBounds = new Box2(projectileTransform.Position, projectileTransform.Position);
+
+        if (_fixturesQuery.TryComp(projectile, out var projFixtureComp))
+        {
+            foreach (var fixture in projFixtureComp.Fixtures.Values)
+            {
+                for (var i = 0; i < fixture.Shape.ChildCount; i++)
+                {
+                    var boundy = fixture.Shape.ComputeAABB(projectileTransform, i);
+                    projectileBounds = projectileBounds.Union(boundy);
+                }
+            }
+        }
+
+        if (targetBounds.Intersects(projectileBounds))
+            return true;
+
+        var xDist = Math.Max(targetBounds.Left - projectileBounds.Right, projectileBounds.Left - targetBounds.Right);
+        var yDist = Math.Max(targetBounds.Bottom - projectileBounds.Top, projectileBounds.Bottom - targetBounds.Top);
+        xDist = Math.Max(0, xDist);
+        yDist = Math.Max(0, yDist);
+        var aabbDistance = xDist * xDist + yDist * yDist;
+
+        return aabbDistance <= MarginTiles * MarginTiles;
+    }
+}

--- a/Content.Shared/_RMC14/Movement/SharedRMCLagCompensationSystem.cs
+++ b/Content.Shared/_RMC14/Movement/SharedRMCLagCompensationSystem.cs
@@ -132,18 +132,23 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
         var targetCoordinates = _transform.ToMapCoordinates(GetCoordinates(target, perspectiveSession));
         var transform = new Transform(targetCoordinates.Position, 0);
         var targetBounds = new Box2(transform.Position, transform.Position);
+        var hasMatchingFixture = false;
 
         foreach (var fixture in target.Comp.Fixtures.Values)
         {
             if ((fixture.CollisionLayer & projectile.Comp.CollisionMask) == 0)
                 continue;
 
+            hasMatchingFixture = true;
             for (var i = 0; i < fixture.Shape.ChildCount; i++)
             {
                 var boundy = fixture.Shape.ComputeAABB(transform, i);
                 targetBounds = targetBounds.Union(boundy);
             }
         }
+
+        if (!hasMatchingFixture)
+            return false;
 
         var projectileTransform = new Transform(substeppedProjectilePos, 0);
         var projectileBounds = new Box2(projectileTransform.Position, projectileTransform.Position);

--- a/Content.Shared/_RMC14/Projectiles/AfterProjectileHitEvent.cs
+++ b/Content.Shared/_RMC14/Projectiles/AfterProjectileHitEvent.cs
@@ -1,0 +1,7 @@
+using Content.Shared.Projectiles;
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared._RMC14.Projectiles;
+
+[ByRefEvent]
+public record struct AfterProjectileHitEvent(Entity<ProjectileComponent> Projectile, EntityUid Target);

--- a/Content.Shared/_RMC14/Weapons/Ranged/BeforeAttemptShootEvent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/BeforeAttemptShootEvent.cs
@@ -1,0 +1,7 @@
+using System.Numerics;
+using Robust.Shared.Map;
+
+namespace Content.Shared._RMC14.Weapons.Ranged;
+
+[ByRefEvent]
+public record struct BeforeAttemptShootEvent(EntityCoordinates Origin, Vector2 Offset, bool Handled = false);

--- a/Content.Shared/_RMC14/Weapons/Ranged/GunClickToFireComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/GunClickToFireComponent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Weapons.Ranged;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class GunClickToFireComponent : Component;

--- a/Content.Shared/_RMC14/Weapons/Ranged/GunUseGunOriginComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/GunUseGunOriginComponent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Weapons.Ranged;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class GunUseGunOriginComponent : Component;

--- a/Content.Shared/_RMC14/Weapons/Ranged/Prediction/GunIgnorePredictionComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Prediction/GunIgnorePredictionComponent.cs
@@ -1,0 +1,7 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Weapons.Ranged.Prediction;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(SharedGunPredictionSystem))]
+public sealed partial class GunIgnorePredictionComponent : Component;

--- a/Content.Shared/_RMC14/Weapons/Ranged/Prediction/IgnorePredictionHideComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Prediction/IgnorePredictionHideComponent.cs
@@ -1,0 +1,7 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Weapons.Ranged.Prediction;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(SharedGunPredictionSystem))]
+public sealed partial class IgnorePredictionHideComponent : Component;

--- a/Content.Shared/_RMC14/Weapons/Ranged/Prediction/IgnorePredictionHitComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Prediction/IgnorePredictionHitComponent.cs
@@ -1,0 +1,7 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Weapons.Ranged.Prediction;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(SharedGunPredictionSystem))]
+public sealed partial class IgnorePredictionHitComponent : Component;

--- a/Content.Shared/_RMC14/Weapons/Ranged/Prediction/PredictedChamberClientComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Prediction/PredictedChamberClientComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared._RMC14.Weapons.Ranged.Prediction;
+
+/// <summary>
+/// Client-side chamber round tracked outside networked container slots during gun prediction.
+/// </summary>
+[RegisterComponent]
+public sealed partial class PredictedChamberClientComponent : Component
+{
+    [DataField]
+    public EntityUid? Round;
+}

--- a/Content.Shared/_RMC14/Weapons/Ranged/Prediction/PredictedProjectileClientComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Prediction/PredictedProjectileClientComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Map;
+
+namespace Content.Shared._RMC14.Weapons.Ranged.Prediction;
+
+[RegisterComponent]
+public sealed partial class PredictedProjectileClientComponent : Component
+{
+    [DataField]
+    public bool Hit;
+
+    [DataField]
+    public EntityCoordinates? Coordinates;
+}

--- a/Content.Shared/_RMC14/Weapons/Ranged/Prediction/PredictedProjectileHitComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Prediction/PredictedProjectileHitComponent.cs
@@ -1,0 +1,16 @@
+using Content.Shared.Projectiles;
+using Robust.Shared.GameStates;
+using Robust.Shared.Map;
+
+namespace Content.Shared._RMC14.Weapons.Ranged.Prediction;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedGunPredictionSystem), typeof(SharedProjectileSystem))]
+public sealed partial class PredictedProjectileHitComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public EntityCoordinates Origin;
+
+    [DataField, AutoNetworkedField]
+    public float Distance;
+}

--- a/Content.Shared/_RMC14/Weapons/Ranged/Prediction/PredictedProjectileHitEvent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Prediction/PredictedProjectileHitEvent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Weapons.Ranged.Prediction;
+
+[Serializable, NetSerializable]
+public sealed class PredictedProjectileHitEvent(int projectile, HashSet<(NetEntity Id, MapCoordinates Coordinates)> hit) : EntityEventArgs
+{
+    public readonly int Projectile = projectile;
+    public readonly HashSet<(NetEntity Id, MapCoordinates Coordinates)> Hit = hit;
+}

--- a/Content.Shared/_RMC14/Weapons/Ranged/Prediction/PredictedProjectileServerComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Prediction/PredictedProjectileServerComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Player;
+
+namespace Content.Shared._RMC14.Weapons.Ranged.Prediction;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class PredictedProjectileServerComponent : Component
+{
+    public ICommonSession? Shooter;
+
+    [DataField, AutoNetworkedField]
+    public int ClientId;
+
+    [DataField, AutoNetworkedField]
+    public EntityUid? ClientEnt;
+
+    [DataField]
+    public bool Hit;
+}

--- a/Content.Shared/_RMC14/Weapons/Ranged/Prediction/SharedGunPredictionSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Prediction/SharedGunPredictionSystem.cs
@@ -1,0 +1,53 @@
+using Content.Shared._RMC14.CCVar;
+using Content.Shared.CombatMode;
+using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Configuration;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
+
+namespace Content.Shared._RMC14.Weapons.Ranged.Prediction;
+
+public abstract class SharedGunPredictionSystem : EntitySystem
+{
+    [Dependency] private readonly SharedCombatModeSystem _combatMode = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly SharedGunSystem _gun = default!;
+
+    public bool GunPrediction { get; private set; }
+
+    public override void Initialize()
+    {
+        Subs.CVar(_config, RMCCVars.RMCGunPrediction, v => GunPrediction = v, true);
+    }
+
+    public List<EntityUid>? ShootRequested(
+        NetEntity netGun,
+        NetCoordinates coordinates,
+        NetEntity? target,
+        List<int>? projectiles,
+        ICommonSession session,
+        bool rearmSemiAuto = false)
+    {
+        var user = session.AttachedEntity;
+
+        if (user == null ||
+            !_combatMode.IsInCombatMode(user) ||
+            !_gun.TryGetGun(user.Value, out var gun))
+        {
+            return null;
+        }
+
+        if (gun.Owner != GetEntity(netGun))
+            return null;
+
+#pragma warning disable RA0002
+        gun.Comp.ShootCoordinates = GetCoordinates(coordinates);
+        gun.Comp.Target = GetEntity(target);
+#pragma warning restore RA0002
+
+        if (rearmSemiAuto)
+            _gun.ResetShotCounter(gun);
+
+        return _gun.AttemptShoot(user.Value, gun, projectiles, session);
+    }
+}

--- a/Content.Shared/_RMC14/Weapons/Ranged/RMCBeforeMuzzleFlashEvent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/RMCBeforeMuzzleFlashEvent.cs
@@ -1,0 +1,6 @@
+using System.Numerics;
+
+namespace Content.Shared._RMC14.Weapons.Ranged;
+
+[ByRefEvent]
+public record struct RMCBeforeMuzzleFlashEvent(EntityUid Weapon, Vector2 Offset = default);


### PR DESCRIPTION
## Informacje o PR
<!-- Co zostało zmienione? -->

Portnięty system predykcji broni z RMC. Dzięki temu strzały i pociski są przewidywane po stronie klienta, broń reaguje natychmiast, bez opóźnienia sieciowego. Predykcja obejmuje wszystkie rodzaje broni palnej. Bronie, które nie powinny być przewidywane, są odpowiednio oznaczone i działają po staremu (autorytatywnie po stronie serwera).

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->

- Dodano system predykcji broni wraz z niezbędną infrastrukturą.
- Zintegrowano predykcję z istniejącym systemem strzelania, pociskami oraz trafieniami.
Bronie wykluczone z predykcji renderują pociski jedynie po stronie serwera.
- Zachowano i przywrócono dotychczasową funkcjonalność trafień (błysk, dźwięk, wstrząs kamery, przebijanie, logi) oraz inteligentne celowanie.
- Drobne dostosowania prototypów broni.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nowe funkcje**
  * Dodano przewidywanie strzałów i trafień, zapewniające płynniejszą obsługę broni oraz szybszą reakcję wizualną.
  * Ulepszono wykrywanie kolizji pocisków i obsługę penetracji, ograniczając fałszywe trafienia.
  * Dodano kompensację opóźnień sieciowych dla dokładniejszego określania pozycji i trafień.
  * Wprowadzono obsługę strzelania kliknięciem oraz elastyczne przypisywanie dźwięków obrażeń.

* **Ulepszenia**
  * Zsynchronizowano efekty trafień i widoczność pocisków między klientem a serwerem.
  * Dodano ustawienia umożliwiające dostosowanie predykcji, kolizji i kompensacji opóźnień.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->