### PR TITLE
Dodano możliwość odtwarzania dźwięku artylerii przez UI artbs + przen…

### DIFF
--- a/Content.Client/_Polonium/BluespaceStrike/BluespaceStrikeEui.cs
+++ b/Content.Client/_Polonium/BluespaceStrike/BluespaceStrikeEui.cs
@@ -71,6 +71,11 @@ public sealed partial class BluespaceStrikeEui : BaseEui
         SendMessage(new BluespaceStrikeEuiMsg.Confirm(epicenter, radius, delaySeconds, showMarkersAndSound));
     }
 
+    public void PlayArtillerySound()
+    {
+        SendMessage(new BluespaceStrikeEuiMsg.PlayArtillerySound());
+    }
+
     public override void HandleState(EuiStateBase state)
     {
         if (state is not BluespaceStrikeEuiState strikeState)

--- a/Content.Client/_Polonium/BluespaceStrike/BluespaceStrikeWindow.xaml
+++ b/Content.Client/_Polonium/BluespaceStrike/BluespaceStrikeWindow.xaml
@@ -1,7 +1,7 @@
 <DefaultWindow
     xmlns="https://spacestation14.io"
     Title="{Loc 'admin-bluespace-strike-eui-title'}"
-    SetHeight="420">
+    SetHeight="460">
     <BoxContainer Name="MainContainer" Orientation="Vertical">
 
         <BoxContainer Orientation="Horizontal">
@@ -41,6 +41,7 @@
 
         <Control MinSize="0 20"/>
 
+        <Button Name="PlayArtillerySound" Text="{Loc 'admin-bluespace-strike-eui-label-play-artillery'}" />
         <Button Name="Confirm" Text="{Loc 'admin-bluespace-strike-eui-label-confirm'}" />
     </BoxContainer>
 </DefaultWindow>

--- a/Content.Client/_Polonium/BluespaceStrike/BluespaceStrikeWindow.xaml.cs
+++ b/Content.Client/_Polonium/BluespaceStrike/BluespaceStrikeWindow.xaml.cs
@@ -41,6 +41,7 @@ public sealed partial class BluespaceStrikeWindow : DefaultWindow
 
         MapOptions.OnItemSelected += MapSelected;
         Recentre.OnPressed += _ => SetLocation();
+        PlayArtillerySound.OnPressed += _ => _eui.PlayArtillerySound();
         Confirm.OnPressed += SubmitButtonOnOnPressed;
 
         Preview.OnToggled += _ => UpdatePreview();

--- a/Content.Server/Administration/UI/AdminAnnounceEui.cs
+++ b/Content.Server/Administration/UI/AdminAnnounceEui.cs
@@ -50,7 +50,12 @@ namespace Content.Server.Administration.UI
                             break;
                         // TODO: Per-station announcement support
                         case AdminAnnounceType.Station:
-                            _chatSystem.DispatchGlobalAnnouncement(doAnnounce.Announcement, doAnnounce.Announcer, colorOverride: Color.Gold);
+                            var centCom = doAnnounce.Announcer == Loc.GetString("admin-announce-announcer-default");
+                            _chatSystem.DispatchGlobalAnnouncement(
+                                doAnnounce.Announcement,
+                                doAnnounce.Announcer,
+                                colorOverride: Color.Gold,
+                                centComAnnouncement: centCom);
                             break;
                     }
 

--- a/Content.Server/Announcements/AnnounceCommand.cs
+++ b/Content.Server/Announcements/AnnounceCommand.cs
@@ -52,8 +52,8 @@ public sealed partial class AnnounceCommand : LocalizedEntityCommands
         var message = args[0];
         var sender = Loc.GetString("cmd-announce-sender");
         var color = Color.Gold;
-
         SoundSpecifier? sound = null;
+        var centComAnnouncement = args.Length < 2;
 
         // Optional sender argument
         if (args.Length >= 2)
@@ -77,7 +77,7 @@ public sealed partial class AnnounceCommand : LocalizedEntityCommands
         if (args.Length >= 4)
             sound = new SoundPathSpecifier(args[3]);
 
-        _chat.DispatchGlobalAnnouncement(message, sender, true, sound, color);
+        _chat.DispatchGlobalAnnouncement(message, sender, true, sound, color, centComAnnouncement);
         shell.WriteLine(Loc.GetString("shell-command-success"));
     }
 

--- a/Content.Server/Announcements/AnnounceCommand.cs
+++ b/Content.Server/Announcements/AnnounceCommand.cs
@@ -19,7 +19,6 @@
 using Content.Server.Administration;
 using Content.Server.Chat.Systems;
 using Content.Shared.Administration;
-using Content.Shared.Chat;
 using Robust.Shared.Audio;
 using Robust.Shared.Console;
 using Robust.Shared.ContentPack;
@@ -53,7 +52,8 @@ public sealed partial class AnnounceCommand : LocalizedEntityCommands
         var message = args[0];
         var sender = Loc.GetString("cmd-announce-sender");
         var color = Color.Gold;
-        var sound = SharedChatSystem.DefaultAnnouncementSound;
+
+        SoundSpecifier? sound = null;
 
         // Optional sender argument
         if (args.Length >= 2)

--- a/Content.Server/Chat/Systems/ChatSystem.Announcements.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.Announcements.cs
@@ -24,7 +24,13 @@ public sealed partial class ChatSystem
         _chatManager.ChatMessageToAll(ChatChannel.Radio, message, wrappedMessage, default, false, true, colorOverride);
         if (playSound)
         {
-            _audio.PlayGlobal(announcementSound ?? DefaultAnnouncementSound, Filter.Broadcast(), true, AudioParams.Default.WithVolume(-2f));
+            // Polonium
+            var sound = announcementSound ?? (sender == Loc.GetString("admin-announce-announcer-default")
+                ? CCAnnouncementSound
+                : DefaultAnnouncementSound);
+
+            _audio.PlayGlobal(sound, Filter.Broadcast(), true,
+                AudioParams.Default.WithVolume(announcementSound != null ? -2f : -3f));
         }
         _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Global station announcement from {sender}: {message}");
     }

--- a/Content.Server/Chat/Systems/ChatSystem.Announcements.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.Announcements.cs
@@ -15,7 +15,8 @@ public sealed partial class ChatSystem
         string? sender = null,
         bool playSound = true,
         SoundSpecifier? announcementSound = null,
-        Color? colorOverride = null
+        Color? colorOverride = null,
+        bool centComAnnouncement = false
         )
     {
         sender ??= Loc.GetString("chat-manager-sender-announcement");
@@ -25,7 +26,7 @@ public sealed partial class ChatSystem
         if (playSound)
         {
             // Polonium
-            var sound = announcementSound ?? (sender == Loc.GetString("admin-announce-announcer-default")
+            var sound = announcementSound ?? (centComAnnouncement
                 ? CCAnnouncementSound
                 : DefaultAnnouncementSound);
 

--- a/Content.Server/_Polonium/BluespaceStrike/BluespaceStrikeEui.cs
+++ b/Content.Server/_Polonium/BluespaceStrike/BluespaceStrikeEui.cs
@@ -5,6 +5,7 @@
 
 using Content.Server.Administration.Logs;
 using Content.Server.AlertLevel;
+using Content.Server.Audio;
 using Content.Server.EUI;
 using Content.Server.Explosion.EntitySystems;
 using Content.Server.Station.Systems;
@@ -13,6 +14,9 @@ using Content.Shared.Administration;
 using Content.Shared.Database;
 using Content.Shared.Eui;
 using JetBrains.Annotations;
+using Robust.Server.Player;
+using Robust.Shared.Audio;
+using Robust.Shared.Player;
 
 namespace Content.Server._Polonium.BluespaceStrike;
 
@@ -23,7 +27,9 @@ public sealed class BluespaceStrikeEui : BaseEui
     private readonly ExplosionSystem _explosion;
     private readonly AlertLevelSystem _alertLevel;
     private readonly StationSystem _station;
+    private readonly ServerGlobalSoundSystem _globalSound;
     private readonly IAdminLogManager _adminLog;
+    private readonly IPlayerManager _playerManager;
     private readonly ISawmill _sawmill;
 
     public BluespaceStrikeEui()
@@ -33,7 +39,9 @@ public sealed class BluespaceStrikeEui : BaseEui
         _explosion = sys.GetEntitySystem<ExplosionSystem>();
         _alertLevel = sys.GetEntitySystem<AlertLevelSystem>();
         _station = sys.GetEntitySystem<StationSystem>();
+        _globalSound = sys.GetEntitySystem<ServerGlobalSoundSystem>();
         _adminLog = IoCManager.Resolve<IAdminLogManager>();
+        _playerManager = IoCManager.Resolve<IPlayerManager>();
         _sawmill = IoCManager.Resolve<ILogManager>().GetSawmill("bluespace-strike");
     }
 
@@ -71,6 +79,9 @@ public sealed class BluespaceStrikeEui : BaseEui
                 break;
             case BluespaceStrikeEuiMsg.Confirm confirm:
                 HandleConfirm(confirm);
+                break;
+            case BluespaceStrikeEuiMsg.PlayArtillerySound:
+                HandlePlayArtillerySound();
                 break;
         }
     }
@@ -147,5 +158,17 @@ public sealed class BluespaceStrikeEui : BaseEui
 
         _adminLog.Add(LogType.Action, LogImpact.High,
             $"{Player} confirmed bluespace strike EUI at {confirm.Epicenter} r={confirm.Radius} t={confirm.DelaySeconds}s warn={confirm.ShowMarkersAndSound}");
+    }
+
+    private void HandlePlayArtillerySound()
+    {
+        var audio = AudioParams.Default
+            .WithVolume(BluespaceStrikeComponent.ArtilleryAnnounceVolume)
+            .AddVolume(-8);
+        var filter = Filter.Empty().AddAllPlayers(_playerManager);
+        _globalSound.PlayAdminGlobal(filter, BluespaceStrikeComponent.ArtilleryAnnounceSound, audio);
+
+        _adminLog.Add(LogType.Action, LogImpact.Medium,
+            $"{Player} played bluespace artillery announce sound via artbs EUI");
     }
 }

--- a/Content.Server/_Polonium/BluespaceStrike/BluespaceStrikeEui.cs
+++ b/Content.Server/_Polonium/BluespaceStrike/BluespaceStrikeEui.cs
@@ -17,6 +17,7 @@ using JetBrains.Annotations;
 using Robust.Server.Player;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
+using Robust.Shared.Timing;
 
 namespace Content.Server._Polonium.BluespaceStrike;
 
@@ -30,7 +31,9 @@ public sealed class BluespaceStrikeEui : BaseEui
     private readonly ServerGlobalSoundSystem _globalSound;
     private readonly IAdminLogManager _adminLog;
     private readonly IPlayerManager _playerManager;
+    private readonly IGameTiming _timing;
     private readonly ISawmill _sawmill;
+    private TimeSpan _nextArtillerySound = TimeSpan.Zero;
 
     public BluespaceStrikeEui()
     {
@@ -42,6 +45,7 @@ public sealed class BluespaceStrikeEui : BaseEui
         _globalSound = sys.GetEntitySystem<ServerGlobalSoundSystem>();
         _adminLog = IoCManager.Resolve<IAdminLogManager>();
         _playerManager = IoCManager.Resolve<IPlayerManager>();
+        _timing = IoCManager.Resolve<IGameTiming>();
         _sawmill = IoCManager.Resolve<ILogManager>().GetSawmill("bluespace-strike");
     }
 
@@ -162,11 +166,16 @@ public sealed class BluespaceStrikeEui : BaseEui
 
     private void HandlePlayArtillerySound()
     {
+        if (_timing.CurTime < _nextArtillerySound)
+            return;
+
+        // playglobalsound <path> <volume>
         var audio = AudioParams.Default
             .WithVolume(BluespaceStrikeComponent.ArtilleryAnnounceVolume)
             .AddVolume(-8);
         var filter = Filter.Empty().AddAllPlayers(_playerManager);
         _globalSound.PlayAdminGlobal(filter, BluespaceStrikeComponent.ArtilleryAnnounceSound, audio);
+        _nextArtillerySound = _timing.CurTime + BluespaceStrikeComponent.ArtilleryAnnounceCooldown;
 
         _adminLog.Add(LogType.Action, LogImpact.Medium,
             $"{Player} played bluespace artillery announce sound via artbs EUI");

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -440,12 +440,14 @@ public abstract partial class SharedChatSystem : EntitySystem
     /// <param name="playSound">Play the announcement sound.</param>
     /// <param name="announcementSound">Sound to play.</param>
     /// <param name="colorOverride">Optional color for the announcement message.</param>
+    /// <param name="centComAnnouncement">When true and no explicit sound is given, play CentComm announcement sound.</param>
     public virtual void DispatchGlobalAnnouncement(
         string message,
         string? sender = null,
         bool playSound = true,
         SoundSpecifier? announcementSound = null,
-        Color? colorOverride = null
+        Color? colorOverride = null,
+        bool centComAnnouncement = false
         )
     { }
 

--- a/Content.Shared/_Polonium/BluespaceStrike/BluespaceStrikeComponent.cs
+++ b/Content.Shared/_Polonium/BluespaceStrike/BluespaceStrikeComponent.cs
@@ -26,6 +26,7 @@ public sealed partial class BluespaceStrikeComponent : Component
     public const string ExplosionType = "BluespaceArtillery";
     public const string ArtilleryAnnounceSound = "/Audio/_Polonium/Admeme/artyleria.ogg";
     public const float ArtilleryAnnounceVolume = 25f;
+    public static readonly TimeSpan ArtilleryAnnounceCooldown = TimeSpan.FromSeconds(20);
     public static readonly EntProtoId ControllerPrototype = "BluespaceStrikeController";
     public static readonly EntProtoId MarkerPrototype = "BluespaceStrikeMarker";
     public static readonly EntProtoId IncomingPrototype = "BluespaceStrikeIncoming";

--- a/Content.Shared/_Polonium/BluespaceStrike/BluespaceStrikeComponent.cs
+++ b/Content.Shared/_Polonium/BluespaceStrike/BluespaceStrikeComponent.cs
@@ -24,6 +24,8 @@ public sealed partial class BluespaceStrikeComponent : Component
     public const float MaxMarkerRadius = 100f;
 
     public const string ExplosionType = "BluespaceArtillery";
+    public const string ArtilleryAnnounceSound = "/Audio/_Polonium/Admeme/artyleria.ogg";
+    public const float ArtilleryAnnounceVolume = 25f;
     public static readonly EntProtoId ControllerPrototype = "BluespaceStrikeController";
     public static readonly EntProtoId MarkerPrototype = "BluespaceStrikeMarker";
     public static readonly EntProtoId IncomingPrototype = "BluespaceStrikeIncoming";

--- a/Content.Shared/_Polonium/BluespaceStrike/BluespaceStrikeEuiMsg.cs
+++ b/Content.Shared/_Polonium/BluespaceStrike/BluespaceStrikeEuiMsg.cs
@@ -57,6 +57,9 @@ public static class BluespaceStrikeEuiMsg
             ShowMarkersAndSound = showMarkersAndSound;
         }
     }
+
+    [Serializable, NetSerializable]
+    public sealed class PlayArtillerySound : EuiMessageBase;
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Locale/en-US/_Polonium/bluespace-strike.ftl
+++ b/Resources/Locale/en-US/_Polonium/bluespace-strike.ftl
@@ -8,6 +8,7 @@ admin-bluespace-strike-eui-label-markers = Markers + air-raid sound
 admin-bluespace-strike-eui-warning-not-epsilon = Warning! Alert code is not Epsilon. Make sure you know what you are doing.
 admin-bluespace-strike-eui-label-radius = Radius (max 100)
 admin-bluespace-strike-eui-label-delay = Delay (1–300 s)
+admin-bluespace-strike-eui-label-play-artillery = Play artillery sound
 admin-bluespace-strike-eui-label-confirm = Fire!
 
 cmd-artbs-desc = Opens the bluespace strike targeting UI.

--- a/Resources/Locale/pl-PL/_Polonium/bluespace-strike.ftl
+++ b/Resources/Locale/pl-PL/_Polonium/bluespace-strike.ftl
@@ -8,6 +8,7 @@ admin-bluespace-strike-eui-label-markers = Markery + syrena
 admin-bluespace-strike-eui-warning-not-epsilon = Uwaga! Kod alertu to nie Epsilon. Upewnij się, że wiesz, co robisz.
 admin-bluespace-strike-eui-label-radius = Promień (max 100)
 admin-bluespace-strike-eui-label-delay = Opóźnienie (1–300 s)
+admin-bluespace-strike-eui-label-play-artillery = Odtwórz dźwięk artylerii
 admin-bluespace-strike-eui-label-confirm = Ognia!
 
 cmd-artbs-desc = Otwiera UI celowania uderzenia bluespace.

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -345,7 +345,7 @@
     weight: 4
   - type: MeteorSwarm
     announcement: station-event-bio-swarm-start-announcement
-    announcementSound: /Audio/Announcements/attention.ogg
+    announcementSound: /Audio/_Polonium/Announcements/attention.ogg
     meteors:
       MeteorFlesh: 1
     waves:
@@ -363,7 +363,7 @@
     weight: 5
   - type: MeteorSwarm
     announcement: station-event-bio-swarm-start-announcement
-    announcementSound: /Audio/Announcements/attention.ogg
+    announcementSound: /Audio/_Polonium/Announcements/attention.ogg
     meteors:
       MeteorKudzu: 1
     waves:

--- a/Resources/Prototypes/SoundCollections/announcements.yml
+++ b/Resources/Prototypes/SoundCollections/announcements.yml
@@ -13,6 +13,7 @@
   - /Audio/Announcements/RoundEnd/apc_destroyed.ogg
   - /Audio/Announcements/RoundEnd/disappointed.ogg
   - /Audio/Announcements/RoundEnd/notevenpaidforthis.ogg
+  - /Audio/Announcements/RoundEnd/stalemate.ogg
   - /Audio/_Polonium/Announcements/RoundEnd/ale_urwal.ogg
   - /Audio/_Polonium/Announcements/RoundEnd/jestem_hardkorem.ogg
 


### PR DESCRIPTION
…iesiono niektóre ogłoszenia z `polonium-old`

<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Admini teraz mogą odtworzyć dźwięk artylerii przez zwykłe UI `artbs`. No i przeniesiono brakujące ogłoszenia ze starej gałęzi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nowe funkcje**
  * Dodano przycisk odtwarzania dźwięku artylerii w oknie Bluespace Strike.
  * Dźwięk artylerii jest odtwarzany globalnie dla wszystkich graczy i rejestrowany w logach administracyjnych.

* **Ulepszenia**
  * Powiększono okno Bluespace Strike, aby pomieścić nową akcję.
  * Komenda globalnych ogłoszeń nie odtwarza już domyślnego dźwięku, jeśli nie podano własnego.
  * Zaktualizowano dźwięki wydarzeń meteorów i zakończenia rundy.
  * Dodano angielskie i polskie tłumaczenie nowej etykiety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->