### PR TITLE
Poprawiono usuwanie nieistniejącego layeru sprite'a

### DIFF
--- a/Content.Client/_Funkystation/Stains/StainSystem.cs
+++ b/Content.Client/_Funkystation/Stains/StainSystem.cs
@@ -32,21 +32,18 @@ public sealed partial class StainSystem : SharedStainSystem
 
         var spriteEnt = new Entity<SpriteComponent?>(ent.Owner, args.Sprite);
 
-        var layers = new List<int>(ent.Comp.RevealedLayers);
-        layers.Sort((a, b) => b.CompareTo(a));
-
-        foreach (var layer in layers)
+        foreach (var key in ent.Comp.RevealedLayers)
         {
-            _sprite.RemoveLayer(spriteEnt, layer);
+            _sprite.RemoveLayer(spriteEnt, key, logMissing: false);
         }
 
         ent.Comp.RevealedLayers.Clear();
 
-        foreach (var (_, layerData) in BuildVisuals(ent, ent.Comp.IconVisuals, "icon"))
+        foreach (var (key, layerData) in BuildVisuals(ent, ent.Comp.IconVisuals, "icon"))
         {
-#pragma warning disable CS0618
-            ent.Comp.RevealedLayers.Add(args.Sprite.AddLayer(layerData));
-#pragma warning restore CS0618
+            var index = _sprite.AddLayer(spriteEnt, layerData, null);
+            _sprite.LayerMapSet(spriteEnt, key, index);
+            ent.Comp.RevealedLayers.Add(key);
         }
     }
 

--- a/Content.Shared/_Funkystation/Stains/Components/StainableComponent.cs
+++ b/Content.Shared/_Funkystation/Stains/Components/StainableComponent.cs
@@ -30,7 +30,7 @@ public sealed partial class StainableComponent : Component
     public List<PrototypeLayerData> IconVisuals = new();
 
     [ViewVariables]
-    public HashSet<int> RevealedLayers = new();
+    public HashSet<string> RevealedLayers = new();
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Problem był że `StainSystem` trzymał indeksy warstw, chameleon przebudowuje sprite i indeks `1` przestaje istnieć. Więc teraz przechowujemy nie indeksy, a klucze string - usuwamy po kluczach i z nowym `logMissing: false`

https://github.com/polonium14/polonium-station/issues/786#issuecomment-5050509041
