### PR TITLE
Zwierzęta muszą działać z health analyzerem 

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
@@ -214,7 +214,13 @@ public sealed partial class HealthAnalyzerWindow : FancyWindow
         // Whole-body view has no single DamageableComponent that sums every limb (the mob's
         // own pool tracks whatever's dealt directly to it, not a total of its organs - see
         // BodyDamageBridgeSystem), so it's computed here by adding up every organ's damage.
-        var bodyDamage = isPart ? _damageable.GetAllDamage(damageSource) : GetBodyDamage(_target.Value);
+        // Mobs without TargetingComponent (corgi, cat, crab) never get their damage bridged
+        // to limb organs at all, so fall back to the mob's own DamageableComponent for those.
+        var bodyDamage = isPart
+            ? _damageable.GetAllDamage(damageSource)
+            : _entityManager.HasComponent<TargetingComponent>(_target.Value)
+                ? GetBodyDamage(_target.Value)
+                : _damageable.GetAllDamage(_target.Value);
 
         ReturnButton.Visible = isPart;
         PartNameLabel.Visible = isPart;

--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
@@ -1,4 +1,3 @@
-
 // SPDX-FileCopyrightText: 2022 Fishfish458 <47410468+Fishfish458@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
 // SPDX-FileCopyrightText: 2022 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
@@ -22,6 +21,8 @@
 // SPDX-FileCopyrightText: 2025 Hannah Giovanna Dawson <karakkaraz@gmail.com>
 // SPDX-FileCopyrightText: 2025 LordCarve <27449516+LordCarve@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2026 Fruitsalad <949631+Fruitsalad@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 Maciej Walendziuk <15122746+maciejwalendziuk@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 maciejwalendziuk <15122746+maciejwalendziuk@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2026 taydeo <tay@funkystation.org>
 // SPDX-FileCopyrightText: 2026 taydeo <td12233a@gmail.com>
 //


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
PR przywraca możliwość badania zwierząt przy pomocy health analyzera.
https://github.com/polonium14/polonium-station/issues/786

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
Health analyzer nie działa ze zwierzętami.

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
Fallback do DamageableComponent (po staremu - pomijając traume), jako że zwierzęta nie działają z traumą. Może kiedyś to poprawimy.

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->
<img width="981" height="573" alt="image" src="https://github.com/user-attachments/assets/5a05dd26-d3ed-4bea-b2e4-e493b08439d3" />


---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: haze
- fix: Naprawiono health analyzer, tak żeby działał ze zwierzętami



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Poprawki**
  * Ulepszono wyświetlanie obrażeń całego ciała w oknie analizatora zdrowia.
  * Obrażenia są teraz poprawnie liczone i prezentowane również dla obiektów, które nie mają systemu celowania.
  * Wyświetlanie obrażeń wybranych części ciała pozostaje bez zmian.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->