### PR TITLE
HUD doll pokazuje stan zdrowia

### DIFF
--- a/Content.Server/_Shitmed/Targeting/TargetingSystem.cs
+++ b/Content.Server/_Shitmed/Targeting/TargetingSystem.cs
@@ -49,7 +49,7 @@ public sealed partial class TargetingSystem : SharedTargetingSystem
         }
         else if (args is { OldMobState: MobState.Dead, NewMobState: MobState.Alive or MobState.Critical })
         {
-            component.BodyStatus = _woundSystem.GetWoundableStatesOnBodyPainFeels(uid);
+            component.BodyStatus = _woundSystem.GetDamageableStatesOnBody(uid);
             changed = true;
         }
 

--- a/Content.Server/_Shitmed/Targeting/TargetingSystem.cs
+++ b/Content.Server/_Shitmed/Targeting/TargetingSystem.cs
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Maciej Walendziuk <15122746+maciejwalendziuk@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 maciejwalendziuk <15122746+maciejwalendziuk@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System;
 using Content.Shared._Shitmed.Medical.Surgery.Wounds;
 using Content.Shared._Shitmed.Medical.Surgery.Wounds.Systems;

--- a/Content.Shared/_Shitmed/Medical/Surgery/Pain/Systems/PainSystem.Damage.cs
+++ b/Content.Shared/_Shitmed/Medical/Surgery/Pain/Systems/PainSystem.Damage.cs
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Maciej Walendziuk <15122746+maciejwalendziuk@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 maciejwalendziuk <15122746+maciejwalendziuk@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;

--- a/Content.Shared/_Shitmed/Medical/Surgery/Pain/Systems/PainSystem.Damage.cs
+++ b/Content.Shared/_Shitmed/Medical/Surgery/Pain/Systems/PainSystem.Damage.cs
@@ -533,7 +533,7 @@ public partial class PainSystem
         if (!TryComp<TargetingComponent>(body, out var targeting))
             return;
 
-        targeting.BodyStatus = _wound.GetWoundableStatesOnBodyPainFeels(body);
+        targeting.BodyStatus = _wound.GetDamageableStatesOnBody(body);
         Dirty(body, targeting);
 
         if (_net.IsServer)

--- a/Content.Shared/_Shitmed/Medical/Surgery/Wounds/Systems/WoundSystem.Queries.cs
+++ b/Content.Shared/_Shitmed/Medical/Surgery/Wounds/Systems/WoundSystem.Queries.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Content.Shared._Shitmed.Body;
-using Content.Shared._Shitmed.Medical.Surgery.Pain.Components;
 using Content.Shared._Shitmed.Medical.Surgery.Wounds.Components;
 using Content.Shared._Shitmed.Targeting;
 using Content.Shared.Body;
@@ -194,68 +193,6 @@ public sealed partial class WoundSystem
                 continue;
 
             result[target] = woundable.WoundableSeverity;
-        }
-
-        return result;
-    }
-
-    /// <summary>
-    /// Same as <see cref="GetWoundableStatesOnBody"/> but each limb-organ's bucket is
-    /// re-derived from WoundableIntegrity weighted by that limb's NerveComponent.PainFeels
-    /// (1 by default, pushed up/down by tourniquets/painkillers/nerve damage via
-    /// PainSystem.TryAddPainFeelsModifier) instead of just reading the cached
-    /// WoundableSeverity directly - a numbed limb reads healthier on the doll than its actual
-    /// wound state, matching what the mob would subjectively perceive checking themselves
-    /// over, not the limb's objective condition. Organs without a NerveComponent (shouldn't
-    /// normally happen for a woundable limb, but not asserted) fall back to the unweighted
-    /// WoundableSeverity.
-    /// </summary>
-    public Dictionary<TargetBodyPart, WoundableSeverity> GetWoundableStatesOnBodyPainFeels(EntityUid mob)
-    {
-        var result = new Dictionary<TargetBodyPart, WoundableSeverity>();
-
-        foreach (var part in SharedTargetingSystem.GetValidParts())
-        {
-            result[part] = WoundableSeverity.Severed;
-        }
-
-        if (!TryComp<BodyComponent>(mob, out var body) || body.Organs is null)
-            return result;
-
-        foreach (var organ in body.Organs.ContainedEntities)
-        {
-            if (!TryComp<OrganComponent>(organ, out var organComp)
-                || organComp.Category is not { } category
-                || !LimbTargetMap.TryGetTarget(category, out var target)
-                || !TryComp<WoundableComponent>(organ, out var woundable))
-                continue;
-
-            if (!TryComp<NerveComponent>(organ, out var nerve))
-            {
-                result[target] = woundable.WoundableSeverity;
-                continue;
-            }
-
-            var damageFeeling = woundable.WoundableIntegrity * nerve.PainFeels;
-            var severity = woundable.WoundableSeverity;
-
-            if (damageFeeling >= woundable.IntegrityCap)
-            {
-                severity = WoundableSeverity.Healthy;
-            }
-            else if (woundable.SortedThresholds is { } sorted)
-            {
-                foreach (var (candidate, threshold) in sorted)
-                {
-                    if (candidate == WoundableSeverity.Severed)
-                        continue;
-
-                    if (damageFeeling <= threshold)
-                        severity = candidate;
-                }
-            }
-
-            result[target] = severity;
         }
 
         return result;

--- a/Content.Shared/_Shitmed/Medical/Surgery/Wounds/Systems/WoundSystem.Queries.cs
+++ b/Content.Shared/_Shitmed/Medical/Surgery/Wounds/Systems/WoundSystem.Queries.cs
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Maciej Walendziuk <15122746+maciejwalendziuk@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 maciejwalendziuk <15122746+maciejwalendziuk@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Linq;
 using Content.Shared._Shitmed.Body;
 using Content.Shared._Shitmed.Medical.Surgery.Wounds.Components;

--- a/Content.Shared/_Shitmed/Medical/Surgery/Wounds/Systems/WoundSystem.Severity.cs
+++ b/Content.Shared/_Shitmed/Medical/Surgery/Wounds/Systems/WoundSystem.Severity.cs
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Maciej Walendziuk <15122746+maciejwalendziuk@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 maciejwalendziuk <15122746+maciejwalendziuk@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Linq;
 using Content.Shared._Shitmed.Medical.Surgery.Traumas.Components;
 using Content.Shared._Shitmed.Medical.Surgery.Traumas.Systems;

--- a/Content.Shared/_Shitmed/Medical/Surgery/Wounds/Systems/WoundSystem.Severity.cs
+++ b/Content.Shared/_Shitmed/Medical/Surgery/Wounds/Systems/WoundSystem.Severity.cs
@@ -253,9 +253,8 @@ public sealed partial class WoundSystem
     /// <summary>
     /// Pushes this limb's severity into the owning mob's TargetingComponent.BodyStatus and
     /// notifies the client to refresh the targeting/health-analyzer UI. Uses
-    /// GetWoundableStatesOnBodyPainFeels rather than the plain GetWoundableStatesOnBody -
-    /// BodyStatus feeds the PartStatus doll HUD widget, which is meant to show what the mob
-    /// itself perceives (pain-feels-weighted), not raw wound state.
+    /// GetDamageableStatesOnBody - the same proc the health analyzer's doll reads - so the
+    /// PartStatus doll HUD widget always matches the analyzer.
     /// </summary>
     private void SyncTargetingBodyStatus(EntityUid woundable)
     {
@@ -265,7 +264,7 @@ public sealed partial class WoundSystem
         if (!TryComp<TargetingComponent>(body, out var targeting))
             return;
 
-        targeting.BodyStatus = GetWoundableStatesOnBodyPainFeels(body);
+        targeting.BodyStatus = GetDamageableStatesOnBody(body);
         Dirty(body, targeting);
 
         RaiseNetworkEvent(new TargetIntegrityChangeEvent(GetNetEntity(body)), body);


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Laleczka na HUDzie pokazuje teraz rzeczywisty stan zdrowia zamiast bólu (tak jak było przed rebase).

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
Wprowadzało to niepotrzebne zamieszanie (lalka pokazuje, że cie boli a gracz myśli, że jest połamany albo mocno obity).

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
Zastąpienie metod sprawdzających ból sprawdzającymi zdrowie (jak w health analyzerze).

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->
<img width="902" height="261" alt="image" src="https://github.com/user-attachments/assets/0cfbafe7-d51c-40bd-a5ef-3f3558f42a98" />


---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: haze
- tweak: HUD doll pokazuje stan zdrowia zamiast bólu.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Ulepszenia**
  * Ujednolicono prezentowanie statusu uszkodzeń ciała z informacjami używanymi przez analizator zdrowia i HUD.
  * Statusy obrażeń są teraz aktualizowane spójnie po zmianie stanu postaci, w tym po wskrzeszeniu lub przejściu w stan krytyczny.
  * Informacje o integralności ciała lepiej odzwierciedlają rzeczywisty poziom uszkodzeń, niezależnie od odczuwania bólu.

* **Porządki**
  * Usunięto nieużywaną metodę odpowiedzialną za wcześniejsze wyliczanie statusów na podstawie odczuwania bólu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->