### PR TITLE
Ulepszenia do zachowania śluz przeciwpożarowych przy braku zasilania …

### DIFF
--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -79,6 +79,10 @@ namespace Content.Server.Doors.Systems
         {
             component.Powered = args.Powered;
             Dirty(uid, component);
+
+            // drop bolts when power dies, reevaluate when it comes back
+            if (_boltControlQuery.TryComp(uid, out var boltControl))
+                _firelockBolts.UpdateHazardBolts((uid, boltControl), component);
         }
 
         public override void Update(float frameTime)
@@ -93,9 +97,9 @@ namespace Content.Server.Doors.Systems
             var query = EntityQueryEnumerator<FirelockComponent, DoorComponent>();
             while (query.MoveNext(out var uid, out var firelock, out var door))
             {
+                // reclose on Danger even without power - bolts still need power
                 if (_atmosAlarmQuery.TryComp(uid, out var alarmable)
                     && alarmable.LastAlarmState == AtmosAlarmType.Danger
-                    && this.IsPowered(uid, EntityManager)
                     && door.State == DoorState.Open)
                 {
                     EmergencyPressureStop(uid, firelock, door);
@@ -151,19 +155,21 @@ namespace Content.Server.Doors.Systems
 
         private void OnAtmosAlarm(EntityUid uid, FirelockComponent component, AtmosAlarmEvent args)
         {
-            if (!this.IsPowered(uid, EntityManager))
-                return;
-
             if (!TryComp<DoorComponent>(uid, out var doorComponent))
                 return;
 
             if (args.AlarmType == AtmosAlarmType.Normal)
             {
+                // opening still needs power
+                if (!this.IsPowered(uid, EntityManager))
+                    return;
+
                 if (doorComponent.State == DoorState.Closed)
                     _doorSystem.TryOpen(uid);
             }
             else if (args.AlarmType == AtmosAlarmType.Danger)
             {
+                // close even when unpowered
                 EmergencyPressureStop(uid, component, doorComponent);
             }
         }

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.Bolts.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.Bolts.cs
@@ -75,19 +75,20 @@ public abstract partial class SharedDoorSystem
         UpdateBoltLightStatus(ent);
     }
 
-    public void SetBoltsDown(Entity<DoorBoltComponent> ent, bool value, EntityUid? user = null, bool predicted = false)
+    public void SetBoltsDown(Entity<DoorBoltComponent> ent, bool value, EntityUid? user = null, bool predicted = false, bool force = false)
     {
-        TrySetBoltDown(ent, value, user, predicted);
+        TrySetBoltDown(ent, value, user, predicted, force);
     }
 
     public bool TrySetBoltDown(
         Entity<DoorBoltComponent> ent,
         bool value,
         EntityUid? user = null,
-        bool predicted = false
+        bool predicted = false,
+        bool force = false
     )
     {
-        if (!_powerReceiver.IsPowered(ent.Owner))
+        if (!force && !_powerReceiver.IsPowered(ent.Owner))
             return false;
         if (ent.Comp.BoltsDown == value)
             return false;

--- a/Content.Shared/_Funkystation/FirelockBolt/EntitySystems/SharedFirelockBoltControlSystem.cs
+++ b/Content.Shared/_Funkystation/FirelockBolt/EntitySystems/SharedFirelockBoltControlSystem.cs
@@ -159,9 +159,9 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
 
     private void OnPried(Entity<FirelockBoltControlComponent> ent, ref PriedEvent args)
     {
-        // drop bolts before StartOpening runs
+        // drop bolts before StartOpening, even when unpowered
         if (DoorBoltQuery.TryComp(ent.Owner, out var bolt) && bolt.BoltsDown)
-            DoorSystem.SetBoltsDown((ent.Owner, bolt), false, args.User, predicted: true);
+            DoorSystem.SetBoltsDown((ent.Owner, bolt), false, args.User, predicted: true, force: true);
     }
 
     private void ApplyBoltForDoorState(Entity<FirelockBoltControlComponent> ent, DoorState state)
@@ -177,16 +177,12 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
 
             case DoorState.Closed:
             case DoorState.Welded:
-
                 UpdateHazardBolts(ent);
-
                 break;
 
             case DoorState.Open:
-                DoorSystem.SetBoltsDown((ent.Owner, bolt), false, predicted: true);
-
+                DoorSystem.SetBoltsDown((ent.Owner, bolt), false, predicted: true, force: true);
                 ent.Comp.IsManualClose = false;
-
                 break;
         }
     }
@@ -205,14 +201,14 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
         if (!DoorBoltQuery.TryComp(ent.Owner, out var bolt))
             return;
 
-        var shouldBolt = (door.State == DoorState.Closed || door.State == DoorState.Welded)
+        var shouldBolt = firelock.Powered
+            && (door.State == DoorState.Closed || door.State == DoorState.Welded)
             && (ent.Comp.AlarmActive || firelock.IsLocked);
 
         if (bolt.BoltsDown == shouldBolt)
             return;
 
-        DoorSystem.SetBoltsDown((ent.Owner, bolt), shouldBolt, predicted: true);
-        
+        DoorSystem.SetBoltsDown((ent.Owner, bolt), shouldBolt, predicted: true, force: !shouldBolt);
         PushState(ent);
     }
 
@@ -236,7 +232,7 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
         if (value)
         {
             if (DoorBoltQuery.TryComp(ent.Owner, out var bolt))
-                DoorSystem.SetBoltsDown((ent.Owner, bolt), false);
+                DoorSystem.SetBoltsDown((ent.Owner, bolt), false, force: true);
         }
         else
         {


### PR DESCRIPTION
…i predykcji

<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Dopełnienie #810. Zapomniałem uwzględnić zachowanie śluz podczas braku prądu. Teraz da się ich otworzyć łomem również w takich warunkach, wtedy one się nie boltują, póki nie powróci zasilanie