### PR TITLE
Dodano możliwość dostosowania mnożnika leczenia 

### DIFF
--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
@@ -502,6 +502,7 @@
     sprite: _Shitmed/Objects/Specific/Medical/Surgery/hemostat.rsi
     state: hemostat
   - type: SurgeryTendWoundsEffect
+    healMultiplier: 0.12
     damage:
       types:
         Blunt: 0
@@ -523,6 +524,7 @@
     state: hemostat
   - type: SurgeryTendWoundsEffect
     mainGroup: Burn
+    healMultiplier: 0.3
     damage:
       types:
         Heat: 0

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2026 Maciej Walendziuk <15122746+maciejwalendziuk@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 maciejwalendziuk <15122746+maciejwalendziuk@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Dodano możliwość dostosowania mnożnika leczenia (surgery - Repair damaged tissue, Repair burnt tissue) z pliku `surgery_steps.yml` pomijając zmiany C#. Podniesiono mnożnik leczenia brute z 0.07 na 0.12.
https://github.com/polonium14/polonium-station/issues/786

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
_Brak_

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
Dodano możliwość dostosowania mnożnika leczenia (surgery - Repair damaged tissue, Repair burnt tissue) z pliku `surgery_steps.yml` pomijając zmiany C#. 

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->
_Brak_

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: haze
- tweak: Podniesiono mnożnik leczenia obrażeń obuchowych i oparzeń podczas operacji!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Ulepszenia**
  * Dodano mnożniki skuteczności leczenia ran dla uszkodzeń mechanicznych i termicznych (brute: 0.12, burn: 0.3).
  * Zaktualizowano informacje licencyjne/autorów na początku pliku konfiguracji kroków szycia/leczenia.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->