### PR TITLE
Brak głosów oddanych na tryb gry i mapę nie wywołuje losowania 

### DIFF
--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -29,6 +29,7 @@
 // SPDX-FileCopyrightText: 2026 Nikita (Nick) <174215049+nikitosych@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2026 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
 // SPDX-FileCopyrightText: 2026 Winkarst-cpu <74284083+Winkarst-cpu@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 maciejwalendziuk <15122746+maciejwalendziuk@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2026 taydeo <tay@funkystation.org>
 // SPDX-FileCopyrightText: 2026 taydeo <td12233a@gmail.com>
 //

--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -280,6 +280,12 @@ namespace Content.Server.Voting.Managers
 
             vote.OnFinished += (_, args) =>
             {
+                if (vote.CastVotes.Count == 0)
+                {
+                    _adminLogger.Add(LogType.Vote, LogImpact.Low, $"Preset vote finished with no votes cast; keeping current preset.");
+                    return;
+                }
+
                 string picked;
                 if (args.Winner == null)
                 {
@@ -327,6 +333,12 @@ namespace Content.Server.Voting.Managers
 
             vote.OnFinished += (_, args) =>
             {
+                if (vote.CastVotes.Count == 0)
+                {
+                    _adminLogger.Add(LogType.Vote, LogImpact.Low, $"Map vote finished with no votes cast; keeping current map.");
+                    return;
+                }
+
                 GameMapPrototype picked;
                 if (args.Winner == null)
                 {


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Jeśli gracze nie zagłosują na tryb gry lub mapę to te wartości są losowane. Odbiega to od upstreamowego zachowania i psuje testy.

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
Closes #819. 

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
Test failował (#819), bo podczas lobby uruchamiało się głosowanie, w którym nikt nie głosował. W związku z tym istniało prawdopodobieństwo gdzie dla testu związanego z pracami losuje się tryb deathmatch, który nie ma do wyboru żadnych prac. Zmieniono logikę VoteManagera tak, żeby nie losował map ani trybów gry w przypadku kiedy nie został oddany żaden głos - mapa i tryb gry pozostaje bez zmian. 

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->
_Brak_

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: haze
- tweak: Tryb gry oraz mapa nie zmienia się jeśli nie został oddany żaden głos (lobby)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Poprawki**
  * Zakończone głosowania bez oddanych głosów nie zmieniają już bieżącego presetu ani mapy.
  * Dodano obsługę oraz rejestrowanie takich przypadków, aby zapobiec nieoczekiwanym zmianom po nierozstrzygniętym głosowaniu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->