### PR TITLE
Przebudowano zachowanie śluz przeciwpożarowych 

### DIFF
--- a/Content.Client/_Funkystation/FirelockBolt/EntitySystems/FirelockBoltControlSystem.cs
+++ b/Content.Client/_Funkystation/FirelockBolt/EntitySystems/FirelockBoltControlSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared._Funkystation.FirelockBolt.EntitySystems;
+
+namespace Content.Client._Funkystation.FirelockBolt.EntitySystems;
+
+public sealed class FirelockBoltControlSystem : SharedFirelockBoltControlSystem;

--- a/Content.Client/_Funkystation/FirelockBolt/EntitySystems/FirelockBoltControlSystem.cs
+++ b/Content.Client/_Funkystation/FirelockBolt/EntitySystems/FirelockBoltControlSystem.cs
@@ -1,9 +1,0 @@
-// SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
-using Content.Shared._Funkystation.FirelockBolt.EntitySystems;
-
-namespace Content.Client._Funkystation.FirelockBolt.EntitySystems;
-
-public sealed class FirelockBoltControlSystem : SharedFirelockBoltControlSystem;

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.DeviceLinking.Systems;
 using Content.Server.DeviceNetwork.Systems;
 using Content.Server.Popups;
 using Content.Server.Power.EntitySystems;
+using Content.Server._Funkystation.FirelockBolt.EntitySystems;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Administration.Logs;
@@ -43,6 +44,7 @@ public sealed partial class AirAlarmSystem : EntitySystem
     [Dependency] private DeviceNetworkSystem _deviceNet = default!;
     [Dependency] private DeviceLinkSystem _deviceLink = default!;
     [Dependency] private DeviceListSystem _deviceList = default!;
+    [Dependency] private FirelockBoltControlSystem _firelockBolts = default!;
     [Dependency] private PopupSystem _popup = default!;
     [Dependency] private UserInterfaceSystem _ui = default!;
     [Dependency] private EntityQuery<DeviceNetworkComponent> _deviceNetworkQuery = default!;
@@ -441,6 +443,9 @@ public sealed partial class AirAlarmSystem : EntitySystem
         }
 
         UpdateUI(uid, component);
+
+        // dont wait for network for firelocks
+        _firelockBolts.PushAlarmToDeviceList(uid, args.AlarmType);
     }
 
     private string GetPort(AirAlarmComponent comp)

--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -79,10 +79,6 @@ namespace Content.Server.Doors.Systems
         {
             component.Powered = args.Powered;
             Dirty(uid, component);
-
-            // drop bolts when power dies, reevaluate when it comes back
-            if (_boltControlQuery.TryComp(uid, out var boltControl))
-                _firelockBolts.UpdateHazardBolts((uid, boltControl), component);
         }
 
         public override void Update(float frameTime)
@@ -97,9 +93,9 @@ namespace Content.Server.Doors.Systems
             var query = EntityQueryEnumerator<FirelockComponent, DoorComponent>();
             while (query.MoveNext(out var uid, out var firelock, out var door))
             {
-                // reclose on Danger even without power - bolts still need power
                 if (_atmosAlarmQuery.TryComp(uid, out var alarmable)
                     && alarmable.LastAlarmState == AtmosAlarmType.Danger
+                    && this.IsPowered(uid, EntityManager)
                     && door.State == DoorState.Open)
                 {
                     EmergencyPressureStop(uid, firelock, door);
@@ -155,21 +151,19 @@ namespace Content.Server.Doors.Systems
 
         private void OnAtmosAlarm(EntityUid uid, FirelockComponent component, AtmosAlarmEvent args)
         {
+            if (!this.IsPowered(uid, EntityManager))
+                return;
+
             if (!TryComp<DoorComponent>(uid, out var doorComponent))
                 return;
 
             if (args.AlarmType == AtmosAlarmType.Normal)
             {
-                // opening still needs power
-                if (!this.IsPowered(uid, EntityManager))
-                    return;
-
                 if (doorComponent.State == DoorState.Closed)
                     _doorSystem.TryOpen(uid);
             }
             else if (args.AlarmType == AtmosAlarmType.Danger)
             {
-                // close even when unpowered
                 EmergencyPressureStop(uid, component, doorComponent);
             }
         }

--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -4,6 +4,8 @@ using Content.Server.Atmos.Monitor.Components;
 using Content.Server.Atmos.Monitor.Systems;
 using Content.Server.Power.EntitySystems;
 using Content.Server.Shuttles.Components;
+using Content.Server._Funkystation.FirelockBolt.EntitySystems;
+using Content.Shared._Funkystation.FirelockBolt.Components;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Atmos.Monitor;
@@ -22,11 +24,13 @@ namespace Content.Server.Doors.Systems
         [Dependency] private SharedAppearanceSystem _appearance = default!;
         [Dependency] private SharedMapSystem _mapping = default!;
         [Dependency] private PointLightSystem _pointLight = default!;
+        [Dependency] private FirelockBoltControlSystem _firelockBolts = default!;
 
         [Dependency] private EntityQuery<AtmosAlarmableComponent> _atmosAlarmQuery = default!;
         [Dependency] private EntityQuery<AirtightComponent> _airtightQuery = default!;
         [Dependency] private EntityQuery<AppearanceComponent> _appearanceQuery = default!;
         [Dependency] private EntityQuery<PointLightComponent> _pointLightQuery = default!;
+        [Dependency] private EntityQuery<FirelockBoltControlComponent> _boltControlQuery = default!;
 
         private const int UpdateInterval = 30;
         private int _accumulatedTicks;
@@ -36,13 +40,18 @@ namespace Content.Server.Doors.Systems
             base.Initialize();
 
             SubscribeLocalEvent<FirelockComponent, AtmosAlarmEvent>(OnAtmosAlarm);
-            SubscribeLocalEvent<FirelockComponent, PowerChangedEvent>(PowerChanged);
+
+            SubscribeLocalEvent<FirelockComponent, PowerChangedEvent>(PowerChanged, before: new[] { typeof(AtmosAlarmableSystem) });
         }
 
         private void PowerChanged(EntityUid uid, FirelockComponent component, ref PowerChangedEvent args)
         {
             component.Powered = args.Powered;
             Dirty(uid, component);
+
+            // blackout must not drop bolts
+            if (args.Powered && _boltControlQuery.TryComp(uid, out var boltControl))
+                _firelockBolts.UpdateHazardBolts((uid, boltControl), component);
         }
 
         public override void Update(float frameTime)
@@ -53,19 +62,16 @@ namespace Content.Server.Doors.Systems
 
             _accumulatedTicks = 0;
 
-
             var query = EntityQueryEnumerator<FirelockComponent, DoorComponent>();
             while (query.MoveNext(out var uid, out var firelock, out var door))
             {
                 if (_atmosAlarmQuery.TryComp(uid, out var alarmable)
                     && alarmable.LastAlarmState == AtmosAlarmType.Danger
-                    && this.IsPowered(uid, EntityManager)
                     && door.State == DoorState.Open)
                 {
                     EmergencyPressureStop(uid, firelock, door);
                 }
 
-                // only bother to check pressure on doors that are some variation of closed.
                 if (door.State != DoorState.Closed
                     && door.State != DoorState.Welded
                     && door.State != DoorState.Denying
@@ -77,19 +83,20 @@ namespace Content.Server.Doors.Systems
                 if (_airtightQuery.TryGetComponent(uid, out var airtight)
                     && _appearanceQuery.TryGetComponent(uid, out var appearance))
                 {
-                    var (pressure, fire) = CheckPressureAndFire(uid, firelock, airtight);
+                    var (pressure, fire) = CheckPressureAndFire(uid, firelock, airtight, door.State == DoorState.Open);
 
                     // Funky change
                     if (door.State == DoorState.Open)
                     {
+                        firelock.Pressure = pressure;
+                        firelock.Temperature = fire;
+                        Dirty(uid, firelock);
+
                         if (pressure || fire)
-                        {
                             EmergencyPressureStop(uid, firelock, door);
-                        }
                     }
                     else
                     {
-
                         _appearance.SetData(uid, DoorVisuals.ClosedLights, fire || pressure, appearance);
                         firelock.Temperature = fire;
                         firelock.Pressure = pressure;
@@ -98,9 +105,10 @@ namespace Content.Server.Doors.Systems
                         Dirty(uid, firelock);
 
                         if (_pointLightQuery.TryComp(uid, out var pointLight))
-                        {
                             _pointLight.SetEnabled(uid, fire | pressure, pointLight);
-                        }
+
+                        if (_boltControlQuery.TryComp(uid, out var boltControl))
+                            _firelockBolts.UpdateHazardBolts((uid, boltControl), firelock, door);
                     }
                 }
             }
@@ -108,14 +116,20 @@ namespace Content.Server.Doors.Systems
 
         private void OnAtmosAlarm(EntityUid uid, FirelockComponent component, AtmosAlarmEvent args)
         {
-            if (!this.IsPowered(uid, EntityManager))
-                return;
-
             if (!TryComp<DoorComponent>(uid, out var doorComponent))
                 return;
 
             if (args.AlarmType == AtmosAlarmType.Normal)
             {
+                if (!this.IsPowered(uid, EntityManager))
+                    return;
+
+                if (component.IsLocked)
+                    return;
+
+                if (TryComp<DoorBoltComponent>(uid, out var bolt) && bolt.BoltsDown)
+                    return;
+
                 if (doorComponent.State == DoorState.Closed)
                     _doorSystem.TryOpen(uid);
             }

--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -51,7 +51,7 @@ namespace Content.Server.Doors.Systems
 
             // blackout must not drop bolts
             if (args.Powered && _boltControlQuery.TryComp(uid, out var boltControl))
-                _firelockBolts.UpdateHazardBolts((uid, boltControl), component);
+                _firelockBolts.RefreshAlarmBolts((uid, boltControl));
         }
 
         public override void Update(float frameTime)

--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -1,43 +1,9 @@
-// SPDX-FileCopyrightText: 2022 Flipp Syder <76629141+vulppine@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 Moony <moony@hellomouse.net>
-// SPDX-FileCopyrightText: 2022 Paul Ritter <ritter.paul1@googlemail.com>
-// SPDX-FileCopyrightText: 2022 Vera Aguilera Puerto <6766154+Zumorica@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 corentt <36075110+corentt@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 mirrorcult <lunarautomaton6@gmail.com>
-// SPDX-FileCopyrightText: 2022 moonheart08 <moonheart08@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 vulppine <vulppine@gmail.com>
-// SPDX-FileCopyrightText: 2022 wrexbe <81056464+wrexbe@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Theomund <34360334+Theomund@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Tom Leys <tom@crump-leys.com>
-// SPDX-FileCopyrightText: 2023 Visne <39844191+Visne@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 metalgearsloth <comedian_vs_clown@hotmail.com>
-// SPDX-FileCopyrightText: 2024 Cojoke <83733158+Cojoke-dot@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Partmedia <kevinz5000@gmail.com>
-// SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 nikthechampiongr <32041239+nikthechampiongr@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 ShadowCommander <10494922+ShadowCommander@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2026 Dmitry <57028746+DIMMoon1@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2026 Eveloop <26272940+eveloop@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2026 MaiaArai <158123176+YaraaraY@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2026 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
-// SPDX-FileCopyrightText: 2026 Princess Cheeseballs <66055347+Princess-Cheeseballs@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2026 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2026 taydeo <tay@funkystation.org>
-// SPDX-FileCopyrightText: 2026 taydeo <td12233a@gmail.com>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
 using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Monitor.Components;
 using Content.Server.Atmos.Monitor.Systems;
 using Content.Server.Power.EntitySystems;
 using Content.Server.Shuttles.Components;
-using Content.Server._Funkystation.FirelockBolt.EntitySystems;
-using Content.Shared._Funkystation.FirelockBolt.Components;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Atmos.Monitor;
@@ -56,13 +22,11 @@ namespace Content.Server.Doors.Systems
         [Dependency] private SharedAppearanceSystem _appearance = default!;
         [Dependency] private SharedMapSystem _mapping = default!;
         [Dependency] private PointLightSystem _pointLight = default!;
-        [Dependency] private FirelockBoltControlSystem _firelockBolts = default!;
 
         [Dependency] private EntityQuery<AtmosAlarmableComponent> _atmosAlarmQuery = default!;
         [Dependency] private EntityQuery<AirtightComponent> _airtightQuery = default!;
         [Dependency] private EntityQuery<AppearanceComponent> _appearanceQuery = default!;
         [Dependency] private EntityQuery<PointLightComponent> _pointLightQuery = default!;
-        [Dependency] private EntityQuery<FirelockBoltControlComponent> _boltControlQuery = default!;
 
         private const int UpdateInterval = 30;
         private int _accumulatedTicks;
@@ -113,16 +77,11 @@ namespace Content.Server.Doors.Systems
                 if (_airtightQuery.TryGetComponent(uid, out var airtight)
                     && _appearanceQuery.TryGetComponent(uid, out var appearance))
                 {
-                    var (pressure, fire) = CheckPressureAndFire(uid, firelock, airtight, door.State == DoorState.Open); // open firelocks arent AirBlocked so we have to opt into the pressure check
+                    var (pressure, fire) = CheckPressureAndFire(uid, firelock, airtight);
 
                     // Funky change
                     if (door.State == DoorState.Open)
                     {
-                        // Set before close so firelock bolts as soon as it finishes closing
-                        firelock.Pressure = pressure;
-                        firelock.Temperature = fire;
-                        Dirty(uid, firelock);
-
                         if (pressure || fire)
                         {
                             EmergencyPressureStop(uid, firelock, door);
@@ -130,6 +89,7 @@ namespace Content.Server.Doors.Systems
                     }
                     else
                     {
+
                         _appearance.SetData(uid, DoorVisuals.ClosedLights, fire || pressure, appearance);
                         firelock.Temperature = fire;
                         firelock.Pressure = pressure;
@@ -141,9 +101,6 @@ namespace Content.Server.Doors.Systems
                         {
                             _pointLight.SetEnabled(uid, fire | pressure, pointLight);
                         }
-
-                        if (_boltControlQuery.TryComp(uid, out var boltControl))
-                            _firelockBolts.UpdateHazardBolts((uid, boltControl), firelock, door);
                     }
                 }
             }

--- a/Content.Server/_Funkystation/FirelockBolt/EntitySystems/FirelockBoltControlSystem.cs
+++ b/Content.Server/_Funkystation/FirelockBolt/EntitySystems/FirelockBoltControlSystem.cs
@@ -89,15 +89,6 @@ public sealed partial class FirelockBoltControlSystem : SharedFirelockBoltContro
     private void ApplyAlarmState(Entity<FirelockBoltControlComponent> ent, AtmosAlarmType alarmType)
     {
         var alarmActive = alarmType == AtmosAlarmType.Danger;
-
-        if (!alarmActive
-            && TryComp<FirelockComponent>(ent.Owner, out var firelock)
-            && !firelock.Powered)
-        {
-            PushState(ent);
-            return;
-        }
-
         if (ent.Comp.AlarmActive != alarmActive)
         {
             ent.Comp.AlarmActive = alarmActive;
@@ -108,5 +99,17 @@ public sealed partial class FirelockBoltControlSystem : SharedFirelockBoltContro
             UpdateHazardBolts(ent);
 
         PushState(ent);
+    }
+
+    public void RefreshAlarmBolts(Entity<FirelockBoltControlComponent> ent)
+    {
+        var alarmType = AtmosAlarmType.Normal;
+        if (_alarmableQuery.TryComp(ent.Owner, out var alarmable)
+            && alarmable.LastAlarmState != AtmosAlarmType.Invalid)
+        {
+            alarmType = alarmable.LastAlarmState;
+        }
+
+        ApplyAlarmState(ent, alarmType);
     }
 }

--- a/Content.Server/_Funkystation/FirelockBolt/EntitySystems/FirelockBoltControlSystem.cs
+++ b/Content.Server/_Funkystation/FirelockBolt/EntitySystems/FirelockBoltControlSystem.cs
@@ -1,45 +1,112 @@
-﻿using Content.Server.Atmos.Monitor.Systems;
+﻿using Content.Server.Atmos.Monitor.Components;
+using Content.Server.Atmos.Monitor.Systems;
 using Content.Server.Doors.Systems;
+using Content.Server.Power.EntitySystems;
 using Content.Shared._Funkystation.FirelockBolt.Components;
 using Content.Shared._Funkystation.FirelockBolt.EntitySystems;
 using Content.Shared.Atmos.Monitor;
+using Content.Shared.DeviceNetwork.Components;
 using Content.Shared.Doors.Components;
 
 namespace Content.Server._Funkystation.FirelockBolt.EntitySystems;
 
 public sealed partial class FirelockBoltControlSystem : SharedFirelockBoltControlSystem
 {
+    [Dependency] private AtmosAlarmableSystem _atmosAlarmable = default!;
+    [Dependency] private EntityQuery<FirelockBoltControlComponent> _boltControlQuery = default!;
+    [Dependency] private EntityQuery<AtmosAlarmableComponent> _alarmableQuery = default!;
+    [Dependency] private EntityQuery<DeviceListComponent> _deviceListQuery = default!;
+    [Dependency] private EntityQuery<DeviceNetworkComponent> _deviceNetQuery = default!;
+
     public override void Initialize()
     {
         base.Initialize();
 
+        // network packet path on the firelock itself
         SubscribeLocalEvent<FirelockBoltControlComponent, AtmosAlarmEvent>(OnAtmosAlarm, before: new[] { typeof(FirelockSystem) });
+        SubscribeLocalEvent<FireAlarmComponent, AtmosAlarmEvent>(OnFireAlarm, before: new[] { typeof(FirelockSystem) });
     }
 
     private void OnAtmosAlarm(EntityUid uid, FirelockBoltControlComponent component, AtmosAlarmEvent args)
     {
-        component.AlarmActive = args.AlarmType != AtmosAlarmType.Normal;
-        Dirty(uid, component);
+        ApplyAlarmState((uid, component), args.AlarmType);
+    }
 
-        if (component.Override)
+    private void OnFireAlarm(EntityUid uid, FireAlarmComponent component, AtmosAlarmEvent args)
+    {
+        PushAlarmToDeviceList(uid, args.AlarmType);
+    }
+
+    /// <summary>
+    /// Air/FireAlarm status change - update DeviceList firelocks without waiting for net packets
+    /// </summary>
+    public void PushAlarmToDeviceList(EntityUid alarmUid, AtmosAlarmType alarmType)
+    {
+        if (!this.IsPowered(alarmUid, EntityManager))
             return;
 
-        if (component.AlarmActive)
+        if (!_deviceListQuery.TryComp(alarmUid, out var deviceList))
+            return;
+
+        string? alarmAddress = null;
+        if (_deviceNetQuery.TryComp(alarmUid, out var alarmNet)
+            && !string.IsNullOrEmpty(alarmNet.Address))
         {
-            // If an alarm is triggered and the door is closed, bolt
-            if (DoorQuery.TryComp(uid, out var door) && (door.State == DoorState.Closed || door.State == DoorState.Welded))
-            {
-                if (DoorBoltQuery.TryComp(uid, out var bolt))
-                    DoorSystem.SetBoltsDown((uid, bolt), true);
-            }
-        }
-        else
-        {
-            // If the alarm clears, unbolt
-            if (DoorBoltQuery.TryComp(uid, out var bolt))
-                DoorSystem.SetBoltsDown((uid, bolt), false);
+            alarmAddress = alarmNet.Address;
         }
 
-        PushState((uid, component));
+        foreach (var device in deviceList.Devices)
+        {
+            if (!_boltControlQuery.HasComp(device))
+                continue;
+
+            if (_alarmableQuery.TryComp(device, out var alarmable) && alarmAddress != null)
+            {
+                alarmable.NetworkAlarmStates[alarmAddress] = alarmType;
+
+                var netMax = _atmosAlarmable.TryGetHighestAlert(device, out var highest, alarmable)
+                    ? highest.Value
+                    : AtmosAlarmType.Normal;
+
+                if (alarmable.LastAlarmState != netMax)
+                {
+                    alarmable.LastAlarmState = netMax;
+                    RaiseLocalEvent(device, new AtmosAlarmEvent(netMax), true);
+                    continue;
+                }
+
+                if (_boltControlQuery.TryComp(device, out var boltControl))
+                    ApplyAlarmState((device, boltControl), netMax);
+
+                continue;
+            }
+
+            if (_boltControlQuery.TryComp(device, out var boltOnly))
+                ApplyAlarmState((device, boltOnly), alarmType);
+        }
+    }
+
+    private void ApplyAlarmState(Entity<FirelockBoltControlComponent> ent, AtmosAlarmType alarmType)
+    {
+        var alarmActive = alarmType == AtmosAlarmType.Danger;
+
+        if (!alarmActive
+            && TryComp<FirelockComponent>(ent.Owner, out var firelock)
+            && !firelock.Powered)
+        {
+            PushState(ent);
+            return;
+        }
+
+        if (ent.Comp.AlarmActive != alarmActive)
+        {
+            ent.Comp.AlarmActive = alarmActive;
+            Dirty(ent, ent.Comp);
+        }
+
+        if (!ent.Comp.Override)
+            UpdateHazardBolts(ent);
+
+        PushState(ent);
     }
 }

--- a/Content.Server/_Funkystation/FirelockBolt/EntitySystems/FirelockBoltControlSystem.cs
+++ b/Content.Server/_Funkystation/FirelockBolt/EntitySystems/FirelockBoltControlSystem.cs
@@ -1,13 +1,9 @@
-// SPDX-FileCopyrightText: 2026 MaiaArai <158123176+YaraaraY@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
-using Content.Server.Atmos.Monitor.Systems;
+﻿using Content.Server.Atmos.Monitor.Systems;
 using Content.Server.Doors.Systems;
 using Content.Shared._Funkystation.FirelockBolt.Components;
 using Content.Shared._Funkystation.FirelockBolt.EntitySystems;
 using Content.Shared.Atmos.Monitor;
+using Content.Shared.Doors.Components;
 
 namespace Content.Server._Funkystation.FirelockBolt.EntitySystems;
 
@@ -22,12 +18,27 @@ public sealed partial class FirelockBoltControlSystem : SharedFirelockBoltContro
 
     private void OnAtmosAlarm(EntityUid uid, FirelockBoltControlComponent component, AtmosAlarmEvent args)
     {
-        component.AlarmActive = args.AlarmType == AtmosAlarmType.Danger;
+        component.AlarmActive = args.AlarmType != AtmosAlarmType.Normal;
         Dirty(uid, component);
 
-        // bolt/unbolt immediately when air alarm (or fire alarm) status changes
-        if (!component.Override)
-            UpdateHazardBolts((uid, component));
+        if (component.Override)
+            return;
+
+        if (component.AlarmActive)
+        {
+            // If an alarm is triggered and the door is closed, bolt
+            if (DoorQuery.TryComp(uid, out var door) && (door.State == DoorState.Closed || door.State == DoorState.Welded))
+            {
+                if (DoorBoltQuery.TryComp(uid, out var bolt))
+                    DoorSystem.SetBoltsDown((uid, bolt), true);
+            }
+        }
+        else
+        {
+            // If the alarm clears, unbolt
+            if (DoorBoltQuery.TryComp(uid, out var bolt))
+                DoorSystem.SetBoltsDown((uid, bolt), false);
+        }
 
         PushState((uid, component));
     }

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.Bolts.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.Bolts.cs
@@ -75,19 +75,21 @@ public abstract partial class SharedDoorSystem
         UpdateBoltLightStatus(ent);
     }
 
-    public void SetBoltsDown(Entity<DoorBoltComponent> ent, bool value, EntityUid? user = null, bool predicted = false)
+    public void SetBoltsDown(Entity<DoorBoltComponent> ent, bool value, EntityUid? user = null, bool predicted = false, bool force = false)
     {
-        TrySetBoltDown(ent, value, user, predicted);
+        TrySetBoltDown(ent, value, user, predicted, force);
     }
 
     public bool TrySetBoltDown(
         Entity<DoorBoltComponent> ent,
         bool value,
         EntityUid? user = null,
-        bool predicted = false
+        bool predicted = false,
+        bool force = false
     )
     {
-        if (!_powerReceiver.IsPowered(ent.Owner))
+        // force = firelock pry/override can drop bolts without power
+        if (!force && !_powerReceiver.IsPowered(ent.Owner))
             return false;
         if (ent.Comp.BoltsDown == value)
             return false;

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.Bolts.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.Bolts.cs
@@ -75,20 +75,19 @@ public abstract partial class SharedDoorSystem
         UpdateBoltLightStatus(ent);
     }
 
-    public void SetBoltsDown(Entity<DoorBoltComponent> ent, bool value, EntityUid? user = null, bool predicted = false, bool force = false)
+    public void SetBoltsDown(Entity<DoorBoltComponent> ent, bool value, EntityUid? user = null, bool predicted = false)
     {
-        TrySetBoltDown(ent, value, user, predicted, force);
+        TrySetBoltDown(ent, value, user, predicted);
     }
 
     public bool TrySetBoltDown(
         Entity<DoorBoltComponent> ent,
         bool value,
         EntityUid? user = null,
-        bool predicted = false,
-        bool force = false
+        bool predicted = false
     )
     {
-        if (!force && !_powerReceiver.IsPowered(ent.Owner))
+        if (!_powerReceiver.IsPowered(ent.Owner))
             return false;
         if (ent.Comp.BoltsDown == value)
             return false;

--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -1,13 +1,3 @@
-// SPDX-FileCopyrightText: 2024 nikthechampiongr <32041239+nikthechampiongr@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 ShadowCommander <10494922+ShadowCommander@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2026 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
-// SPDX-FileCopyrightText: 2026 Whatstone <166147148+whatston3@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2026 taydeo <tay@funkystation.org>
-// SPDX-FileCopyrightText: 2026 taydeo <td12233a@gmail.com>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
 using Content.Shared.Access.Systems;
 using Content.Shared.Doors.Components;
 using Content.Shared.Examine;
@@ -75,12 +65,6 @@ public abstract partial class SharedFirelockSystem : EntitySystem
     private void OnBeforePry(EntityUid uid, FirelockComponent component, ref BeforePryEvent args)
     {
         if (args.Cancelled || !component.Powered || args.StrongPry || args.PryPowered)
-            return;
-
-        if (component.IsLocked)
-            return;
-
-        if (TryComp<DoorBoltComponent>(uid, out var bolt) && bolt.BoltsDown)
             return;
 
         args.Cancelled = true;

--- a/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
+++ b/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
@@ -1,3 +1,5 @@
+using Content.Shared._Funkystation.FirelockBolt.Components;
+using Content.Shared._Funkystation.FirelockBolt.EntitySystems;
 using Content.Shared.Access.Components;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
@@ -27,6 +29,7 @@ public abstract partial class SharedDoorRemoteSystem : EntitySystem
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private TagSystem _tagSystem = default!;
+    [Dependency] private SharedFirelockBoltControlSystem _firelockBolts = default!;
     [Dependency] protected IGameTiming Timing = default!;
 
 
@@ -71,6 +74,15 @@ public abstract partial class SharedDoorRemoteSystem : EntitySystem
             return;
         }
 
+        // Remote control is blocked while lever override is on
+        if (TryComp<FirelockBoltControlComponent>(args.Target, out var firelockBolts)
+            && !_firelockBolts.CanRemoteControl((args.Target.Value, firelockBolts), out var overrideReason)
+            && overrideReason != null)
+        {
+            _popup.PopupEntity(Loc.GetString(overrideReason), args.User, args.User);
+            return;
+        }
+
         var accessTarget = args.Used;
         // This covers the accesses the REMOTE has, and is not effected by the user's ID card.
         if (entity.Comp.IncludeUserAccess) // Allows some door remotes to inherit the user's access.
@@ -109,10 +121,30 @@ public abstract partial class SharedDoorRemoteSystem : EntitySystem
                 {
                     if (!boltsComp.BoltWireCut)
                     {
-                        _doorSystem.SetBoltsDown((args.Target.Value, boltsComp), !boltsComp.BoltsDown, user: args.User, predicted: true);
+                        var willBolt = !boltsComp.BoltsDown;
+
+                        if (firelockBolts != null)
+                        {
+                            if (!_firelockBolts.TrySetBoltsFromRemote(
+                                    (args.Target.Value, firelockBolts),
+                                    willBolt,
+                                    out var failReason,
+                                    args.User,
+                                    predicted: true))
+                            {
+                                if (failReason != null)
+                                    _popup.PopupEntity(Loc.GetString(failReason), args.User, args.User);
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            _doorSystem.SetBoltsDown((args.Target.Value, boltsComp), willBolt, user: args.User, predicted: true);
+                        }
+
                         _adminLogger.Add(LogType.Action,
                             LogImpact.Medium,
-                            $"{ToPrettyString(args.User):player} used {ToPrettyString(args.Used)} on {ToPrettyString(args.Target.Value)} to {(boltsComp.BoltsDown ? "" : "un")}bolt it");
+                            $"{ToPrettyString(args.User):player} used {ToPrettyString(args.Used)} on {ToPrettyString(args.Target.Value)} to {(willBolt ? "" : "un")}bolt it");
                     }
                 }
 

--- a/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
+++ b/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
@@ -1,19 +1,3 @@
-// SPDX-FileCopyrightText: 2024 Jake Huxell <JakeHuxell@pm.me>
-// SPDX-FileCopyrightText: 2024 Plykiya <58439124+Plykiya@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Fildrance <fildrance@gmail.com>
-// SPDX-FileCopyrightText: 2025 Samuka <47865393+Samuka-C@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2026 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
-// SPDX-FileCopyrightText: 2026 Velken <8467292+Velken@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2026 Whatstone <166147148+whatston3@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2026 lunarcomets <140772713+lunarcomets@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2026 taydeo <tay@funkystation.org>
-// SPDX-FileCopyrightText: 2026 taydeo <td12233a@gmail.com>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
-using Content.Shared._Funkystation.FirelockBolt.Components;
-using Content.Shared._Funkystation.FirelockBolt.EntitySystems;
 using Content.Shared.Access.Components;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
@@ -43,7 +27,6 @@ public abstract partial class SharedDoorRemoteSystem : EntitySystem
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private TagSystem _tagSystem = default!;
-    [Dependency] private SharedFirelockBoltControlSystem _firelockBolts = default!;
     [Dependency] protected IGameTiming Timing = default!;
 
 
@@ -126,23 +109,10 @@ public abstract partial class SharedDoorRemoteSystem : EntitySystem
                 {
                     if (!boltsComp.BoltWireCut)
                     {
-                        var willBolt = !boltsComp.BoltsDown;
-
-                        if (TryComp<FirelockBoltControlComponent>(args.Target, out var firelockBolts))
-                        {
-                            _firelockBolts.SetOverride((args.Target.Value, firelockBolts), !willBolt, playSound: false);
-                            
-                            if (willBolt)
-                                _doorSystem.SetBoltsDown((args.Target.Value, boltsComp), true, user: args.User, predicted: true);
-                        }
-                        else
-                        {
-                            _doorSystem.SetBoltsDown((args.Target.Value, boltsComp), willBolt, user: args.User, predicted: true);
-                        }
-
+                        _doorSystem.SetBoltsDown((args.Target.Value, boltsComp), !boltsComp.BoltsDown, user: args.User, predicted: true);
                         _adminLogger.Add(LogType.Action,
                             LogImpact.Medium,
-                            $"{ToPrettyString(args.User):player} used {ToPrettyString(args.Used)} on {ToPrettyString(args.Target.Value)} to {(willBolt ? "" : "un")}bolt it");
+                            $"{ToPrettyString(args.User):player} used {ToPrettyString(args.Used)} on {ToPrettyString(args.Target.Value)} to {(boltsComp.BoltsDown ? "" : "un")}bolt it");
                     }
                 }
 

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Airlock.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Airlock.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Funkystation.FirelockBolt.Components;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.Doors.Components;
@@ -39,12 +40,31 @@ public abstract partial class SharedStationAiSystem
             return;
         }
 
-        var setResult = _doors.TrySetBoltDown((ent, component), args.Bolted, args.User, predicted: true);
+        bool setResult;
+        string? failReason = null;
+        if (TryComp<FirelockBoltControlComponent>(ent, out var firelockBolts))
+        {
+            setResult = _firelockBolts.TrySetBoltsFromRemote(
+                (ent, firelockBolts),
+                args.Bolted,
+                out failReason,
+                args.User,
+                predicted: true);
+
+            if (!setResult && failReason != null)
+                _popup.PopupEntity(Loc.GetString(failReason), args.User, args.User);
+        }
+        else
+        {
+            setResult = _doors.TrySetBoltDown((ent, component), args.Bolted, args.User, predicted: true);
+        }
+
         if (!setResult)
         {
             _adminLogger.Add(LogType.Action,
                 $"{args.User} was unable to change bolt status on {ent} to [{args.Bolted}] using the Station AI radial.");
-            ShowDeviceNotRespondingPopup(args.User);
+            if (failReason == null)
+                ShowDeviceNotRespondingPopup(args.User);
         }
         else
         {

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Funkystation.FirelockBolt.EntitySystems;
 using Content.Shared.Access.Systems;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions;
@@ -53,6 +54,7 @@ public abstract partial class SharedStationAiSystem : EntitySystem
     [Dependency] private SharedDoorSystem _doors = default!;
     [Dependency] private SharedDoAfterSystem _doAfter = default!;
     [Dependency] private SharedElectrocutionSystem _electrify = default!;
+    [Dependency] private SharedFirelockBoltControlSystem _firelockBolts = default!;
     [Dependency] private SharedEyeSystem _eye = default!;
     [Dependency] protected SharedMapSystem Maps = default!;
     [Dependency] private SharedMindSystem _mind = default!;

--- a/Content.Shared/_Funkystation/FirelockBolt/Components/FirelockBoltControlComponent.cs
+++ b/Content.Shared/_Funkystation/FirelockBolt/Components/FirelockBoltControlComponent.cs
@@ -25,6 +25,9 @@ public sealed partial class FirelockBoltControlComponent : Component
     [DataField, AutoNetworkedField]
     public bool IsManualClose;
 
+    [DataField, AutoNetworkedField]
+    public bool IsRemoteBolted;
+
     /// <summary>
     /// Sound played when the manual override is engaged
     /// </summary>

--- a/Content.Shared/_Funkystation/FirelockBolt/EntitySystems/SharedFirelockBoltControlSystem.cs
+++ b/Content.Shared/_Funkystation/FirelockBolt/EntitySystems/SharedFirelockBoltControlSystem.cs
@@ -3,7 +3,10 @@ using Content.Shared.DoAfter;
 using Content.Shared.Doors;
 using Content.Shared.Doors.Components;
 using Content.Shared.Doors.Systems;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
+using Content.Shared.Power.EntitySystems;
+using Content.Shared.Prying.Components;
 using Content.Shared.Verbs;
 using Content.Shared.Wires;
 using Robust.Shared.Audio.Systems;
@@ -19,9 +22,13 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
     [Dependency] private SharedAudioSystem _audio = null!;
     [Dependency] private SharedUserInterfaceSystem _ui = null!;
     [Dependency] private IGameTiming _timing = null!;
+    [Dependency] private SharedHandsSystem _hands = default!;
+    [Dependency] private SharedPowerReceiverSystem _power = default!;
     [Dependency] protected EntityQuery<DoorBoltComponent> DoorBoltQuery = default!;
     [Dependency] protected EntityQuery<DoorComponent> DoorQuery = default!;
+    [Dependency] private EntityQuery<FirelockComponent> _firelockQuery;
     [Dependency] private EntityQuery<WiresPanelComponent> _wiresPanelQuery;
+    [Dependency] private EntityQuery<PryUnpoweredComponent> _pryUnpoweredQuery;
 
     public override void Initialize()
     {
@@ -35,6 +42,14 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
         SubscribeLocalEvent<FirelockBoltControlComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
         SubscribeLocalEvent<FirelockBoltControlComponent, BoundUIOpenedEvent>(OnBuiOpened);
         SubscribeLocalEvent<FirelockBoltControlComponent, FirelockOverrideSetMessage>(OnOverrideSetMessage);
+
+        SubscribeLocalEvent<FirelockBoltControlComponent, BeforePryEvent>(OnBeforePry, after: new[] { typeof(SharedDoorSystem) });
+
+        SubscribeLocalEvent<FirelockBoltControlComponent, PriedEvent>(OnPried, before: new[] { typeof(SharedDoorSystem) });
+
+        SubscribeLocalEvent<FirelockBoltControlComponent, GetPryTimeModifierEvent>(
+            OnGetPryTimeModifier,
+            after: new[] { typeof(SharedDoorSystem), typeof(SharedFirelockSystem) });
     }
 
     private void OnDoorStateChanged(Entity<FirelockBoltControlComponent> ent, ref DoorStateChangedEvent args)
@@ -53,13 +68,11 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
         if (args.Handled || !args.Complex)
             return;
 
-        // record interaction time to detect manual door closes
         ent.Comp.LastManualInteractionTime = _timing.CurTime;
 
         if (!_wiresPanelQuery.TryComp(ent.Owner, out var panel) || !panel.Open)
             return;
 
-        // if the door is not bolted, don't intercept the click. let the door open normally
         var isBolted = DoorBoltQuery.TryComp(ent.Owner, out var bolt) && bolt.BoltsDown;
         if (!isBolted)
             return;
@@ -134,6 +147,61 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
         SetOverride(ent, args.TargetOverride);
     }
 
+    private void OnBeforePry(Entity<FirelockBoltControlComponent> ent, ref BeforePryEvent args)
+    {
+        if (ent.Comp.Override)
+            return;
+
+        if (!DoorBoltQuery.TryComp(ent.Owner, out var bolt) || !bolt.BoltsDown)
+            return;
+
+        if (!_firelockQuery.TryComp(ent.Owner, out var firelock))
+            return;
+
+        // powered + bolted = lever only
+        if (firelock.Powered)
+        {
+            args.Cancelled = true;
+            return;
+        }
+
+        // unpowered + bolted = force-open tols
+        args.Cancelled = false;
+        args.Message = null;
+    }
+
+    private void OnGetPryTimeModifier(Entity<FirelockBoltControlComponent> ent, ref GetPryTimeModifierEvent args)
+    {
+        if (!_firelockQuery.TryComp(ent.Owner, out var firelock) || firelock.Powered)
+            return;
+
+        if (!DoorBoltQuery.TryComp(ent.Owner, out var bolt) || !bolt.BoltsDown)
+            return;
+
+        // if user is holding a prying tool, use its speed
+        if (_hands.TryGetActiveItem(args.User, out var held)
+            && TryComp<PryingComponent>(held, out var prying)
+            && prying.Enabled)
+        {
+            args.BaseTime = TimeSpan.FromSeconds(3);
+            args.PryTimeModifier = 1f;
+            return;
+        }
+
+        // otherwise, use the default prying speed
+        var handMod = _pryUnpoweredQuery.TryComp(ent.Owner, out var unpowered)
+            ? unpowered.PryModifier
+            : 0.5f;
+        args.BaseTime = TimeSpan.FromSeconds(10 * handMod);
+        args.PryTimeModifier = 1f;
+    }
+
+    private void OnPried(Entity<FirelockBoltControlComponent> ent, ref PriedEvent args)
+    {
+        if (DoorBoltQuery.TryComp(ent.Owner, out var bolt) && bolt.BoltsDown)
+            DoorSystem.SetBoltsDown((ent.Owner, bolt), false, args.User, predicted: true, force: true);
+    }
+
     private void ApplyBoltForDoorState(Entity<FirelockBoltControlComponent> ent, DoorState state)
     {
         if (ent.Comp.Override || !DoorBoltQuery.TryComp(ent.Owner, out var bolt))
@@ -142,25 +210,132 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
         switch (state)
         {
             case DoorState.Closing:
-                // if the door starts closing within 1.5 seconds of a player clicking it, it's a manual close, don't bolt
                 ent.Comp.IsManualClose = (_timing.CurTime - ent.Comp.LastManualInteractionTime) < TimeSpan.FromSeconds(1.5);
                 break;
 
             case DoorState.Closed:
             case DoorState.Welded:
-                // bolt shut if it was automatically closed
-                if (ent.Comp.AlarmActive || !ent.Comp.IsManualClose)
-                    DoorSystem.SetBoltsDown((ent.Owner, bolt), true, predicted: true);
+                UpdateHazardBolts(ent);
                 break;
 
             case DoorState.Open:
-                DoorSystem.SetBoltsDown((ent.Owner, bolt), false, predicted: true);
+                DoorSystem.SetBoltsDown((ent.Owner, bolt), false, predicted: true, force: true);
+                ent.Comp.IsRemoteBolted = false;
+                Dirty(ent, ent.Comp);
                 ent.Comp.IsManualClose = false;
                 break;
         }
     }
 
-    private void SetOverride(Entity<FirelockBoltControlComponent> ent, bool value)
+    public bool IsHazardous(Entity<FirelockBoltControlComponent> ent, FirelockComponent? firelock = null)
+    {
+        if (firelock == null && !_firelockQuery.TryComp(ent.Owner, out firelock))
+            return ent.Comp.AlarmActive;
+
+        return ent.Comp.AlarmActive || firelock.IsLocked;
+    }
+
+    /// <summary>
+    /// Remote control is blocked while lever override is on
+    /// </summary>
+    public bool CanRemoteControl(Entity<FirelockBoltControlComponent> ent, out string? failReason)
+    {
+        if (ent.Comp.Override)
+        {
+            failReason = "firelock-bolt-control-remote-override";
+            return false;
+        }
+
+        failReason = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Wnen using remote or AI, try to set bolts down or up. Hazard blocks unbolt, override blocks everything
+    /// </summary>
+    public bool TrySetBoltsFromRemote(
+        Entity<FirelockBoltControlComponent> ent,
+        bool boltsDown,
+        out string? failReason,
+        EntityUid? user = null,
+        bool predicted = true)
+    {
+        if (!CanRemoteControl(ent, out failReason))
+            return false;
+
+        if (!boltsDown && IsHazardous(ent))
+        {
+            failReason = "firelock-bolt-control-remote-hazard";
+            return false;
+        }
+
+        if (!DoorBoltQuery.TryComp(ent.Owner, out var bolt))
+        {
+            failReason = null;
+            return false;
+        }
+
+        if (bolt.BoltsDown != boltsDown)
+        {
+            if (!DoorSystem.TrySetBoltDown((ent.Owner, bolt), boltsDown, user, predicted))
+            {
+                failReason = null;
+                return false;
+            }
+        }
+
+        ent.Comp.IsRemoteBolted = boltsDown;
+        Dirty(ent, ent.Comp);
+        PushState(ent);
+        failReason = null;
+        return true;
+    }
+
+    /// <summary>
+    /// hazard forces bolts on. safe drops them unless remote/AI is holding the bolt
+    /// When no power, leave bolts alone so they stay pryable
+    /// </summary>
+    public void UpdateHazardBolts(Entity<FirelockBoltControlComponent> ent, FirelockComponent? firelock = null, DoorComponent? door = null)
+    {
+        if (ent.Comp.Override)
+            return;
+
+        if (firelock == null && !_firelockQuery.TryComp(ent.Owner, out firelock))
+            return;
+
+        if (door == null && !DoorQuery.TryComp(ent.Owner, out door))
+            return;
+
+        if (!DoorBoltQuery.TryComp(ent.Owner, out var bolt))
+            return;
+
+        // use live power - FirelockComponent.Powered can lag behind PowerChanged order
+        if (!firelock.Powered || !_power.IsPowered(ent.Owner))
+            return;
+
+        var closed = door.State == DoorState.Closed || door.State == DoorState.Welded;
+        var hazardous = closed && IsHazardous(ent, firelock);
+
+        if (hazardous)
+        {
+            if (!bolt.BoltsDown)
+            {
+                DoorSystem.SetBoltsDown((ent.Owner, bolt), true, predicted: true);
+                PushState(ent);
+            }
+
+            return;
+        }
+
+        // safe - release unless remote wants them held
+        if (!ent.Comp.IsRemoteBolted && bolt.BoltsDown)
+        {
+            DoorSystem.SetBoltsDown((ent.Owner, bolt), false, predicted: true);
+            PushState(ent);
+        }
+    }
+
+    public void SetOverride(Entity<FirelockBoltControlComponent> ent, bool value, bool playSound = true)
     {
         if (ent.Comp.Override == value)
             return;
@@ -168,17 +343,23 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
         ent.Comp.Override = value;
         Dirty(ent, ent.Comp);
 
-        var sound = value ? ent.Comp.EnableSound : ent.Comp.DisableSound;
-        _audio.PlayPvs(sound, ent.Owner);
+        if (playSound)
+        {
+            var sound = value ? ent.Comp.EnableSound : ent.Comp.DisableSound;
+            _audio.PlayPvs(sound, ent.Owner);
+        }
 
         if (value)
         {
+            ent.Comp.IsRemoteBolted = false;
+            Dirty(ent, ent.Comp);
+
             if (DoorBoltQuery.TryComp(ent.Owner, out var bolt))
-                DoorSystem.SetBoltsDown((ent.Owner, bolt), false);
+                DoorSystem.SetBoltsDown((ent.Owner, bolt), false, force: true);
         }
-        else if (DoorQuery.TryComp(ent.Owner, out var door))
+        else
         {
-            ApplyBoltForDoorState(ent, door.State);
+            UpdateHazardBolts(ent);
         }
 
         PushState(ent);

--- a/Content.Shared/_Funkystation/FirelockBolt/EntitySystems/SharedFirelockBoltControlSystem.cs
+++ b/Content.Shared/_Funkystation/FirelockBolt/EntitySystems/SharedFirelockBoltControlSystem.cs
@@ -1,15 +1,9 @@
-// SPDX-FileCopyrightText: 2026 MaiaArai <158123176+YaraaraY@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
-using Content.Shared._Funkystation.FirelockBolt.Components;
+﻿using Content.Shared._Funkystation.FirelockBolt.Components;
 using Content.Shared.DoAfter;
 using Content.Shared.Doors;
 using Content.Shared.Doors.Components;
 using Content.Shared.Doors.Systems;
 using Content.Shared.Interaction;
-using Content.Shared.Prying.Components;
 using Content.Shared.Verbs;
 using Content.Shared.Wires;
 using Robust.Shared.Audio.Systems;
@@ -27,7 +21,6 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
     [Dependency] private IGameTiming _timing = null!;
     [Dependency] protected EntityQuery<DoorBoltComponent> DoorBoltQuery = default!;
     [Dependency] protected EntityQuery<DoorComponent> DoorQuery = default!;
-    [Dependency] private EntityQuery<FirelockComponent> _firelockQuery;
     [Dependency] private EntityQuery<WiresPanelComponent> _wiresPanelQuery;
 
     public override void Initialize()
@@ -42,10 +35,6 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
         SubscribeLocalEvent<FirelockBoltControlComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
         SubscribeLocalEvent<FirelockBoltControlComponent, BoundUIOpenedEvent>(OnBuiOpened);
         SubscribeLocalEvent<FirelockBoltControlComponent, FirelockOverrideSetMessage>(OnOverrideSetMessage);
-        // after DoorBolt so crowbar can still get through hazard bolts
-        SubscribeLocalEvent<FirelockBoltControlComponent, BeforePryEvent>(OnBeforePry, after: new[] { typeof(SharedDoorSystem) });
-
-        SubscribeLocalEvent<FirelockBoltControlComponent, PriedEvent>(OnPried, before: new[] { typeof(SharedDoorSystem) });
     }
 
     private void OnDoorStateChanged(Entity<FirelockBoltControlComponent> ent, ref DoorStateChangedEvent args)
@@ -145,25 +134,6 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
         SetOverride(ent, args.TargetOverride);
     }
 
-    private void OnBeforePry(Entity<FirelockBoltControlComponent> ent, ref BeforePryEvent args)
-    {
-        if (!args.Cancelled || ent.Comp.Override)
-            return;
-
-        if (!DoorBoltQuery.TryComp(ent.Owner, out var bolt) || !bolt.BoltsDown)
-            return;
-
-        args.Cancelled = false;
-        args.Message = null;
-    }
-
-    private void OnPried(Entity<FirelockBoltControlComponent> ent, ref PriedEvent args)
-    {
-        // drop bolts before StartOpening runs
-        if (DoorBoltQuery.TryComp(ent.Owner, out var bolt) && bolt.BoltsDown)
-            DoorSystem.SetBoltsDown((ent.Owner, bolt), false, args.User, predicted: true);
-    }
-
     private void ApplyBoltForDoorState(Entity<FirelockBoltControlComponent> ent, DoorState state)
     {
         if (ent.Comp.Override || !DoorBoltQuery.TryComp(ent.Owner, out var bolt))
@@ -172,54 +142,25 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
         switch (state)
         {
             case DoorState.Closing:
+                // if the door starts closing within 1.5 seconds of a player clicking it, it's a manual close, don't bolt
                 ent.Comp.IsManualClose = (_timing.CurTime - ent.Comp.LastManualInteractionTime) < TimeSpan.FromSeconds(1.5);
                 break;
 
             case DoorState.Closed:
             case DoorState.Welded:
-
-                UpdateHazardBolts(ent);
-
+                // bolt shut if it was automatically closed
+                if (ent.Comp.AlarmActive || !ent.Comp.IsManualClose)
+                    DoorSystem.SetBoltsDown((ent.Owner, bolt), true, predicted: true);
                 break;
 
             case DoorState.Open:
                 DoorSystem.SetBoltsDown((ent.Owner, bolt), false, predicted: true);
-
                 ent.Comp.IsManualClose = false;
-
                 break;
         }
     }
 
-    public void UpdateHazardBolts(Entity<FirelockBoltControlComponent> ent, FirelockComponent? firelock = null, DoorComponent? door = null)
-    {
-        if (ent.Comp.Override)
-            return;
-
-        if (firelock == null && !_firelockQuery.TryComp(ent.Owner, out firelock))
-            return;
-
-        if (door == null && !DoorQuery.TryComp(ent.Owner, out door))
-            return;
-
-        if (!DoorBoltQuery.TryComp(ent.Owner, out var bolt))
-            return;
-
-        var shouldBolt = (door.State == DoorState.Closed || door.State == DoorState.Welded)
-            && (ent.Comp.AlarmActive || firelock.IsLocked);
-
-        if (bolt.BoltsDown == shouldBolt)
-            return;
-
-        DoorSystem.SetBoltsDown((ent.Owner, bolt), shouldBolt, predicted: true);
-        
-        PushState(ent);
-    }
-
-    /// <summary>
-    /// While on, hazard wont rebolt this door
-    /// </summary>
-    public void SetOverride(Entity<FirelockBoltControlComponent> ent, bool value, bool playSound = true)
+    private void SetOverride(Entity<FirelockBoltControlComponent> ent, bool value)
     {
         if (ent.Comp.Override == value)
             return;
@@ -227,20 +168,17 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
         ent.Comp.Override = value;
         Dirty(ent, ent.Comp);
 
-        if (playSound)
-        {
-            var sound = value ? ent.Comp.EnableSound : ent.Comp.DisableSound;
-            _audio.PlayPvs(sound, ent.Owner);
-        }
+        var sound = value ? ent.Comp.EnableSound : ent.Comp.DisableSound;
+        _audio.PlayPvs(sound, ent.Owner);
 
         if (value)
         {
             if (DoorBoltQuery.TryComp(ent.Owner, out var bolt))
                 DoorSystem.SetBoltsDown((ent.Owner, bolt), false);
         }
-        else
+        else if (DoorQuery.TryComp(ent.Owner, out var door))
         {
-            UpdateHazardBolts(ent);
+            ApplyBoltForDoorState(ent, door.State);
         }
 
         PushState(ent);

--- a/Content.Shared/_Funkystation/FirelockBolt/EntitySystems/SharedFirelockBoltControlSystem.cs
+++ b/Content.Shared/_Funkystation/FirelockBolt/EntitySystems/SharedFirelockBoltControlSystem.cs
@@ -159,9 +159,9 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
 
     private void OnPried(Entity<FirelockBoltControlComponent> ent, ref PriedEvent args)
     {
-        // drop bolts before StartOpening, even when unpowered
+        // drop bolts before StartOpening runs
         if (DoorBoltQuery.TryComp(ent.Owner, out var bolt) && bolt.BoltsDown)
-            DoorSystem.SetBoltsDown((ent.Owner, bolt), false, args.User, predicted: true, force: true);
+            DoorSystem.SetBoltsDown((ent.Owner, bolt), false, args.User, predicted: true);
     }
 
     private void ApplyBoltForDoorState(Entity<FirelockBoltControlComponent> ent, DoorState state)
@@ -177,12 +177,16 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
 
             case DoorState.Closed:
             case DoorState.Welded:
+
                 UpdateHazardBolts(ent);
+
                 break;
 
             case DoorState.Open:
-                DoorSystem.SetBoltsDown((ent.Owner, bolt), false, predicted: true, force: true);
+                DoorSystem.SetBoltsDown((ent.Owner, bolt), false, predicted: true);
+
                 ent.Comp.IsManualClose = false;
+
                 break;
         }
     }
@@ -201,14 +205,14 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
         if (!DoorBoltQuery.TryComp(ent.Owner, out var bolt))
             return;
 
-        var shouldBolt = firelock.Powered
-            && (door.State == DoorState.Closed || door.State == DoorState.Welded)
+        var shouldBolt = (door.State == DoorState.Closed || door.State == DoorState.Welded)
             && (ent.Comp.AlarmActive || firelock.IsLocked);
 
         if (bolt.BoltsDown == shouldBolt)
             return;
 
-        DoorSystem.SetBoltsDown((ent.Owner, bolt), shouldBolt, predicted: true, force: !shouldBolt);
+        DoorSystem.SetBoltsDown((ent.Owner, bolt), shouldBolt, predicted: true);
+        
         PushState(ent);
     }
 
@@ -232,7 +236,7 @@ public abstract partial class SharedFirelockBoltControlSystem : EntitySystem
         if (value)
         {
             if (DoorBoltQuery.TryComp(ent.Owner, out var bolt))
-                DoorSystem.SetBoltsDown((ent.Owner, bolt), false, force: true);
+                DoorSystem.SetBoltsDown((ent.Owner, bolt), false);
         }
         else
         {

--- a/Resources/Locale/en-US/_Funkystation/doors/firelocks.ftl
+++ b/Resources/Locale/en-US/_Funkystation/doors/firelocks.ftl
@@ -4,3 +4,5 @@ firelock-bolt-control-window-status-unlocked = UNLOCKED
 firelock-bolt-control-window-status-override = OVERRIDE ENGAGED
 firelock-bolt-control-window-hint = Pull for manual bolt override.
 firelock-bolt-control-verb-open-ui = Open bolt override panel
+firelock-bolt-control-remote-override = Manual override is engaged - remote control disabled
+firelock-bolt-control-remote-hazard = Firelock is sealing a hazard - bolts cannot be released

--- a/Resources/Locale/en-US/prototypes/generated/entities/structures/doors/firelocks/firelock.ftl
+++ b/Resources/Locale/en-US/prototypes/generated/entities/structures/doors/firelocks/firelock.ftl
@@ -1,5 +1,5 @@
 ent-BaseFirelock = firelock
-    .desc = Apply crowbar.
+    .desc = A maintenance panel tray sits on the mechanism's surface, along with a marked pry point for forcing the firelock open when unpowered.
 ent-Firelock = { ent-BaseFirelock }
     .desc = { ent-BaseFirelock.desc }
 ent-FirelockGlass = glass firelock

--- a/Resources/Locale/pl-PL/_Funkystation/doors/firelocks.ftl
+++ b/Resources/Locale/pl-PL/_Funkystation/doors/firelocks.ftl
@@ -1,6 +1,8 @@
-firelock-bolt-control-window-title = Bolt Override
-firelock-bolt-control-window-status-locked = BOLTED
-firelock-bolt-control-window-status-unlocked = UNLOCKED
-firelock-bolt-control-window-status-override = OVERRIDE ENGAGED
-firelock-bolt-control-window-hint = Pull for manual bolt override.
-firelock-bolt-control-verb-open-ui = Open bolt override panel
+firelock-bolt-control-window-title = Nadpisanie bolców
+firelock-bolt-control-window-status-locked = ZABOLTOWANE
+firelock-bolt-control-window-status-unlocked = ODBLOKOWANE
+firelock-bolt-control-window-status-override = NADPISANIE AKTYWNE
+firelock-bolt-control-window-hint = Pociągnij, aby nadpisać bolce.
+firelock-bolt-control-verb-open-ui = Otwórz panel nadpisania bolców
+firelock-bolt-control-remote-override = Ręczne nadpisanie jest aktywne - sterowanie zdalne wyłączone
+firelock-bolt-control-remote-hazard = Śluza przeciwpożarowa izoluje zagrożenie - bolce nie mogą zostać zwolnione

--- a/Resources/Locale/pl-PL/prototypes/generated/entities/structures/doors/firelocks/firelock.ftl
+++ b/Resources/Locale/pl-PL/prototypes/generated/entities/structures/doors/firelocks/firelock.ftl
@@ -1,5 +1,5 @@
 ent-BaseFirelock = śluza przeciwpożarowa
-    .desc = Użyj łomu.
+    .desc = Na powierzchni mechanizmu widać tackę z panelem technicznym oraz oznaczony otwór do wyważenia śluzy przy braku zasilania.
 ent-Firelock = { ent-BaseFirelock }
     .desc = { ent-BaseFirelock.desc }
 ent-FirelockGlass = szklana śluza przeciwpożarowa

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -3,7 +3,7 @@
   abstract: true
   parent: BaseStructure
   name: firelock
-  description: Apply crowbar.
+  description: A maintenance panel tray sits on the mechanism's surface, along with a marked pry point for forcing the firelock open when unpowered.
   components:
   - type: Anchorable
     flags:
@@ -31,6 +31,7 @@
   - type: Tag
     tags:
     - ForceFixRotations # Allow fixrotations to target these
+    - DoorRemoteWhitelist # Polonium
   - type: Destructible
     thresholds:
     - trigger:
@@ -227,6 +228,7 @@
   - type: Tag
     tags:
     - ForceNoFixRotations # Prevent fixrotations from targeting these, since the base Firelock is targeted
+    - DoorRemoteWhitelist
   - type: Door
     occludes: false
   - type: Physics

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -1,60 +1,3 @@
-# SPDX-FileCopyrightText: 2020 Git-Nivrak <59925169+Git-Nivrak@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2020 Paul Ritter <ritter.paul1@googlemail.com>
-# SPDX-FileCopyrightText: 2020 Víctor Aguilera Puerto <zddm@outlook.es>
-# SPDX-FileCopyrightText: 2021 Galactic Chimp <GalacticChimpanzee@gmail.com>
-# SPDX-FileCopyrightText: 2021 Kara D <lunarautomaton6@gmail.com>
-# SPDX-FileCopyrightText: 2021 Kara Dinyes <lunarautomaton6@gmail.com>
-# SPDX-FileCopyrightText: 2021 Paul <ritter.paul1+git@googlemail.com>
-# SPDX-FileCopyrightText: 2021 Peptide90 <78795277+Peptide90@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
-# SPDX-FileCopyrightText: 2021 Silver <silvertorch5@gmail.com>
-# SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
-# SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto <zddm@outlook.es>
-# SPDX-FileCopyrightText: 2021 metalgearsloth <comedian_vs_clown@hotmail.com>
-# SPDX-FileCopyrightText: 2021 tmtmtl30 <53132901+tmtmtl30@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 Alex Evgrashin <aevgrashin@yandex.ru>
-# SPDX-FileCopyrightText: 2022 Andreas Kämper <andreas@kaemper.tech>
-# SPDX-FileCopyrightText: 2022 CrudeWax <75271456+CrudeWax@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 Flipp Syder <76629141+vulppine@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 Jacob Tong <10494922+ShadowCommander@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 Julian Giebel <juliangiebel@live.de>
-# SPDX-FileCopyrightText: 2022 Vera Aguilera Puerto <6766154+Zumorica@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 Visne <39844191+Visne@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 WlarusFromDaSpace <44726328+WlarusFromDaSpace@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 keronshb <54602815+keronshb@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 mirrorcult <lunarautomaton6@gmail.com>
-# SPDX-FileCopyrightText: 2022 themias <89101928+themias@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 vulppine <vulppine@gmail.com>
-# SPDX-FileCopyrightText: 2023 Chase Maguire <32408355+Wirdal@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Morb <14136326+Morb0@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 TemporalOroboros <TemporalOroboros@gmail.com>
-# SPDX-FileCopyrightText: 2023 Tom Leys <tom@crump-leys.com>
-# SPDX-FileCopyrightText: 2023 deltanedas <39013340+deltanedas@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 lzk <124214523+lzk228@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Ilya246 <57039557+Ilya246@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Tayrtahn <tayrtahn@gmail.com>
-# SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 nikthechampiongr <32041239+nikthechampiongr@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 osjarw <62134478+osjarw@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 ArtisticRoomba <145879011+ArtisticRoomba@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 ShadowCommander <10494922+ShadowCommander@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Southbridge <7013162+southbridge-fur@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 chromiumboy <50505512+chromiumboy@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2026 MaiaArai <158123176+YaraaraY@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2026 Steve <marlumpy@gmail.com>
-# SPDX-FileCopyrightText: 2026 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2026 pathetic meowmeow <uhhadd@gmail.com>
-# SPDX-FileCopyrightText: 2026 taydeo <tay@funkystation.org>
-# SPDX-FileCopyrightText: 2026 taydeo <td12233a@gmail.com>
-# SPDX-FileCopyrightText: 2026 āda <ss.adasts@gmail.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 - type: entity
   id: BaseFirelock
   abstract: true
@@ -88,7 +31,6 @@
   - type: Tag
     tags:
     - ForceFixRotations # Allow fixrotations to target these
-    - DoorRemoteWhitelist # Polonium: allow remotes to interact with firelocks
   - type: Destructible
     thresholds:
     - trigger:
@@ -285,7 +227,6 @@
   - type: Tag
     tags:
     - ForceNoFixRotations # Prevent fixrotations from targeting these, since the base Firelock is targeted
-    - DoorRemoteWhitelist
   - type: Door
     occludes: false
   - type: Physics


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->

:cl: nikita
- tweak: Przebudowano zachowanie śluz przeciwpożarowych - przy zasilaniu zabołtowane otwierają się tylko dźwignią override, bez zasilania można je wyważyć (rękoma ~10 s, łom szybciej, jaws jeszcze szybciej), po czym zamykają się bez boltów i wracają bolce po przywróceniu zasilania przy zagrożeniu.
- tweak: Piloty drzwi i AI mogą boltować/rozboltować śluzy bez override, a przy zagrożeniu rozboltowanie jest blokowane. Przy włączonym override pilot nie działa, a bolce są zdjęte.
- tweak: Status boltów śluz aktualizuje się od razu przy zmianie statusu AirAlarm/FireAlarm
- tweak: Polskie tłumaczenie i UX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nowe funkcje**
  * Dodano zdalne sterowanie bolcami firelocków dla pilotów i systemów SI.
  * Firelocki przekazują alarmy bezpośrednio do podłączonych urządzeń, zapewniając szybszą reakcję.
  * Dodano komunikaty informujące o ręcznym nadpisaniu oraz blokadzie zwalniania podczas zagrożenia.

* **Poprawki**
  * Ulepszono automatyczne ryglowanie przy pożarach i niebezpiecznym ciśnieniu.
  * Zablokowano niebezpieczne odryglowanie podczas aktywnego zagrożenia.
  * Zdalne sterowanie poprawnie uwzględnia brak zasilania i stan ręcznego nadpisania.

* **Tłumaczenia i opisy**
  * Uzupełniono polskie tłumaczenia komunikatów firelocków.
  * Doprecyzowano opis panelu konserwacyjnego i awaryjnego podważania.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->