### PR TITLE
Zbiorczy PR z zabezpieczeniami różnych fragmentów kodu

### DIFF
--- a/Content.Server/DeviceNetwork/Systems/DeviceListSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceListSystem.cs
@@ -13,6 +13,8 @@ public sealed partial class DeviceListSystem : SharedDeviceListSystem
     [Dependency] private NetworkConfiguratorSystem _configurator = default!;
     [Dependency] private EntityQuery<DeviceNetworkComponent> _deviceNetworkQuery = default!;
 
+    private float _pruneAccum;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -20,6 +22,25 @@ public sealed partial class DeviceListSystem : SharedDeviceListSystem
         SubscribeLocalEvent<DeviceListComponent, BeforeBroadcastAttemptEvent>(OnBeforeBroadcast);
         SubscribeLocalEvent<DeviceListComponent, BeforePacketSentEvent>(OnBeforePacketSent);
         SubscribeLocalEvent<BeforeSerializationEvent>(OnMapSave);
+    }
+    
+    // Na liście urządzeń mogą pozostać odnośniki do już usuniętych encji, jeśli delete nie został wykonany w DeviceNetwork.Shutdown()
+    // Musimy sprzątać te odnośniki z DeviceListComponent.Devices przed każdym broadcastem i wysyłaniem pakietów
+    public override void Update(float frameTime)
+    {
+        _pruneAccum += frameTime;
+
+        if (_pruneAccum < 1f)
+            return;
+
+        _pruneAccum = 0f;
+        
+        var query = EntityQueryEnumerator<DeviceListComponent>();
+
+        while (query.MoveNext(out var uid, out var list))
+        {
+            PruneDeletedDevices(uid, list);
+        }
     }
 
     private void OnShutdown(EntityUid uid, DeviceListComponent component, ComponentShutdown args)
@@ -84,6 +105,8 @@ public sealed partial class DeviceListSystem : SharedDeviceListSystem
     /// </summary>
     private void OnBeforeBroadcast(EntityUid uid, DeviceListComponent component, BeforeBroadcastAttemptEvent args)
     {
+        PruneDeletedDevices(uid, component);
+
         //Don't filter anything if the device list is empty
         if (component.Devices.Count == 0)
         {

--- a/Content.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
+++ b/Content.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
@@ -232,7 +232,7 @@ public sealed partial class SecretPlusSystem : GameRuleSystem<SecretPlusComponen
 
             if (chaosScore == null)
             {
-                Log.Error($"Tried running roundstart event {entProto.ID}, but chaos score was null");
+                Log.Warning($"Tried running roundstart event {entProto.ID}, but chaos score was null");
                 continue;
             }
 
@@ -392,7 +392,7 @@ public sealed partial class SecretPlusSystem : GameRuleSystem<SecretPlusComponen
             var chaosScore = GetChaosScore(ev.Proto, ev.RuleComp);
             if (chaosScore == null)
             {
-                Log.Error($"Tried running event {ev.Proto.ID}, but chaos score was null");
+                Log.Warning($"Tried running event {ev.Proto.ID}, but chaos score was null");
                 continue;
             }
 

--- a/Content.Server/_RMC14/Weapons/Ranged/Prediction/GunPredictionSystem.cs
+++ b/Content.Server/_RMC14/Weapons/Ranged/Prediction/GunPredictionSystem.cs
@@ -256,6 +256,8 @@ public sealed partial class GunPredictionSystem : SharedGunPredictionSystem
             _predictedHits.Clear();
         }
 
+        PrunePredictedProjectileClientEnts();
+
         var predicted = EntityQueryEnumerator<PredictedProjectileHitComponent, TransformComponent>();
         while (predicted.MoveNext(out var uid, out var hit, out var xform))
         {

--- a/Content.Shared/DeviceNetwork/Systems/SharedDeviceListSystem.cs
+++ b/Content.Shared/DeviceNetwork/Systems/SharedDeviceListSystem.cs
@@ -13,6 +13,24 @@ public abstract class SharedDeviceListSystem : EntitySystem
         }
         return component.Devices;
     }
+
+    /// <summary>
+    /// Clean deleted or invalid device uids.
+    /// </summary>
+    protected bool PruneDeletedDevices(EntityUid uid, DeviceListComponent list)
+    {
+        var temp = list.Devices.ToList();
+
+        // if we did not remove any devices
+        if (list.Devices.RemoveWhere(d => TerminatingOrDeleted(d)) == 0)
+            return false;
+
+        RaiseLocalEvent(uid, new DeviceListUpdateEvent(temp, list.Devices.ToList()));
+
+        Dirty(uid, list);
+
+        return true;
+    }
 }
 
 public sealed class DeviceListUpdateEvent : EntityEventArgs

--- a/Content.Shared/DeviceNetwork/Systems/SharedDeviceListSystem.cs
+++ b/Content.Shared/DeviceNetwork/Systems/SharedDeviceListSystem.cs
@@ -19,16 +19,24 @@ public abstract class SharedDeviceListSystem : EntitySystem
     /// </summary>
     protected bool PruneDeletedDevices(EntityUid uid, DeviceListComponent list)
     {
-        var temp = list.Devices.ToList();
-
-        // if we did not remove any devices
-        if (list.Devices.RemoveWhere(d => TerminatingOrDeleted(d)) == 0)
+        if (!list.Devices.Any(d => TerminatingOrDeleted(d)))
             return false;
 
+        var temp = list.Devices.ToList();
+
+        // reverse index may still exist whoile device is Terminating
+        foreach (var device in temp)
+        {
+            if (!TerminatingOrDeleted(device))
+                continue;
+
+            if (TryComp(device, out DeviceNetworkComponent? net))
+                net.DeviceLists.Remove(uid);
+        }
+
+        list.Devices.RemoveWhere(d => TerminatingOrDeleted(d));
         RaiseLocalEvent(uid, new DeviceListUpdateEvent(temp, list.Devices.ToList()));
-
         Dirty(uid, list);
-
         return true;
     }
 }

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
@@ -209,7 +209,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         {
             var movementEntity = doAfter.MovementEntity;
             //var movementXform = Transform(movementEntity);
-            
+
             if (!TryComp(movementEntity, out TransformComponent? movementXform))
                 return true;
 
@@ -223,7 +223,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
                 if (!TryComp(target, out TransformComponent? targetXform))
                     return true;
 
-                if (targetXform.Coordinates.TryDistance(EntityManager, movementXform.Coordinates, out var distance) ||
+                if (targetXform.Coordinates.TryDistance(EntityManager, movementXform.Coordinates, out var distance) &&
                     Math.Abs(distance - doAfter.TargetDistance) > args.MovementThreshold)
                     return true;
             }

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
@@ -208,16 +208,23 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         if (args.BreakOnMove && !(!args.BreakOnWeightlessMove && _gravity.IsWeightless(args.User)))
         {
             var movementEntity = doAfter.MovementEntity;
-            var movementXform = Transform(movementEntity);
+            //var movementXform = Transform(movementEntity);
+            
+            if (!TryComp(movementEntity, out TransformComponent? movementXform))
+                return true;
 
             // Whether the effective movement entity has moved too much from its original position.
             if (!_transform.InRange(movementXform.Coordinates, doAfter.UserPosition, args.MovementThreshold))
                 return true;
 
             // Whether the distance between the effective movement entity and the target(if any) has changed too much.
-            if (args.Target is { } target && Transform(target).Coordinates.TryDistance(EntityManager, movementXform.Coordinates, out var distance))
+            if (args.Target is { } target)
             {
-                if (Math.Abs(distance - doAfter.TargetDistance) > args.MovementThreshold)
+                if (!TryComp(target, out TransformComponent? targetXform))
+                    return true;
+
+                if (targetXform.Coordinates.TryDistance(EntityManager, movementXform.Coordinates, out var distance) ||
+                    Math.Abs(distance - doAfter.TargetDistance) > args.MovementThreshold)
                     return true;
             }
         }

--- a/Content.Shared/Gibbing/GibbingSystem.cs
+++ b/Content.Shared/Gibbing/GibbingSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Destructible;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Audio;
 using Robust.Shared.Network;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Random;
 
@@ -67,9 +68,13 @@ public sealed partial class GibbingSystem : EntitySystem
 
     private void FlingDroppedEntity(EntityUid target)
     {
+        if (!TryComp<PhysicsComponent>(target, out var body))
+            // Polonium: if the entity has no body, it's not a giblet (i hope so)
+            return;
+
         var impulse = GibletLaunchImpulse + _random.NextFloat(GibletLaunchImpulseVariance);
         var scatterVec = _random.NextAngle().ToVec() * impulse;
-        _physics.ApplyLinearImpulse(target, scatterVec);
+        _physics.ApplyLinearImpulse(target, scatterVec, body: body);
     }
 }
 

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
@@ -347,7 +347,7 @@ public abstract partial class SharedHandsSystem
     /// </summary>
     public void SwapHands(Entity<HandsComponent?> ent, bool checkActionBlocker = false, bool reverse = false)
     {
-        if (!Resolve(ent, ref ent.Comp))
+        if (!Resolve(ent, ref ent.Comp, false))
             return;
 
         if (checkActionBlocker && !_actionBlocker.CanInteract(ent.Owner, null))

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -8,6 +8,7 @@ using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory.Events;
+using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Item;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
@@ -590,8 +591,10 @@ public abstract partial class InventorySystem
         {
             // Give me liberty, give me death
             // TODO: Give me an API that can tell the difference between a virtual item and an electropak being removed.
-            if (!HasComp<AttachedClothingComponent>(item))
-                args.Giblets.Add(item);
+            if (HasComp<AttachedClothingComponent>(item) || HasComp<VirtualItemComponent>(item)) // virtual items are not giblets
+                continue;
+
+            args.Giblets.Add(item);
         }
     }
 }

--- a/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
@@ -334,7 +334,8 @@ namespace Content.Shared.Movement.Systems
         {
             // Relayed movement just uses the same keybinds given we're moving the relayed entity
             // the same as us.
-            if (!MoverQuery.Resolve(entity, ref entity.Comp))
+            
+            if (!MoverQuery.Resolve(entity, ref entity.Comp, false)) // false: some entities get stray input without an InputMover
                 return;
 
             // TODO: Should move this into HandleMobMovement itself.

--- a/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
@@ -159,6 +159,11 @@ namespace Content.Shared.Movement.Systems
 
         private void OnMoverGetState(Entity<InputMoverComponent> entity, ref ComponentGetState args)
         {
+            if (entity.Comp.RelativeEntity is { } rel && TerminatingOrDeleted(rel))
+            {
+                entity.Comp.RelativeEntity = null;
+            }
+
             args.State = new InputMoverComponentState()
             {
                 CanMove = entity.Comp.CanMove,

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.Module.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.Module.cs
@@ -27,7 +27,6 @@ public abstract partial class SharedBorgSystem
         SubscribeLocalEvent<ItemBorgModuleComponent, ComponentStartup>(OnProvideItemStartup);
         SubscribeLocalEvent<ItemBorgModuleComponent, BorgModuleSelectedEvent>(OnItemModuleSelected);
         SubscribeLocalEvent<ItemBorgModuleComponent, BorgModuleUnselectedEvent>(OnItemModuleUnselected);
-
         SubscribeLocalEvent<ComponentBorgModuleComponent, BorgModuleInstalledEvent>(OnComponentModuleInstalled);
         SubscribeLocalEvent<ComponentBorgModuleComponent, BorgModuleUninstalledEvent>(OnComponentModuleUninstalled);
 
@@ -110,7 +109,13 @@ public abstract partial class SharedBorgSystem
 
                 var handId = $"{GetNetEntity(module.Owner)}-hand-{i}";
                 if (itemModuleComp.StoredItems.TryGetValue(handId, out var item))
+                {
+
+                    if (TerminatingOrDeleted(item))
+                        continue;
+
                     _container.Remove(item, container, destination: coordinates);
+                }
             }
 
             itemModuleComp.StoredItems.Clear();
@@ -226,8 +231,18 @@ public abstract partial class SharedBorgSystem
             {
                 if (module.Comp.StoredItems.TryGetValue(handId, out var storedItem))
                 {
-                    item = storedItem;
-                    // DoPickup handles removing the item from the container.
+                    if (TerminatingOrDeleted(storedItem))
+                    {
+                        module.Comp.StoredItems.Remove(handId);
+                        // respawn corrupted item from hand proto if any
+                        if (hand.Item is { } deadProto)
+                            item = PredictedSpawnAtPosition(deadProto, xform.Coordinates);
+                    }
+                    else
+                    {
+                        item = storedItem;
+                        // DoPickup handles removing the item from the container.
+                    }
                 }
             }
             else if (hand.Item is { } itemProto)

--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -57,6 +57,16 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
     [SubscribeLocalEvent]
     private void OnGrappleJointRemoved(Entity<GrapplingProjectileComponent> entity, ref JointRemovedEvent args)
     {
+        // Polonium: Prefer Ungrapple so gun drops its networked Projectile ref instamntly
+        if (TryComp<ProjectileComponent>(entity, out var projectile) &&
+            projectile.Weapon is { } weapon &&
+            TryComp<GrapplingGunComponent>(weapon, out var gun) &&
+            gun.Projectile == entity.Owner)
+        {
+            Ungrapple((weapon, gun), true);
+            return;
+        }
+
         if (_netManager.IsServer)
             QueueDel(entity);
     }
@@ -64,6 +74,21 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
     [SubscribeLocalEvent]
     private void OnGrappleProjectileShutdown(Entity<GrapplingProjectileComponent> ent, ref ComponentShutdown args)
     {
+        if (TryComp<ProjectileComponent>(ent, out var projectileComp) &&
+            projectileComp.Weapon is { } weapon &&
+            !TerminatingOrDeleted(weapon) &&
+            TryComp<GrapplingGunComponent>(weapon, out var gun) &&
+            gun.Projectile == ent.Owner)
+        {
+            _appearance.SetData(weapon, SharedTetherGunSystem.TetherVisualsStatus.Key, true);
+            SetReeling((weapon, gun), false, null);
+
+            gun.Projectile = null;
+
+            DirtyField(weapon, gun, nameof(GrapplingGunComponent.Projectile));
+            _gun.ChangeBasicEntityAmmoCount(weapon, 1);
+        }
+
         if (!TryComp<EmbeddableProjectileComponent>(ent, out var embedComp) || embedComp.EmbeddedIntoUid == null)
             return;
 
@@ -345,6 +370,10 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         if (grapple.Comp.Projectile is not { } projectile)
             return;
 
+        // Current tick must clear the networked ref first. QueueDel is deferred and PVS can run first
+        grapple.Comp.Projectile = null;
+        DirtyField(grapple.Owner, grapple.Comp, nameof(GrapplingGunComponent.Projectile));
+
         if (isBreak && Timing.IsFirstTimePredicted)
         {
             if (user != null)
@@ -355,12 +384,10 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
 
         _appearance.SetData(grapple.Owner, SharedTetherGunSystem.TetherVisualsStatus.Key, true);
 
-        if (_netManager.IsServer)
+        if (_netManager.IsServer && !TerminatingOrDeleted(projectile))
             QueueDel(projectile);
 
         SetReeling(grapple, false, user);
-        grapple.Comp.Projectile = null;
-        DirtyField(grapple.Owner, grapple.Comp, nameof(GrapplingGunComponent.Projectile));
         _gun.ChangeBasicEntityAmmoCount(grapple.Owner, 1);
     }
 

--- a/Content.Shared/Weapons/Ranged/Components/TargetedByProjectilesComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/TargetedByProjectilesComponent.cs
@@ -1,0 +1,10 @@
+using Content.Shared.Weapons.Ranged.Systems;
+
+namespace Content.Shared.Weapons.Ranged.Components;
+
+[RegisterComponent]
+[Access(typeof(SharedGunSystem))]
+public sealed partial class TargetedByProjectilesComponent : Component
+{
+    public HashSet<EntityUid> Projectiles = new();
+}

--- a/Content.Shared/Weapons/Ranged/Components/TargetedProjectileComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/TargetedProjectileComponent.cs
@@ -8,5 +8,5 @@ namespace Content.Shared.Weapons.Ranged.Components;
 public sealed partial class TargetedProjectileComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public EntityUid Target;
+    public EntityUid? Target;
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Shoot.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Shoot.cs
@@ -44,6 +44,37 @@ public abstract partial class SharedGunSystem
         Subs.CVar(_config, RMCCVars.RMCGunPrediction, v => GunPrediction = v, true);
     }
 
+    private void InitializeTargetedProjectile()
+    {
+        SubscribeLocalEvent<TargetedByProjectilesComponent, EntityTerminatingEvent>(OnProjectileTargetTerminating);
+        SubscribeLocalEvent<TargetedProjectileComponent, ComponentShutdown>(OnTargetedProjectileShutdown);
+    }
+
+    private void OnProjectileTargetTerminating(EntityUid uid, TargetedByProjectilesComponent component, ref EntityTerminatingEvent args)
+    {
+        foreach (var proj in component.Projectiles)
+        {
+            if (!TryComp(proj, out TargetedProjectileComponent? targeted) || targeted.Target != uid)
+                continue;
+
+            targeted.Target = null;
+            Dirty(proj, targeted);
+        }
+    }
+
+    private void OnTargetedProjectileShutdown(Entity<TargetedProjectileComponent> ent, ref ComponentShutdown args)
+    {
+        if (ent.Comp.Target is not { } target || TerminatingOrDeleted(target))
+            return;
+
+        if (!TryComp(target, out TargetedByProjectilesComponent? tracked))
+            return;
+
+        tracked.Projectiles.Remove(ent.Owner);
+        if (tracked.Projectiles.Count == 0)
+            RemComp<TargetedByProjectilesComponent>(target);
+    }
+
     public void ResetShotCounter(Entity<GunComponent> gun)
     {
         if (gun.Comp.ShotCounter == 0)
@@ -501,6 +532,9 @@ public abstract partial class SharedGunSystem
             var targeted = EnsureComp<TargetedProjectileComponent>(uid);
             targeted.Target = target;
             Dirty(uid, targeted);
+
+            var tracked = EnsureComp<TargetedByProjectilesComponent>(target);
+            tracked.Projectiles.Add(uid);
         }
 
         if (!HasComp<ProjectileComponent>(uid))

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -164,6 +164,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         InitializeClothing();
         InitializeContainer();
         InitializeSolution();
+        InitializeTargetedProjectile();
 
         // Interactions
         SubscribeLocalEvent<GunComponent, GetVerbsEvent<AlternativeVerb>>(OnAltVerb);

--- a/Content.Shared/_RMC14/Weapons/Ranged/Prediction/SharedGunPredictionSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Prediction/SharedGunPredictionSystem.cs
@@ -20,6 +20,19 @@ public abstract partial class SharedGunPredictionSystem : EntitySystem
         Subs.CVar(_config, RMCCVars.RMCGunPrediction, v => GunPrediction = v, true);
     }
 
+    protected void PrunePredictedProjectileClientEnts()
+    {
+        var query = EntityQueryEnumerator<PredictedProjectileServerComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (comp.ClientEnt is not { } clientEnt || !TerminatingOrDeleted(clientEnt))
+                continue;
+
+            comp.ClientEnt = null;
+            Dirty(uid, comp);
+        }
+    }
+
     public List<EntityUid>? ShootRequested(
         NetEntity netGun,
         NetCoordinates coordinates,

--- a/Content.Shared/_Shitmed/Body/BodyDamageBridgeSystem.cs
+++ b/Content.Shared/_Shitmed/Body/BodyDamageBridgeSystem.cs
@@ -108,7 +108,8 @@ public sealed partial class BodyDamageBridgeSystem : EntitySystem
         if (body.Organs is null)
             return;
 
-        foreach (var contained in body.Organs.ContainedEntities)
+        // copy because TryChangeDamage can yank organs out during foreach
+        foreach (var contained in body.Organs.ContainedEntities.ToArray())
         {
             if (!TryComp<OrganComponent>(contained, out var organComp)
                 || organComp.Category is not { } category


### PR DESCRIPTION
# Informacje o PR
Naprawienie serii błędów pojawiających się na serwerze produkcyjnym podczas usuwania encji, gibowania, obsługi predykcji pocisków, pracy urządzeń oraz restartu rundy.

Głównym problemem były odwołania EntityUid do encji, które zostały już usunięte, a także brakujące komponenty podczas obsługi opóźnionych eventów.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Ulepszenia**
  * Automatycznie przycinane i czyszczone nieaktualne wpisy list urządzeń oraz wygasłe dane dotyczące pocisków (także po stronie klienta).
  * Ulepszono śledzenie pocisków celowanych oraz sprzątanie zakończonych celów.
  * Grappling gun pewniej odpina i zwalnia pociski podczas usuwania lub wyłączania.

* **Poprawki**
  * DoAfter, sterowanie ruchem, moduły borgów i przełączanie dłoni bezpieczniej reagują na encje w trakcie usuwania.
  * Poprawiono obsługę „gibletów”, gibbing i iterację obrażeń kończyn.

* **Drobne zmiany**
  * Uaktualniono poziomy ostrzeżeń w logach przy brakujących danych.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->