### PR TITLE
wyczyszczanie presetu na początku TraitorRuleTest

### DIFF
--- a/Content.IntegrationTests/Tests/GameRules/TraitorRuleTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/TraitorRuleTest.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.IntegrationTests.Fixtures;
 using Content.Server.Antag.Components;
 using Content.Server.GameTicking;
+using Content.Server.GameTicking.Presets;
 using Content.Server.GameTicking.Rules;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Mind;
@@ -86,6 +87,8 @@ public sealed class TraitorRuleTest : GameTest
         TraitorRuleComponent traitorRule = null;
         await server.WaitPost(() =>
         {
+            ticker.SetGamePreset((GamePresetPrototype?) null);
+
             var gameRuleEnt = ticker.AddGameRule(TraitorGameRuleProtoId);
             Assert.That(entMan.TryGetComponent(gameRuleEnt, out traitorRule));
 


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
fix #780

To samo, co w `NukeOpsTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Testy**
  * Zaktualizowano testy reguły „Zdrajca”, aby poprawnie uruchamiały się bez domyślnego presetu gry.
  * Nie zmieniono oczekiwanych rezultatów ani logiki sprawdzanych zachowań.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->