### PR TITLE
Podmieniono na mapie centcomm 6 telefonów na 1 telefon CD; usunięto z…

### DIFF
--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -44357,37 +44357,12 @@ entities:
     - type: Transform
       pos: -3.598611,-0.49923915
       parent: 1668
-- proto: PhoneInstrument
+- proto: CallablePhoneInstrumentCentComm
   entities:
   - uid: 1384
     components:
     - type: Transform
       pos: 0.51263905,1.1600976
-      parent: 1668
-  - uid: 2029
-    components:
-    - type: Transform
-      pos: 28.45356,27.588108
-      parent: 1668
-  - uid: 2849
-    components:
-    - type: Transform
-      pos: -16.54149,11.627905
-      parent: 1668
-  - uid: 4764
-    components:
-    - type: Transform
-      pos: -3.5407324,-49.447086
-      parent: 1668
-  - uid: 6763
-    components:
-    - type: Transform
-      pos: -44.811134,-4.457982
-      parent: 1668
-  - uid: 9609
-    components:
-    - type: Transform
-      pos: -36.167408,11.646058
       parent: 1668
 - proto: PlaqueAtmos
   entities:

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -164,7 +164,6 @@
     - trayScanner
     - AccessConfiguratorUniversal
     - Multitool
-    - CallablePhoneInstrumentCentComm
 
 #Gladiator with spear
 - type: startingGear


### PR DESCRIPTION
… plecaka admina

<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
:cl: nikita
- tweak: Podmieniono na mapie centcomm 6 telefonów na 1 telefon CD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Zmiany**
  - Zaktualizowano wyposażenie i rozmieszczenie telefonów w CentComm.
  - Usunięto nadmiarowe instancje telefonów z mapy.
  - Telefon CentComm nie jest już dostępny w wyposażeniu startowym Aghosta.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->