### PR TITLE
Balancing chnages for Thermite Pack

### DIFF
--- a/Resources/Prototypes/_Polonium/Entities/Objects/Misc/Box.yml
+++ b/Resources/Prototypes/_Polonium/Entities/Objects/Misc/Box.yml
@@ -11,6 +11,7 @@
     whitelist:
       tags:
       - Spray
+      - FireExtinguisher
       - TacticalIgniter
       - Pill
   - type: PhysicalComposition

--- a/Resources/Prototypes/_Polonium/Entities/Objects/Misc/Box.yml
+++ b/Resources/Prototypes/_Polonium/Entities/Objects/Misc/Box.yml
@@ -7,10 +7,10 @@
   - type: Storage
     maxItemSize: Normal
     grid:
-    - 0,0,3,1
+    - 0,0,2,1
     whitelist:
       tags:
-      - FireExtinguisher
+      - Spray
       - TacticalIgniter
       - Pill
   - type: PhysicalComposition
@@ -25,7 +25,7 @@
       - state: flare
   - type: Item
     shape:
-    - 0,0,3,1
+    - 0,0,2,1
 
 - type: entity
   parent: BaseThermitePack
@@ -37,7 +37,7 @@
     containers:
       storagebase: !type:AllSelector
        children:
-        - id: FireExtinguisher
+        - id: SprayBottleSpaceCleaner
         - id: ThermiteSparyer
         - id: TacticalIgniter
         - id: PillDermaline

--- a/Resources/Prototypes/_Polonium/Entities/Objects/Tools/tactical_igniter.yml
+++ b/Resources/Prototypes/_Polonium/Entities/Objects/Tools/tactical_igniter.yml
@@ -29,7 +29,7 @@
   - type: ItemToggleSize
     activatedSize: Normal
   - type: Welder
-    fuelConsumption: 1.5
+    fuelConsumption: 1
     fuelLitCost: 0
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Polonium/Entities/Objects/Tools/thermite_sprayer.yml
+++ b/Resources/Prototypes/_Polonium/Entities/Objects/Tools/thermite_sprayer.yml
@@ -13,7 +13,7 @@
     sprayedPrototype: ExtinguisherSpray
     vaporAmount: 1
     vaporSpread: 0
-    sprayVelocity: 0.5
+    sprayVelocity: 1
   - type: ItemToggle
     soundActivate:
       path: /Audio/Machines/button.ogg


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->

By działało lepiej
Przedewszystkim wyszło po testach że space cleaner jest dobrym counterem dla termitu więc ten został dodany zamiast gaśnicy.

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Ulepszenia**
  * Zmieniono rozmiar i zawartość zestawu termitowego, w tym dodano możliwość przechowywania przedmiotów z tagiem „Spray”.
  * Zawartość zestawu obejmuje teraz butelkę środka do czyszczenia przestrzeni zamiast gaśnicy.
  * Zmniejszono zużycie paliwa przez zapalnik taktyczny z 1,5 do 1 jednostki.
  * Zwiększono prędkość rozpylania termitu z 0,5 do 1, co usprawnia jego aplikację.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->