### PR TITLE
poprawiono fałszywy trigger podczas terminacji encji

### DIFF
--- a/Content.Server/LandMines/LandMineSystem.cs
+++ b/Content.Server/LandMines/LandMineSystem.cs
@@ -28,6 +28,9 @@ public sealed partial class LandMineSystem : EntitySystem
     /// </summary>
     private void HandleStepOnTriggered(EntityUid uid, LandMineComponent component, ref StepTriggeredOnEvent args)
     {
+        if (TerminatingOrDeleted(uid))
+            return;
+
         if (!string.IsNullOrEmpty(component.TriggerText))
         {
             _popupSystem.PopupCoordinates(
@@ -44,6 +47,9 @@ public sealed partial class LandMineSystem : EntitySystem
     /// </summary>
     private void HandleStepOffTriggered(EntityUid uid, LandMineComponent component, ref StepTriggeredOffEvent args)
     {
+        if (TerminatingOrDeleted(uid))
+            return;
+
         // TODO: Adjust to the new trigger system
         _trigger.Trigger(uid, args.Tripper, TriggerSystem.DefaultTriggerKey);
     }

--- a/Content.Shared/_Funkystation/Explosion/EntitySystems/SharedExplosionEffectSystem.cs
+++ b/Content.Shared/_Funkystation/Explosion/EntitySystems/SharedExplosionEffectSystem.cs
@@ -17,6 +17,10 @@ public abstract partial class SharedExplosionEffectSystem : EntitySystem
 
     private void OnExplosionEffectTriggered(Entity<ExplosionEffectComponent> ent, ref ExplosiveTriggeredEvent args)
     {
+        // avoid spawning/throwing during deletion
+        if (TerminatingOrDeleted(ent))
+            return;
+
         foreach (var effect in ent.Comp.VisualEffects)
         {
             SpawnNextToOrDrop(effect, ent);
@@ -32,7 +36,7 @@ public abstract partial class SharedExplosionEffectSystem : EntitySystem
                     var angle = _random.NextAngle();
                     var direction = angle.ToVec().Normalized() * 10;
                     var shrapnel = SpawnNextToOrDrop(effect, ent);
-                    if (Exists(shrapnel))
+                    if (Exists(shrapnel) && !TerminatingOrDeleted(shrapnel))
                     {
                         _throwing.TryThrow(shrapnel, direction, ent.Comp.ShrapnelSpeed / 10);
                     }


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
closes #779 

Problem był taki, że miny były triggerowane podczas Dispose, co powodowało wybuch i rzucanie szrapnelu z `parentUid = 0`. Dodałem sprawdzenia pod kątem `TerminatingOrDeleted`