### PR TITLE
lepsze firelocki

### DIFF
--- a/Content.Client/_Funkystation/FirelockBolt/EntitySystems/FirelockBoltControlSystem.cs
+++ b/Content.Client/_Funkystation/FirelockBolt/EntitySystems/FirelockBoltControlSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared._Funkystation.FirelockBolt.EntitySystems;
 
 namespace Content.Client._Funkystation.FirelockBolt.EntitySystems;

--- a/Content.Client/_Funkystation/FirelockBolt/EntitySystems/FirelockBoltControlSystem.cs
+++ b/Content.Client/_Funkystation/FirelockBolt/EntitySystems/FirelockBoltControlSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared._Funkystation.FirelockBolt.EntitySystems;
+
+namespace Content.Client._Funkystation.FirelockBolt.EntitySystems;
+
+public sealed class FirelockBoltControlSystem : SharedFirelockBoltControlSystem;

--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -117,13 +117,13 @@ namespace Content.Server.Doors.Systems
                     // Funky change
                     if (door.State == DoorState.Open)
                     {
+                        // Set before close so firelock bolts as soon as it finishes closing
+                        firelock.Pressure = pressure;
+                        firelock.Temperature = fire;
+                        Dirty(uid, firelock);
+
                         if (pressure || fire)
                         {
-                            // Set before close so firelock bolts as soon as it finishes closing
-                            firelock.Pressure = pressure;
-                            firelock.Temperature = fire;
-                            Dirty(uid, firelock);
-                            
                             EmergencyPressureStop(uid, firelock, door);
                         }
                     }

--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -4,6 +4,8 @@ using Content.Server.Atmos.Monitor.Components;
 using Content.Server.Atmos.Monitor.Systems;
 using Content.Server.Power.EntitySystems;
 using Content.Server.Shuttles.Components;
+using Content.Server._Funkystation.FirelockBolt.EntitySystems;
+using Content.Shared._Funkystation.FirelockBolt.Components;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Atmos.Monitor;
@@ -22,11 +24,13 @@ namespace Content.Server.Doors.Systems
         [Dependency] private SharedAppearanceSystem _appearance = default!;
         [Dependency] private SharedMapSystem _mapping = default!;
         [Dependency] private PointLightSystem _pointLight = default!;
+        [Dependency] private FirelockBoltControlSystem _firelockBolts = default!;
 
         [Dependency] private EntityQuery<AtmosAlarmableComponent> _atmosAlarmQuery = default!;
         [Dependency] private EntityQuery<AirtightComponent> _airtightQuery = default!;
         [Dependency] private EntityQuery<AppearanceComponent> _appearanceQuery = default!;
         [Dependency] private EntityQuery<PointLightComponent> _pointLightQuery = default!;
+        [Dependency] private EntityQuery<FirelockBoltControlComponent> _boltControlQuery = default!;
 
         private const int UpdateInterval = 30;
         private int _accumulatedTicks;
@@ -77,19 +81,23 @@ namespace Content.Server.Doors.Systems
                 if (_airtightQuery.TryGetComponent(uid, out var airtight)
                     && _appearanceQuery.TryGetComponent(uid, out var appearance))
                 {
-                    var (pressure, fire) = CheckPressureAndFire(uid, firelock, airtight);
+                    var (pressure, fire) = CheckPressureAndFire(uid, firelock, airtight, door.State == DoorState.Open); // open firelocks arent AirBlocked so we have to opt into the pressure check
 
                     // Funky change
                     if (door.State == DoorState.Open)
                     {
                         if (pressure || fire)
                         {
+                            // Set before close so firelock bolts as soon as it finishes closing
+                            firelock.Pressure = pressure;
+                            firelock.Temperature = fire;
+                            Dirty(uid, firelock);
+                            
                             EmergencyPressureStop(uid, firelock, door);
                         }
                     }
                     else
                     {
-
                         _appearance.SetData(uid, DoorVisuals.ClosedLights, fire || pressure, appearance);
                         firelock.Temperature = fire;
                         firelock.Pressure = pressure;
@@ -101,6 +109,9 @@ namespace Content.Server.Doors.Systems
                         {
                             _pointLight.SetEnabled(uid, fire | pressure, pointLight);
                         }
+
+                        if (_boltControlQuery.TryComp(uid, out var boltControl))
+                            _firelockBolts.UpdateHazardBolts((uid, boltControl), firelock, door);
                     }
                 }
             }

--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -23,6 +23,7 @@
 // SPDX-FileCopyrightText: 2026 MaiaArai <158123176+YaraaraY@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2026 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
 // SPDX-FileCopyrightText: 2026 Princess Cheeseballs <66055347+Princess-Cheeseballs@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2026 taydeo <tay@funkystation.org>
 // SPDX-FileCopyrightText: 2026 taydeo <td12233a@gmail.com>

--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -1,3 +1,34 @@
+// SPDX-FileCopyrightText: 2022 Flipp Syder <76629141+vulppine@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2022 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2022 Moony <moony@hellomouse.net>
+// SPDX-FileCopyrightText: 2022 Paul Ritter <ritter.paul1@googlemail.com>
+// SPDX-FileCopyrightText: 2022 Vera Aguilera Puerto <6766154+Zumorica@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2022 corentt <36075110+corentt@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2022 mirrorcult <lunarautomaton6@gmail.com>
+// SPDX-FileCopyrightText: 2022 moonheart08 <moonheart08@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2022 vulppine <vulppine@gmail.com>
+// SPDX-FileCopyrightText: 2022 wrexbe <81056464+wrexbe@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 Theomund <34360334+Theomund@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 Tom Leys <tom@crump-leys.com>
+// SPDX-FileCopyrightText: 2023 Visne <39844191+Visne@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 metalgearsloth <comedian_vs_clown@hotmail.com>
+// SPDX-FileCopyrightText: 2024 Cojoke <83733158+Cojoke-dot@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 Partmedia <kevinz5000@gmail.com>
+// SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 nikthechampiongr <32041239+nikthechampiongr@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 ShadowCommander <10494922+ShadowCommander@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 Dmitry <57028746+DIMMoon1@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 Eveloop <26272940+eveloop@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 MaiaArai <158123176+YaraaraY@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+// SPDX-FileCopyrightText: 2026 Princess Cheeseballs <66055347+Princess-Cheeseballs@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 taydeo <tay@funkystation.org>
+// SPDX-FileCopyrightText: 2026 taydeo <td12233a@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Monitor.Components;

--- a/Content.Server/_Funkystation/FirelockBolt/EntitySystems/FirelockBoltControlSystem.cs
+++ b/Content.Server/_Funkystation/FirelockBolt/EntitySystems/FirelockBoltControlSystem.cs
@@ -3,7 +3,6 @@ using Content.Server.Doors.Systems;
 using Content.Shared._Funkystation.FirelockBolt.Components;
 using Content.Shared._Funkystation.FirelockBolt.EntitySystems;
 using Content.Shared.Atmos.Monitor;
-using Content.Shared.Doors.Components;
 
 namespace Content.Server._Funkystation.FirelockBolt.EntitySystems;
 
@@ -18,27 +17,12 @@ public sealed partial class FirelockBoltControlSystem : SharedFirelockBoltContro
 
     private void OnAtmosAlarm(EntityUid uid, FirelockBoltControlComponent component, AtmosAlarmEvent args)
     {
-        component.AlarmActive = args.AlarmType != AtmosAlarmType.Normal;
+        component.AlarmActive = args.AlarmType == AtmosAlarmType.Danger;
         Dirty(uid, component);
 
-        if (component.Override)
-            return;
-
-        if (component.AlarmActive)
-        {
-            // If an alarm is triggered and the door is closed, bolt
-            if (DoorQuery.TryComp(uid, out var door) && (door.State == DoorState.Closed || door.State == DoorState.Welded))
-            {
-                if (DoorBoltQuery.TryComp(uid, out var bolt))
-                    DoorSystem.SetBoltsDown((uid, bolt), true);
-            }
-        }
-        else
-        {
-            // If the alarm clears, unbolt
-            if (DoorBoltQuery.TryComp(uid, out var bolt))
-                DoorSystem.SetBoltsDown((uid, bolt), false);
-        }
+        // bolt/unbolt immediately when air alarm (or fire alarm) status changes
+        if (!component.Override)
+            UpdateHazardBolts((uid, component));
 
         PushState((uid, component));
     }

--- a/Content.Server/_Funkystation/FirelockBolt/EntitySystems/FirelockBoltControlSystem.cs
+++ b/Content.Server/_Funkystation/FirelockBolt/EntitySystems/FirelockBoltControlSystem.cs
@@ -1,4 +1,9 @@
-﻿using Content.Server.Atmos.Monitor.Systems;
+// SPDX-FileCopyrightText: 2026 MaiaArai <158123176+YaraaraY@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Server.Atmos.Monitor.Systems;
 using Content.Server.Doors.Systems;
 using Content.Shared._Funkystation.FirelockBolt.Components;
 using Content.Shared._Funkystation.FirelockBolt.EntitySystems;

--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -67,6 +67,12 @@ public abstract partial class SharedFirelockSystem : EntitySystem
         if (args.Cancelled || !component.Powered || args.StrongPry || args.PryPowered)
             return;
 
+        if (component.IsLocked)
+            return;
+
+        if (TryComp<DoorBoltComponent>(uid, out var bolt) && bolt.BoltsDown)
+            return;
+
         args.Cancelled = true;
     }
 

--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -1,3 +1,13 @@
+// SPDX-FileCopyrightText: 2024 nikthechampiongr <32041239+nikthechampiongr@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 ShadowCommander <10494922+ShadowCommander@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+// SPDX-FileCopyrightText: 2026 Whatstone <166147148+whatston3@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 taydeo <tay@funkystation.org>
+// SPDX-FileCopyrightText: 2026 taydeo <td12233a@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared.Access.Systems;
 using Content.Shared.Doors.Components;
 using Content.Shared.Examine;

--- a/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
+++ b/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
@@ -1,3 +1,5 @@
+using Content.Shared._Funkystation.FirelockBolt.Components;
+using Content.Shared._Funkystation.FirelockBolt.EntitySystems;
 using Content.Shared.Access.Components;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
@@ -27,6 +29,7 @@ public abstract partial class SharedDoorRemoteSystem : EntitySystem
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private TagSystem _tagSystem = default!;
+    [Dependency] private SharedFirelockBoltControlSystem _firelockBolts = default!;
     [Dependency] protected IGameTiming Timing = default!;
 
 
@@ -109,10 +112,23 @@ public abstract partial class SharedDoorRemoteSystem : EntitySystem
                 {
                     if (!boltsComp.BoltWireCut)
                     {
-                        _doorSystem.SetBoltsDown((args.Target.Value, boltsComp), !boltsComp.BoltsDown, user: args.User, predicted: true);
+                        var willBolt = !boltsComp.BoltsDown;
+
+                        if (TryComp<FirelockBoltControlComponent>(args.Target, out var firelockBolts))
+                        {
+                            _firelockBolts.SetOverride((args.Target.Value, firelockBolts), !willBolt, playSound: false);
+                            
+                            if (willBolt)
+                                _doorSystem.SetBoltsDown((args.Target.Value, boltsComp), true, user: args.User, predicted: true);
+                        }
+                        else
+                        {
+                            _doorSystem.SetBoltsDown((args.Target.Value, boltsComp), willBolt, user: args.User, predicted: true);
+                        }
+
                         _adminLogger.Add(LogType.Action,
                             LogImpact.Medium,
-                            $"{ToPrettyString(args.User):player} used {ToPrettyString(args.Used)} on {ToPrettyString(args.Target.Value)} to {(boltsComp.BoltsDown ? "" : "un")}bolt it");
+                            $"{ToPrettyString(args.User):player} used {ToPrettyString(args.Used)} on {ToPrettyString(args.Target.Value)} to {(willBolt ? "" : "un")}bolt it");
                     }
                 }
 

--- a/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
+++ b/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
@@ -1,3 +1,17 @@
+// SPDX-FileCopyrightText: 2024 Jake Huxell <JakeHuxell@pm.me>
+// SPDX-FileCopyrightText: 2024 Plykiya <58439124+Plykiya@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Fildrance <fildrance@gmail.com>
+// SPDX-FileCopyrightText: 2025 Samuka <47865393+Samuka-C@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+// SPDX-FileCopyrightText: 2026 Velken <8467292+Velken@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 Whatstone <166147148+whatston3@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 lunarcomets <140772713+lunarcomets@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 taydeo <tay@funkystation.org>
+// SPDX-FileCopyrightText: 2026 taydeo <td12233a@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared._Funkystation.FirelockBolt.Components;
 using Content.Shared._Funkystation.FirelockBolt.EntitySystems;
 using Content.Shared.Access.Components;

--- a/Content.Shared/_Funkystation/FirelockBolt/EntitySystems/SharedFirelockBoltControlSystem.cs
+++ b/Content.Shared/_Funkystation/FirelockBolt/EntitySystems/SharedFirelockBoltControlSystem.cs
@@ -1,4 +1,9 @@
-﻿using Content.Shared._Funkystation.FirelockBolt.Components;
+// SPDX-FileCopyrightText: 2026 MaiaArai <158123176+YaraaraY@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared._Funkystation.FirelockBolt.Components;
 using Content.Shared.DoAfter;
 using Content.Shared.Doors;
 using Content.Shared.Doors.Components;

--- a/Content.Shared/_Funkystation/FirelockBolt/EntitySystems/SharedFirelockBoltControlSystem.cs
+++ b/Content.Shared/_Funkystation/FirelockBolt/EntitySystems/SharedFirelockBoltControlSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Doors;
 using Content.Shared.Doors.Components;
 using Content.Shared.Doors.Systems;
 using Content.Shared.Interaction;
+using Content.Shared.Prying.Components;
 using Content.Shared.Verbs;
 using Content.Shared.Wires;
 using Robust.Shared.Audio.Systems;
@@ -21,6 +22,7 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
     [Dependency] private IGameTiming _timing = null!;
     [Dependency] protected EntityQuery<DoorBoltComponent> DoorBoltQuery = default!;
     [Dependency] protected EntityQuery<DoorComponent> DoorQuery = default!;
+    [Dependency] private EntityQuery<FirelockComponent> _firelockQuery;
     [Dependency] private EntityQuery<WiresPanelComponent> _wiresPanelQuery;
 
     public override void Initialize()
@@ -35,6 +37,10 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
         SubscribeLocalEvent<FirelockBoltControlComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
         SubscribeLocalEvent<FirelockBoltControlComponent, BoundUIOpenedEvent>(OnBuiOpened);
         SubscribeLocalEvent<FirelockBoltControlComponent, FirelockOverrideSetMessage>(OnOverrideSetMessage);
+        // after DoorBolt so crowbar can still get through hazard bolts
+        SubscribeLocalEvent<FirelockBoltControlComponent, BeforePryEvent>(OnBeforePry, after: new[] { typeof(SharedDoorSystem) });
+
+        SubscribeLocalEvent<FirelockBoltControlComponent, PriedEvent>(OnPried, before: new[] { typeof(SharedDoorSystem) });
     }
 
     private void OnDoorStateChanged(Entity<FirelockBoltControlComponent> ent, ref DoorStateChangedEvent args)
@@ -134,6 +140,25 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
         SetOverride(ent, args.TargetOverride);
     }
 
+    private void OnBeforePry(Entity<FirelockBoltControlComponent> ent, ref BeforePryEvent args)
+    {
+        if (!args.Cancelled || ent.Comp.Override)
+            return;
+
+        if (!DoorBoltQuery.TryComp(ent.Owner, out var bolt) || !bolt.BoltsDown)
+            return;
+
+        args.Cancelled = false;
+        args.Message = null;
+    }
+
+    private void OnPried(Entity<FirelockBoltControlComponent> ent, ref PriedEvent args)
+    {
+        // drop bolts before StartOpening runs
+        if (DoorBoltQuery.TryComp(ent.Owner, out var bolt) && bolt.BoltsDown)
+            DoorSystem.SetBoltsDown((ent.Owner, bolt), false, args.User, predicted: true);
+    }
+
     private void ApplyBoltForDoorState(Entity<FirelockBoltControlComponent> ent, DoorState state)
     {
         if (ent.Comp.Override || !DoorBoltQuery.TryComp(ent.Owner, out var bolt))
@@ -142,25 +167,54 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
         switch (state)
         {
             case DoorState.Closing:
-                // if the door starts closing within 1.5 seconds of a player clicking it, it's a manual close, don't bolt
                 ent.Comp.IsManualClose = (_timing.CurTime - ent.Comp.LastManualInteractionTime) < TimeSpan.FromSeconds(1.5);
                 break;
 
             case DoorState.Closed:
             case DoorState.Welded:
-                // bolt shut if it was automatically closed
-                if (ent.Comp.AlarmActive || !ent.Comp.IsManualClose)
-                    DoorSystem.SetBoltsDown((ent.Owner, bolt), true, predicted: true);
+
+                UpdateHazardBolts(ent);
+
                 break;
 
             case DoorState.Open:
                 DoorSystem.SetBoltsDown((ent.Owner, bolt), false, predicted: true);
+
                 ent.Comp.IsManualClose = false;
+
                 break;
         }
     }
 
-    private void SetOverride(Entity<FirelockBoltControlComponent> ent, bool value)
+    public void UpdateHazardBolts(Entity<FirelockBoltControlComponent> ent, FirelockComponent? firelock = null, DoorComponent? door = null)
+    {
+        if (ent.Comp.Override)
+            return;
+
+        if (firelock == null && !_firelockQuery.TryComp(ent.Owner, out firelock))
+            return;
+
+        if (door == null && !DoorQuery.TryComp(ent.Owner, out door))
+            return;
+
+        if (!DoorBoltQuery.TryComp(ent.Owner, out var bolt))
+            return;
+
+        var shouldBolt = (door.State == DoorState.Closed || door.State == DoorState.Welded)
+            && (ent.Comp.AlarmActive || firelock.IsLocked);
+
+        if (bolt.BoltsDown == shouldBolt)
+            return;
+
+        DoorSystem.SetBoltsDown((ent.Owner, bolt), shouldBolt, predicted: true);
+        
+        PushState(ent);
+    }
+
+    /// <summary>
+    /// While on, hazard wont rebolt this door
+    /// </summary>
+    public void SetOverride(Entity<FirelockBoltControlComponent> ent, bool value, bool playSound = true)
     {
         if (ent.Comp.Override == value)
             return;
@@ -168,17 +222,20 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
         ent.Comp.Override = value;
         Dirty(ent, ent.Comp);
 
-        var sound = value ? ent.Comp.EnableSound : ent.Comp.DisableSound;
-        _audio.PlayPvs(sound, ent.Owner);
+        if (playSound)
+        {
+            var sound = value ? ent.Comp.EnableSound : ent.Comp.DisableSound;
+            _audio.PlayPvs(sound, ent.Owner);
+        }
 
         if (value)
         {
             if (DoorBoltQuery.TryComp(ent.Owner, out var bolt))
                 DoorSystem.SetBoltsDown((ent.Owner, bolt), false);
         }
-        else if (DoorQuery.TryComp(ent.Owner, out var door))
+        else
         {
-            ApplyBoltForDoorState(ent, door.State);
+            UpdateHazardBolts(ent);
         }
 
         PushState(ent);

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -284,6 +284,7 @@
   - type: Tag
     tags:
     - ForceNoFixRotations # Prevent fixrotations from targeting these, since the base Firelock is targeted
+    - DoorRemoteWhitelist
   - type: Door
     occludes: false
   - type: Physics

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -31,6 +31,7 @@
   - type: Tag
     tags:
     - ForceFixRotations # Allow fixrotations to target these
+    - DoorRemoteWhitelist # Polonium: allow remotes to interact with firelocks
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -1,3 +1,59 @@
+# SPDX-FileCopyrightText: 2020 Git-Nivrak <59925169+Git-Nivrak@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2020 Paul Ritter <ritter.paul1@googlemail.com>
+# SPDX-FileCopyrightText: 2020 Víctor Aguilera Puerto <zddm@outlook.es>
+# SPDX-FileCopyrightText: 2021 Galactic Chimp <GalacticChimpanzee@gmail.com>
+# SPDX-FileCopyrightText: 2021 Kara D <lunarautomaton6@gmail.com>
+# SPDX-FileCopyrightText: 2021 Kara Dinyes <lunarautomaton6@gmail.com>
+# SPDX-FileCopyrightText: 2021 Paul <ritter.paul1+git@googlemail.com>
+# SPDX-FileCopyrightText: 2021 Peptide90 <78795277+Peptide90@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+# SPDX-FileCopyrightText: 2021 Silver <silvertorch5@gmail.com>
+# SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
+# SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto <zddm@outlook.es>
+# SPDX-FileCopyrightText: 2021 metalgearsloth <comedian_vs_clown@hotmail.com>
+# SPDX-FileCopyrightText: 2021 tmtmtl30 <53132901+tmtmtl30@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 Alex Evgrashin <aevgrashin@yandex.ru>
+# SPDX-FileCopyrightText: 2022 Andreas Kämper <andreas@kaemper.tech>
+# SPDX-FileCopyrightText: 2022 CrudeWax <75271456+CrudeWax@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 Flipp Syder <76629141+vulppine@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 Jacob Tong <10494922+ShadowCommander@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 Julian Giebel <juliangiebel@live.de>
+# SPDX-FileCopyrightText: 2022 Vera Aguilera Puerto <6766154+Zumorica@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 Visne <39844191+Visne@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 WlarusFromDaSpace <44726328+WlarusFromDaSpace@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 keronshb <54602815+keronshb@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 mirrorcult <lunarautomaton6@gmail.com>
+# SPDX-FileCopyrightText: 2022 themias <89101928+themias@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 vulppine <vulppine@gmail.com>
+# SPDX-FileCopyrightText: 2023 Chase Maguire <32408355+Wirdal@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Morb <14136326+Morb0@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 TemporalOroboros <TemporalOroboros@gmail.com>
+# SPDX-FileCopyrightText: 2023 Tom Leys <tom@crump-leys.com>
+# SPDX-FileCopyrightText: 2023 deltanedas <39013340+deltanedas@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 lzk <124214523+lzk228@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Ilya246 <57039557+Ilya246@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Tayrtahn <tayrtahn@gmail.com>
+# SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 nikthechampiongr <32041239+nikthechampiongr@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 osjarw <62134478+osjarw@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 ArtisticRoomba <145879011+ArtisticRoomba@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 ShadowCommander <10494922+ShadowCommander@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Southbridge <7013162+southbridge-fur@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 chromiumboy <50505512+chromiumboy@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 MaiaArai <158123176+YaraaraY@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Steve <marlumpy@gmail.com>
+# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 pathetic meowmeow <uhhadd@gmail.com>
+# SPDX-FileCopyrightText: 2026 taydeo <tay@funkystation.org>
+# SPDX-FileCopyrightText: 2026 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 āda <ss.adasts@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   id: BaseFirelock
   abstract: true

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -46,6 +46,7 @@
 # SPDX-FileCopyrightText: 2025 chromiumboy <50505512+chromiumboy@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 MaiaArai <158123176+YaraaraY@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 Steve <marlumpy@gmail.com>
+# SPDX-FileCopyrightText: 2026 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 pathetic meowmeow <uhhadd@gmail.com>
 # SPDX-FileCopyrightText: 2026 taydeo <tay@funkystation.org>


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Śluzy przeciwpożarowe są teraz fajne!

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
:cl: nikita
- tweak: śluzy przeciwpożarowe teraz są boltowane natychmiastowo po zgłoszeniu niebezpieczeństwa przez AirAlarm / AtmosAlarm
- tweak: zaboltowane śluzy przeciwpożarowe teraz da się otworzyć za pomocą łomu lub jaws of life - boltują się ponownie po 2 sekundach
- tweak: zaboltowanymi śluzami przeciwpożarowymi teraz da się sterować za pomocą pilotu 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nowe funkcje**
  - Firelocki reagują na alarmy zagrożenia, blokując lub odblokowując rygle zgodnie ze stanem drzwi.
  - Zdalne sterowanie ryglami firelocków obsługuje blokady i wyjątki.
  - Firelocki mogą być zdalnie obsługiwane za pomocą odpowiednich pilotów.

- **Poprawki**
  - Ulepszono obsługę ciśnienia i temperatury w otwartych firelockach.
  - Podważanie drzwi jest prawidłowo obsługiwane przy aktywnych blokadach i ryglach.
  - Po podważeniu drzwi rygle są automatycznie zwalniane.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->