### PR TITLE
Poprawki kartridżów PDA

### DIFF
--- a/Content.Client/CartridgeLoader/CartridgeLoaderBoundUserInterface.cs
+++ b/Content.Client/CartridgeLoader/CartridgeLoaderBoundUserInterface.cs
@@ -1,6 +1,7 @@
 using Content.Client.UserInterface.Fragments;
 using Content.Shared.CartridgeLoader;
 using Robust.Client.UserInterface;
+using Robust.Shared.Timing;
 
 namespace Content.Client.CartridgeLoader;
 
@@ -18,9 +19,12 @@ public abstract class CartridgeLoaderBoundUserInterface : BoundUserInterface
 
     private IEntityManager _entManager;
 
+    private IGameTiming _timing;
+
     protected CartridgeLoaderBoundUserInterface(EntityUid owner, Enum uiKey) : base(owner, uiKey)
     {
         _entManager = IoCManager.Resolve<IEntityManager>();
+        _timing = IoCManager.Resolve<IGameTiming>();
     }
 
     protected override void UpdateState(BoundUserInterfaceState state)
@@ -39,28 +43,28 @@ public abstract class CartridgeLoaderBoundUserInterface : BoundUserInterface
 
         var activeUI = _entManager.GetEntity(loaderUiState.ActiveUI);
 
+        // Prevent the active program's UI from getting rebuilt and attached multiple times.
+        if (_activeProgram == activeUI && _activeUiFragment is not null)
+            return;
+
         _activeProgram = activeUI;
 
         var ui = RetrieveCartridgeUI(activeUI);
         var comp = RetrieveCartridgeComponent(activeUI);
         var control = ui?.GetUIFragmentRoot();
 
-        //Prevent the same UI fragment from getting disposed and attached multiple times
-        if (_activeUiFragment?.GetType() == control?.GetType())
-            return;
-
         if (_activeUiFragment is not null)
             DetachCartridgeUI(_activeUiFragment);
 
         if (control is not null && _activeProgram.HasValue)
-        {
             AttachCartridgeUI(control, Loc.GetString(comp?.ProgramName ?? "default-program-name"));
-            SendCartridgeUiReadyEvent(_activeProgram.Value);
-        }
 
         _activeCartridgeUI = ui;
         _activeUiFragment?.Dispose();
         _activeUiFragment = control;
+
+        if (control is not null && _activeProgram.HasValue)
+            SendCartridgeUiReadyEvent(_activeProgram.Value);
     }
 
     protected void ActivateCartridge(EntityUid cartridgeUid)
@@ -132,7 +136,10 @@ public abstract class CartridgeLoaderBoundUserInterface : BoundUserInterface
     private void SendCartridgeUiReadyEvent(EntityUid cartridgeUid)
     {
         var message = new CartridgeLoaderUiMessage(_entManager.GetNetEntity(cartridgeUid), CartridgeUiMessageAction.UIReady);
-        SendMessage(message);
+        if (_timing.InPrediction && _timing.IsFirstTimePredicted)
+            SendPredictedMessage(message);
+        else
+            SendMessage(message);
     }
 
     private UIFragment? RetrieveCartridgeUI(EntityUid? cartridgeUid)

--- a/Content.Client/CartridgeLoader/CartridgeLoaderBoundUserInterface.cs
+++ b/Content.Client/CartridgeLoader/CartridgeLoaderBoundUserInterface.cs
@@ -1,3 +1,14 @@
+// SPDX-FileCopyrightText: 2022 Julian Giebel <juliangiebel@live.de>
+// SPDX-FileCopyrightText: 2022 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 TemporalOroboros <TemporalOroboros@gmail.com>
+// SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 maciejwalendziuk <15122746+maciejwalendziuk@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 pathetic meowmeow <uhhadd@gmail.com>
+// SPDX-FileCopyrightText: 2026 taydeo <tay@funkystation.org>
+// SPDX-FileCopyrightText: 2026 taydeo <td12233a@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Client.UserInterface.Fragments;
 using Content.Shared.CartridgeLoader;
 using Robust.Client.UserInterface;

--- a/Content.Server/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
+++ b/Content.Server/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
@@ -89,8 +89,10 @@ public sealed partial class CrewManifestCartridgeSystem : EntitySystem
         {
             if (_unsecureViewersAllowed)
             {
-                _cartridgeLoader.InstallProgram((loaderUid, comp), CartridgePrototypeName, false);
-                return;
+                if (!_cartridgeLoader.HasProgram<CrewManifestCartridgeComponent>((loaderUid, comp)))
+                    _cartridgeLoader.InstallProgram((loaderUid, comp), CartridgePrototypeName, false);
+
+                continue;
             }
 
             if (_cartridgeLoader.TryGetProgram<CrewManifestCartridgeComponent>((loaderUid, comp)) is { } program)

--- a/Content.Server/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
+++ b/Content.Server/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
@@ -1,3 +1,17 @@
+// SPDX-FileCopyrightText: 2023 Phill101 <28949487+Phill101@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 Phill101 <holypics4@gmail.com>
+// SPDX-FileCopyrightText: 2023 Vordenburg <114301317+Vordenburg@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Tayrtahn <tayrtahn@gmail.com>
+// SPDX-FileCopyrightText: 2026 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+// SPDX-FileCopyrightText: 2026 Schuyler Duryee <skywd7766@gmail.com>
+// SPDX-FileCopyrightText: 2026 maciejwalendziuk <15122746+maciejwalendziuk@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 pathetic meowmeow <uhhadd@gmail.com>
+// SPDX-FileCopyrightText: 2026 taydeo <tay@funkystation.org>
+// SPDX-FileCopyrightText: 2026 taydeo <td12233a@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Server.CrewManifest;
 using Content.Server.Station.Systems;
 using Content.Shared.CartridgeLoader;

--- a/Content.Shared/CartridgeLoader/CartridgeLoaderSystem.UserInterface.cs
+++ b/Content.Shared/CartridgeLoader/CartridgeLoaderSystem.UserInterface.cs
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 maciejwalendziuk <15122746+maciejwalendziuk@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 pathetic meowmeow <uhhadd@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Linq;
 
 namespace Content.Shared.CartridgeLoader;

--- a/Content.Shared/CartridgeLoader/CartridgeLoaderSystem.UserInterface.cs
+++ b/Content.Shared/CartridgeLoader/CartridgeLoaderSystem.UserInterface.cs
@@ -23,6 +23,9 @@ public sealed partial class CartridgeLoaderSystem
                 UninstallProgram(ent, cartridge);
                 break;
             case CartridgeUiMessageAction.UIReady:
+                if (!_timing.IsFirstTimePredicted)
+                    break;
+
                 if (ent.Comp.ActiveProgram is { } foreground)
                 {
                     var evt = new CartridgeUiReadyEvent(ent);


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Dwie poprawki w cartridge loaderze:
1. Uruchomiony program w PDA wyswietlal puste okno
2. Przelaczanie CVara `crewmanifest.unsecure` dzialalo tylko na jedno PDA, a po naprawie tego duplikowalo aplikacje w pozostalych


## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
_Brak_

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
UIReady wyprzedzalo Activate. ActivateCartridge uzywa SendPredictedMessage a SendCartridgeUiReadyEvent uzywalo SendMessage. UIReady jest teraz predicted.


## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->
_Brak_

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: haze
- fix: Naprawiono kartridże PDA (w tym manifest załogi)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Ulepszenia**
  * Usprawniono obsługę interfejsu kartridży, ograniczając wielokrotne podpinanie tego samego widoku.
  * Zoptymalizowano synchronizację komunikatów o gotowości interfejsu podczas przewidywania działań.

* **Poprawki błędów**
  * Naprawiono aktualizowanie aktywnego interfejsu po zmianie programu lub jego zamknięciu.
  * Poprawiono automatyczne instalowanie programu manifestu załogi we wszystkich właściwych urządzeniach.
  * Usunięto możliwość wielokrotnego wywoływania obsługi gotowości interfejsu w ramach tego samego przewidywanego działania.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->