### PR TITLE
Fixed non-visible drinks in metamorphic glass

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -33,6 +33,12 @@
   physicalDesc: reagent-physical-desc-aromatic
   flavor: chocolate
   color: "#664300"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   recognizable: true
   metabolisms:
     Digestion:
@@ -47,6 +53,12 @@
   physicalDesc: reagent-physical-desc-creamy
   flavor: creamy
   color: "#DFD7AF"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   metabolisms:
     Digestion:
       effects:
@@ -61,6 +73,12 @@
   physicalDesc: reagent-physical-desc-milky
   flavor: nutty
   color: "#f4eadb"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   metabolisms:
     Digestion:
       effects:
@@ -75,6 +93,12 @@
   physicalDesc: reagent-physical-desc-syrupy
   flavor: creamy
   color: "#FFEABF"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   metabolisms:
     Digestion:
       effects:
@@ -207,6 +231,12 @@
   physicalDesc: reagent-physical-desc-sickly
   flavor: bitter
   color: "#6600CC"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   metabolisms:
     Digestion:
       effects:
@@ -245,6 +275,12 @@
   physicalDesc: reagent-physical-desc-opaque
   flavor: milk
   color: "#DFDFDF"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   recognizable: true
   plantMetabolism:
     - !type:PlantAdjustNutrition
@@ -277,6 +313,12 @@
   physicalDesc: reagent-physical-desc-refreshing
   flavor: oats
   color: "#DEDACD"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   recognizable: true
   metabolisms:
     Digestion:
@@ -301,6 +343,12 @@
   physicalDesc: reagent-physical-desc-putrid
   flavor: terrible
   color: "#faffba"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   metabolisms:
     Digestion:
       effects:
@@ -358,6 +406,12 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: fizzy
   color: "#619494"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   fizziness: 0.8
 
 - type: reagent
@@ -430,6 +484,12 @@
   physicalDesc: reagent-physical-desc-translucent
   flavor: water
   color: "#75b1f0"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   recognizable: true
   boilingPoint: 100.0
   meltingPoint: 0.0
@@ -533,6 +593,12 @@
   physicalDesc: reagent-physical-desc-wormy
   flavor: cheapnoodles
   color: "#664300"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   metabolisms:
     Digestion:
       effects:
@@ -547,6 +613,12 @@
   physicalDesc: reagent-physical-desc-wormy
   flavor: cheapnoodles
   color: "#664300"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   metabolisms:
     Digestion:
       effects:
@@ -583,6 +655,12 @@
   physicalDesc: reagent-physical-desc-creamy
   flavor: pilk
   color: "#e7c69f"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   metabolisms:
     Digestion:
       effects:
@@ -598,6 +676,12 @@
   physicalDesc: reagent-physical-desc-sour
   flavor: bitter
   color: "#B3B599"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   #Macrocosm start
   metabolisms:
     Bloodstream:
@@ -651,6 +735,12 @@
   physicalDesc: reagent-physical-desc-murky
   flavor: mopwata
   color: "#59502b"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   metabolisms:
     Digestion:
       effects:

--- a/Resources/Prototypes/Reagents/Consumable/Drink/juice.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/juice.yml
@@ -7,6 +7,12 @@
   flavor: apple
   color: "#FDAD01"
   recognizable: true
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
 
 - type: reagent
   id: JuiceBanana
@@ -16,6 +22,12 @@
   physicalDesc: reagent-physical-desc-crisp
   flavor: banana
   color: "#FFE777"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
 
 - type: reagent
   id: JuiceBerry
@@ -25,6 +37,12 @@
   physicalDesc: reagent-physical-desc-sweet
   flavor: berry
   color: "#660099"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
 
 - type: reagent
   id: JuiceBluePumpkin
@@ -34,6 +52,12 @@
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: bluepumpkin
   color: "#00BFFF"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
 
 - type: reagent
   id: JuiceBungo
@@ -43,6 +67,12 @@
   physicalDesc: reagent-physical-desc-tart
   flavor: bungo
   color: "#F9E43D"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
 
 - type: reagent
   id: JuiceCarrot
@@ -52,6 +82,12 @@
   physicalDesc: reagent-physical-desc-crisp
   flavor: carrot
   color: "#FF8820"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   metabolisms:
     Digestion:
       metabolites:
@@ -66,6 +102,12 @@
   physicalDesc: reagent-physical-desc-crisp
   flavor: juice
   color: "#512284"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
 
 - type: reagent
   id: JuiceLemon
@@ -90,6 +132,12 @@
   physicalDesc: reagent-physical-desc-citric
   flavor: sour
   color: "#99bb43"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
 
 # /datum/reagent/drink/orangejuice/on_mob_life(var/mob/living/M)
 
@@ -122,6 +170,12 @@
   physicalDesc: reagent-physical-desc-tropical
   flavor: pineapple
   color: yellow
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
 
 - type: reagent
   id: JuiceTomato
@@ -131,6 +185,12 @@
   physicalDesc: reagent-physical-desc-saucey
   flavor: tomato
   color: "#731008"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
 
 - type: reagent
   id: JuiceWatermelon
@@ -155,3 +215,9 @@
   physicalDesc: reagent-physical-desc-sweet
   flavor: cherry
   color: "#84031a"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true

--- a/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
@@ -83,6 +83,12 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: soda
   color: "#2E6671"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
 
 - type: reagent
   id: DrGibb
@@ -107,6 +113,12 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: energydrink
   color: "#ffffbf"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   metabolisms:
     Digestion:
       metabolites:
@@ -128,6 +140,12 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: grapesoda
   color: "#ae94a6"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
 
 - type: reagent
   id: IceCream
@@ -154,6 +172,12 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: lemonlimesoda
   color: "#878F00"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
 
 - type: reagent
   id: LemonLimeCranberry
@@ -163,6 +187,12 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: lemonlimecranberrysoda
   color: "#803C53"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
 
 - type: reagent
   id: PwrGame
@@ -172,6 +202,12 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: pwrgamesoda
   color: "#9385bf"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   fizziness: 0.9 # gamers crave the fizz
 
 - type: reagent
@@ -278,6 +314,12 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: starkistsoda
   color: "#9F3400"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
 
 - type: reagent
   id: FourteenLoko
@@ -317,6 +359,7 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: metallic
   color: "#66538F"
+
 
 # backported missing drinks for funky drinks - Yaket
 - type: reagent
@@ -358,8 +401,8 @@
   flavor: 24voltenergy
   color: "#a5e65d"
   metamorphicSprite:
-    sprite: Objects/Consumable/Drinks/glass_collins_shape.rsi
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
     state: icon
-  metamorphicMaxFillLevels: 3
-  metamorphicFillBaseName: fill
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
   metamorphicChangeColor: true

--- a/Resources/Prototypes/_Funkystation/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/_Funkystation/Reagents/Consumable/Drink/alcohol.yml
@@ -13,10 +13,10 @@
   flavor: spiked-eggnog
   color: "#F5D695"
   metamorphicSprite:
-    sprite: Objects/Consumable/Drinks/glass_collins_shape.rsi
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
     state: icon
-  metamorphicMaxFillLevels: 3
-  metamorphicFillBaseName: fill
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
   metabolisms:
     Digestion:
@@ -57,10 +57,10 @@
   flavor: chutzpah
   color: "#552A00"
   metamorphicSprite:
-    sprite: Objects/Consumable/Drinks/glass_collins_shape.rsi
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
     state: icon
-  metamorphicMaxFillLevels: 3
-  metamorphicFillBaseName: fill
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
   metabolisms:
     Digestion:
@@ -80,10 +80,10 @@
   flavor: margherita-drink
   color: "#FF6C26"
   metamorphicSprite:
-    sprite: Objects/Consumable/Drinks/glass_collins_shape.rsi
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
     state: icon
-  metamorphicMaxFillLevels: 3
-  metamorphicFillBaseName: fill
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
   metabolisms:
     Digestion:
@@ -102,10 +102,10 @@
   flavor: pineapple-margherita
   color: "#FF6C26"
   metamorphicSprite:
-    sprite: Objects/Consumable/Drinks/glass_collins_shape.rsi
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
     state: icon
-  metamorphicMaxFillLevels: 3
-  metamorphicFillBaseName: fill
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
   metabolisms:
     Digestion:

--- a/Resources/Prototypes/_Funkystation/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/_Funkystation/Reagents/Consumable/Drink/drinks.yml
@@ -34,10 +34,10 @@
   flavor: peggnog
   color: "#ffca95"
   metamorphicSprite:
-    sprite: Objects/Consumable/Drinks/glass_collins_shape.rsi
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
     state: icon
-  metamorphicMaxFillLevels: 3
-  metamorphicFillBaseName: fill
+  metamorphicMaxFillLevels: 9
+  metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
   recognizable: true
   metabolisms:


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Naprawiłem napoje które nie były widoczne w metamorficznym szkle (o wiele ich więcej było niż krem kokosowy wspomniany w #786 )

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
Lepiej widzieć że coś jest i się coś pije

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
1. Dodanie tam gdzie nie było informacji o sprite "Objects/Consumable/Drinks/glass_clear.rsi"
2. Poprawienie wcześniej dodanych funky drinków aby też używały wyżej wymienionego sprite'a (imo wygląda lepiej)

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->
<img width="190" height="142" alt="Content Client_jJigcgTGBg" src="https://github.com/user-attachments/assets/3056878b-8def-4312-9e83-9f0e98d065ff" />

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: Yaket
- fix: Naprawiono brak widocznych napojów w szkle metamorficznym



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Ulepszenia**
  * Ujednolicono wizualizację napojów, soków, napojów gazowanych i alkoholi w szklankach.
  * Zwiększono liczbę poziomów napełnienia do 9, zapewniając płynniejsze odwzorowanie ilości płynu.
  * Kolor napoju jest teraz automatycznie odzwierciedlany w jego wyglądzie dla wybranych napojów.
  * Uspójniono nazewnictwo i wygląd kolejnych poziomów napełnienia.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->