### PR TITLE
Poprawki upadających pionków

### DIFF
--- a/Content.IntegrationTests/Tests/_Shitmed/Body/ClientWoundableContainerTest.cs
+++ b/Content.IntegrationTests/Tests/_Shitmed/Body/ClientWoundableContainerTest.cs
@@ -1,0 +1,168 @@
+using System.Numerics;
+using Content.IntegrationTests.Fixtures;
+using Content.Shared._Shitmed.Medical.Surgery.Traumas.Components;
+using Content.Shared._Shitmed.Medical.Surgery.Wounds.Components;
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.Movement.Systems;
+using Content.Shared.Standing;
+using NUnit.Framework;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests._Shitmed.Body;
+
+[TestFixture]
+public sealed class ClientWoundableContainerTest : GameTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: ClientWoundableTestVictim
+  components:
+  - type: Body
+  - type: Damageable
+  - type: Injurable
+  - type: StandingState
+  - type: MovementSpeedModifier
+
+- type: entity
+  id: ClientWoundableTestTorso
+  components:
+  - type: Organ
+    category: Torso
+  - type: Damageable
+  - type: Injurable
+  - type: Woundable
+    integrityCap: 200
+    thresholds:
+      Healthy: 200
+      Minor: 160
+      Moderate: 120
+      Severe: 80
+      Critical: 40
+      Mangled: 14
+      Severed: 0
+
+- type: entity
+  id: ClientWoundableTestLegLeft
+  components:
+  - type: Organ
+    category: LegLeft
+  - type: Damageable
+  - type: Injurable
+  - type: Woundable
+    integrityCap: 200
+    thresholds:
+      Healthy: 200
+      Minor: 160
+      Moderate: 120
+      Severe: 80
+      Critical: 40
+      Mangled: 14
+      Severed: 0
+
+- type: entity
+  id: ClientWoundableTestLegRight
+  components:
+  - type: Organ
+    category: LegRight
+  - type: Damageable
+  - type: Injurable
+  - type: Woundable
+    integrityCap: 200
+    thresholds:
+      Healthy: 200
+      Minor: 160
+      Moderate: 120
+      Severe: 80
+      Critical: 40
+      Mangled: 14
+      Severed: 0
+";
+
+    [Test]
+    public async Task ClientResolvesBoneContainersAndSpeedRefreshDoesNotDownMob()
+    {
+        var pair = Pair;
+        var server = pair.Server;
+        var client = pair.Client;
+
+        var sEntMan = server.ResolveDependency<IEntityManager>();
+        var cEntMan = client.ResolveDependency<IEntityManager>();
+
+        var map = await pair.CreateTestMap();
+        var coords = new MapCoordinates(Vector2.Zero, map.MapId);
+
+        EntityUid victim = default;
+        EntityUid legLeft = default;
+        EntityUid legRight = default;
+
+        await server.WaitPost(() =>
+        {
+            victim = sEntMan.SpawnEntity("ClientWoundableTestVictim", coords);
+            var torso = sEntMan.SpawnEntity("ClientWoundableTestTorso", coords);
+            legLeft = sEntMan.SpawnEntity("ClientWoundableTestLegLeft", coords);
+            legRight = sEntMan.SpawnEntity("ClientWoundableTestLegRight", coords);
+
+            var container = sEntMan.System<SharedContainerSystem>();
+            var organsContainer = container.GetContainer(victim, BodyComponent.ContainerID);
+            container.Insert(torso, organsContainer);
+            container.Insert(legLeft, organsContainer);
+            container.Insert(legRight, organsContainer);
+        });
+
+        await pair.RunTicksSync(5);
+
+        var clientVictim = cEntMan.GetEntity(sEntMan.GetNetEntity(victim));
+        var clientLegLeft = cEntMan.GetEntity(sEntMan.GetNetEntity(legLeft));
+        var clientLegRight = cEntMan.GetEntity(sEntMan.GetNetEntity(legRight));
+
+        await client.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                foreach (var leg in new[] { clientLegLeft, clientLegRight })
+                {
+                    var woundable = cEntMan.GetComponent<WoundableComponent>(leg);
+                    Assert.That(woundable.Wounds, Is.Not.Null,
+                        "The client should resolve a replicated organ's Wounds container from networked state.");
+                    Assert.That(woundable.Bone, Is.Not.Null,
+                        "The client should resolve a replicated organ's Bone container from networked state.");
+
+                    var hasBone = false;
+                    foreach (var contained in woundable.Bone!.ContainedEntities)
+                    {
+                        hasBone |= cEntMan.HasComponent<BoneComponent>(contained);
+                    }
+
+                    Assert.That(hasBone,
+                        "The server-spawned bone entity should be visible inside the client's Bone container.");
+                }
+            });
+        });
+
+        await client.WaitPost(() =>
+        {
+            cEntMan.System<MovementSpeedModifierSystem>().RefreshMovementSpeedModifiers(clientVictim);
+        });
+
+        await client.WaitAssertion(() =>
+        {
+            Assert.That(cEntMan.System<StandingStateSystem>().IsDown(clientVictim), Is.False,
+                "A movement-speed refresh on a healthy mob must not down it on the client.");
+        });
+
+        await server.WaitPost(() =>
+        {
+            sEntMan.System<MovementSpeedModifierSystem>().RefreshMovementSpeedModifiers(victim);
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(sEntMan.System<StandingStateSystem>().IsDown(victim), Is.False,
+                "A movement-speed refresh on a healthy mob must not down it on the server.");
+        });
+    }
+}

--- a/Content.IntegrationTests/Tests/_Shitmed/Body/KnockdownStandUpTest.cs
+++ b/Content.IntegrationTests/Tests/_Shitmed/Body/KnockdownStandUpTest.cs
@@ -1,0 +1,56 @@
+using System.Numerics;
+using Content.IntegrationTests.Fixtures;
+using Content.Shared.Standing;
+using Content.Shared.Stunnable;
+using NUnit.Framework;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests._Shitmed.Body;
+
+
+[TestFixture]
+public sealed class KnockdownStandUpTest : GameTest
+{
+    [TestCase("MobCorgi")]
+    [TestCase("MobHuman")]
+    public async Task KnockedDownMobStandsBackUp(string prototype)
+    {
+        var pair = Pair;
+        var server = pair.Server;
+
+        var sEntMan = server.ResolveDependency<IEntityManager>();
+
+        var map = await pair.CreateTestMap();
+        var coords = new MapCoordinates(Vector2.Zero, map.MapId);
+
+        EntityUid mob = default;
+
+        await server.WaitPost(() =>
+        {
+            mob = sEntMan.SpawnEntity(prototype, coords);
+            var stun = sEntMan.System<SharedStunSystem>();
+            stun.TryKnockdown(mob, TimeSpan.FromSeconds(0.5), force: true);
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(sEntMan.System<StandingStateSystem>().IsDown(mob), Is.True,
+                "Setup failure: the knockdown didn't actually put the mob down.");
+        });
+
+        // 0.5s knockdown + 2s stand-up DoAfter at 30 tps, with generous margin.
+        await pair.RunTicksSync(150);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(sEntMan.HasComponent<KnockedDownComponent>(mob), Is.False,
+                    $"{prototype} should have auto-recovered from a timed knockdown.");
+                Assert.That(sEntMan.System<StandingStateSystem>().IsDown(mob), Is.False,
+                    $"{prototype} should be standing again after the knockdown expired.");
+            });
+        });
+    }
+}

--- a/Content.IntegrationTests/Tests/_Shitmed/Body/LegCollapseGateTest.cs
+++ b/Content.IntegrationTests/Tests/_Shitmed/Body/LegCollapseGateTest.cs
@@ -1,0 +1,162 @@
+using System.Collections.Generic;
+using System.Numerics;
+using Content.IntegrationTests.Fixtures;
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.Movement.Systems;
+using Content.Shared.Standing;
+using Content.Shared.Stunnable;
+using NUnit.Framework;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests._Shitmed.Body;
+
+
+[TestFixture]
+public sealed class LegCollapseGateTest : GameTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: LegGateTestBorgVictim
+  components:
+  - type: Body
+  - type: Damageable
+  - type: Injurable
+  - type: StandingState
+  - type: MovementSpeedModifier
+
+- type: entity
+  id: LegGateTestUncategorizedOrgan
+  components:
+  - type: Organ
+";
+
+    [Test]
+    public async Task LegFreeSpeciesIsNotForcedDownAndCanStand()
+    {
+        var pair = Pair;
+        var server = pair.Server;
+        var sEntMan = server.ResolveDependency<IEntityManager>();
+
+        var map = await pair.CreateTestMap();
+        var coords = new MapCoordinates(Vector2.Zero, map.MapId);
+
+        EntityUid snail = default;
+
+        await server.WaitPost(() =>
+        {
+            snail = sEntMan.SpawnEntity("MobGastropoid", coords);
+        });
+
+        await pair.RunTicksSync(5);
+
+        await server.WaitAssertion(() =>
+        {
+            var standing = sEntMan.System<StandingStateSystem>();
+            Assert.That(standing.IsDown(snail), Is.False,
+                "A leg-free species should not be forced down just by existing.");
+
+            sEntMan.System<MovementSpeedModifierSystem>().RefreshMovementSpeedModifiers(snail);
+            Assert.That(standing.IsDown(snail), Is.False,
+                "A movement-speed refresh must not force a leg-free species down.");
+
+            sEntMan.System<SharedStunSystem>().TryKnockdown(snail, TimeSpan.FromSeconds(0.5), force: true);
+            Assert.That(standing.IsDown(snail), Is.True,
+                "Setup failure: the knockdown didn't actually put the mob down.");
+        });
+
+        // 0.5s knockdown + 2s stand-up DoAfter at 30 tps, with generous margin.
+        await pair.RunTicksSync(150);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(sEntMan.System<StandingStateSystem>().IsDown(snail), Is.False,
+                "A leg-free species must be able to stand back up after a knockdown.");
+        });
+    }
+
+    [Test]
+    public async Task BodyWithoutManifestIsNotStandLocked()
+    {
+        var pair = Pair;
+        var server = pair.Server;
+        var sEntMan = server.ResolveDependency<IEntityManager>();
+
+        var map = await pair.CreateTestMap();
+        var coords = new MapCoordinates(Vector2.Zero, map.MapId);
+
+        EntityUid victim = default;
+
+        await server.WaitPost(() =>
+        {
+            // Borg-shaped: a bare Body plus an uncategorized organ (their brain), no InitialBody.
+            victim = sEntMan.SpawnEntity("LegGateTestBorgVictim", coords);
+            var organ = sEntMan.SpawnEntity("LegGateTestUncategorizedOrgan", coords);
+
+            var container = sEntMan.System<SharedContainerSystem>();
+            container.Insert(organ, container.GetContainer(victim, BodyComponent.ContainerID));
+
+            sEntMan.System<SharedStunSystem>().TryKnockdown(victim, TimeSpan.FromSeconds(0.5), force: true);
+        });
+
+        await pair.RunTicksSync(150);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(sEntMan.System<StandingStateSystem>().IsDown(victim), Is.False,
+                "A Body-haver with no InitialBody manifest (borg-like) must not be stand-locked after a knockdown.");
+        });
+    }
+
+    [Test]
+    public async Task LegDependentSpeciesStillCollapsesWithoutLegs()
+    {
+        var pair = Pair;
+        var server = pair.Server;
+        var sEntMan = server.ResolveDependency<IEntityManager>();
+
+        var map = await pair.CreateTestMap();
+        var coords = new MapCoordinates(Vector2.Zero, map.MapId);
+
+        EntityUid human = default;
+
+        await server.WaitPost(() =>
+        {
+            human = sEntMan.SpawnEntity("MobHuman", coords);
+        });
+
+        await pair.RunTicksSync(5);
+
+        await server.WaitAssertion(() =>
+        {
+            var body = sEntMan.GetComponent<BodyComponent>(human);
+            var legs = new List<EntityUid>();
+            foreach (var organ in body.Organs!.ContainedEntities)
+            {
+                if (sEntMan.TryGetComponent(organ, out OrganComponent? organComp)
+                    && organComp.Category?.Id is "LegLeft" or "LegRight")
+                {
+                    legs.Add(organ);
+                }
+            }
+
+            Assert.That(legs, Has.Count.EqualTo(2), "Setup failure: expected a human to have two legs.");
+            foreach (var leg in legs)
+            {
+                sEntMan.DeleteEntity(leg);
+            }
+        });
+
+        await pair.RunTicksSync(5);
+
+        await server.WaitAssertion(() =>
+        {
+            sEntMan.System<MovementSpeedModifierSystem>().RefreshMovementSpeedModifiers(human);
+            Assert.That(sEntMan.System<StandingStateSystem>().IsDown(human), Is.True,
+                "A leg-dependent species with both legs gone must still collapse.");
+        });
+    }
+}

--- a/Content.IntegrationTests/Tests/_Shitmed/Body/LegCollapseGateTest.cs
+++ b/Content.IntegrationTests/Tests/_Shitmed/Body/LegCollapseGateTest.cs
@@ -136,7 +136,7 @@ public sealed class LegCollapseGateTest : GameTest
             var legs = new List<EntityUid>();
             foreach (var organ in body.Organs!.ContainedEntities)
             {
-                if (sEntMan.TryGetComponent(organ, out OrganComponent? organComp)
+                if (sEntMan.TryGetComponent(organ, out OrganComponent organComp)
                     && organComp.Category?.Id is "LegLeft" or "LegRight")
                 {
                     legs.Add(organ);

--- a/Content.IntegrationTests/Tests/_Shitmed/Body/LegPenaltyTest.cs
+++ b/Content.IntegrationTests/Tests/_Shitmed/Body/LegPenaltyTest.cs
@@ -103,6 +103,64 @@ public sealed class LegPenaltyTest : GameTest
         });
     }
 
+    private static void MendBone(IEntityManager sEntMan, TraumaSystem sTrauma, BodyComponent body, ProtoId<OrganCategoryPrototype> category)
+    {
+        Assert.That(LimbTargetMap.TryGetOrganByCategory(sEntMan, body, category, out var organ), Is.True);
+        var woundable = sEntMan.GetComponent<WoundableComponent>(organ);
+        Assert.That(woundable.Bone, Is.Not.Null);
+
+        var bone = woundable.Bone!.ContainedEntities[0];
+        sTrauma.SetBoneIntegrity(bone, sEntMan.GetComponent<BoneComponent>(bone).IntegrityCap);
+    }
+
+    [Test]
+    public async Task BrokenLegsBlockStandingUntilMended()
+    {
+        var pair = Pair;
+        var server = pair.Server;
+        var sEntMan = server.ResolveDependency<Robust.Shared.GameObjects.IEntityManager>();
+        var sTrauma = server.System<TraumaSystem>();
+        var sMovement = server.System<MovementSpeedModifierSystem>();
+        var sStanding = server.System<StandingStateSystem>();
+
+        var map = await pair.CreateTestMap();
+        var coords = new MapCoordinates(Vector2.Zero, map.MapId);
+
+        EntityUid human = default;
+        await server.WaitPost(() =>
+        {
+            human = sEntMan.SpawnEntity("MobHuman", coords);
+        });
+
+        await pair.RunTicksSync(10);
+
+        await server.WaitAssertion(() =>
+        {
+            var body = sEntMan.GetComponent<BodyComponent>(human);
+
+            BreakBone(sEntMan, sTrauma, body, "LegLeft");
+            BreakBone(sEntMan, sTrauma, body, "LegRight");
+
+            sMovement.RefreshMovementSpeedModifiers(human);
+
+            Assert.That(sStanding.IsDown(human), Is.True,
+                "breaking both leg bones should knock the mob down");
+
+            Assert.That(sStanding.Stand(human), Is.False,
+                "a mob with both leg bones broken should not be able to stand up");
+            Assert.That(sStanding.IsDown(human), Is.True,
+                "a mob with both leg bones broken should still be down after a stand attempt");
+
+            MendBone(sEntMan, sTrauma, body, "LegLeft");
+            MendBone(sEntMan, sTrauma, body, "LegRight");
+
+            Assert.That(sStanding.Stand(human), Is.True,
+                "a mob whose leg bones were mended should be able to stand back up");
+            Assert.That(sStanding.IsDown(human), Is.False,
+                "a mob whose leg bones were mended should be standing after a successful stand attempt");
+        });
+    }
+
     [Test]
     public async Task AllFourLimbsBrokenLeavesTheMobUnableToMoveAtAll()
     {

--- a/Content.Shared/Body/InitialBodySystem.cs
+++ b/Content.Shared/Body/InitialBodySystem.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using Content.Shared._Shitmed.Medical.Surgery;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Body;
 
@@ -46,5 +47,14 @@ public sealed partial class InitialBodySystem : EntitySystem
         }
 
         EnsureComp<SurgeryTargetComponent>(ent);
+    }
+
+    /// <summary>
+    /// Whether this body's initial-organ manifest includes the given category - i.e. whether
+    /// the species is anatomically expected to have one, regardless of what's currently attached.
+    /// </summary>
+    public bool ExpectsOrgan(Entity<InitialBodyComponent?> ent, ProtoId<OrganCategoryPrototype> category)
+    {
+        return Resolve(ent, ref ent.Comp, false) && ent.Comp.Organs.ContainsKey(category);
     }
 }

--- a/Content.Shared/Movement/Sprinting/SprinterComponent.cs
+++ b/Content.Shared/Movement/Sprinting/SprinterComponent.cs
@@ -132,7 +132,7 @@ public sealed partial class SprinterComponent : Component
     {
         DamageDict = new Dictionary<ProtoId<DamageTypePrototype>, FixedPoint2>
         {
-            { "Blunt", 7 },
+            { "Blunt", 2 },     // NFZ-med
         }
     };
 

--- a/Content.Shared/_Shitmed/Medical/Surgery/Traumas/Systems/TraumaSystem.Bones.cs
+++ b/Content.Shared/_Shitmed/Medical/Surgery/Traumas/Systems/TraumaSystem.Bones.cs
@@ -86,6 +86,9 @@ public partial class TraumaSystem
         if (!LimbTargetMap.TryGetOrganByCategory(EntityManager, body, "Torso", out _))
             return;
 
+        if (!IsLegDependent(body))
+            return;
+
         var legless = IsLegless(body);
 
         var multiplier = legless || _standing.IsDown(body.Owner)
@@ -105,8 +108,23 @@ public partial class TraumaSystem
 
     private void OnStandAttempt(Entity<BodyComponent> body, ref StandAttemptEvent args)
     {
-        if (IsLegless(body))
+        if (IsLegDependent(body) && IsLegless(body))
             args.Cancel();
+    }
+
+    /// <summary>
+    /// Whether this body's species is anatomically expected to have legs at all. Bodies that
+    /// were never meant to have any (borg chassis have no InitialBody; leg-free species like
+    /// gastropoids have a manifest without leg categories) locomote without them and are exempt
+    /// from leg collapse - otherwise IsLegless would read their normal anatomy as "both legs
+    /// gone" and permanently force them down. InitialBodyComponent persists on the mob after
+    /// spawn, so its manifest doubles as the expected-anatomy record; a mob whose legs are
+    /// dismembered mid-round still counts as leg-dependent and collapses as intended.
+    /// </summary>
+    private bool IsLegDependent(Entity<BodyComponent> body)
+    {
+        return _initialBody.ExpectsOrgan(body.Owner, "LegLeft")
+            || _initialBody.ExpectsOrgan(body.Owner, "LegRight");
     }
 
     private bool IsLegless(Entity<BodyComponent> body)

--- a/Content.Shared/_Shitmed/Medical/Surgery/Traumas/Systems/TraumaSystem.cs
+++ b/Content.Shared/_Shitmed/Medical/Surgery/Traumas/Systems/TraumaSystem.cs
@@ -38,6 +38,7 @@ public sealed partial class TraumaSystem : EntitySystem
     [Dependency] private MobStateSystem _mobState = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private AlertsSystem _alert = default!;
+    [Dependency] private InitialBodySystem _initialBody = default!;
 
     private string _brokenBonesAlertId = "BrokenBones";
     private string _legsCollapsedAlertId = "LegsCollapsed";

--- a/Content.Shared/_Shitmed/Medical/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
+++ b/Content.Shared/_Shitmed/Medical/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
@@ -31,6 +31,12 @@ public sealed partial class WoundSystem
 
         if (ent.Comp.WoundableIntegrity <= FixedPoint2.Zero)
             ent.Comp.WoundableIntegrity = ent.Comp.IntegrityCap;
+
+        if (_net.IsClient)
+        {
+            ent.Comp.Wounds ??= _container.EnsureContainer<Container>(ent, WoundableComponent.WoundContainerId);
+            ent.Comp.Bone ??= _container.EnsureContainer<Container>(ent, WoundableComponent.BoneContainerId);
+        }
     }
 
     private void OnWoundableMapInit(Entity<WoundableComponent> ent, ref MapInitEvent args)


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Naprawiono upadające ludziki. Problem trauma systemu.

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
Dodano kilka sprawdzeń, żeby odróżnić moby, które mają mieć nogi a nie mają od tych, które nie mają bo nie mają ich mieć (ślimaki, borgi). 

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: haze
- fix: Naprawiono upadające ludziki spowodowane trauma systemem



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Ulepszenia**
  - Gatunki bez nóg nie są już niesłusznie zmuszane do pozycji leżącej.
  - Uszkodzone nogi prawidłowo blokują wstawanie, a po naprawie umożliwiają ponowne podniesienie się.
  - Ulepszono synchronizację kontuzji, kości i ich zawartości między serwerem a klientem.
  - Przerwanie sprintu powoduje mniejsze obrażenia obuchowe.

- **Testy**
  - Dodano kompleksowe testy powalania, wstawania, obrażeń kończyn oraz synchronizacji stanu ciała.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->