### PR TITLE
MergeOverflowTest - poprawki assertów 

### DIFF
--- a/Content.IntegrationTests/Tests/Stacks/StackTests.cs
+++ b/Content.IntegrationTests/Tests/Stacks/StackTests.cs
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 maciejwalendziuk <15122746+maciejwalendziuk@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 āda <ss.adasts@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Collections.Generic;
 using System.Linq;
 using Content.IntegrationTests.Fixtures;

--- a/Content.IntegrationTests/Tests/Stacks/StackTests.cs
+++ b/Content.IntegrationTests/Tests/Stacks/StackTests.cs
@@ -19,7 +19,16 @@ public sealed class StackTest : GameTest
     [Description("Tests for SharedStackSystem.SetCount .")]
     public async Task SetTest()
     {
-        var stack = await Spawn(StackEnt1);
+        var baseEntityCount = 0;
+        EntityUid stack = default;
+
+        await Server.WaitPost(() =>
+        {
+            // The pair may be recycled, so compare entity counts relative to the pre-test state
+            baseEntityCount = SEntMan.EntityCount;
+
+            stack = SSpawn(StackEnt1);
+        });
 
         // Raising the count
         await Server.WaitPost(() => _sStackSystem.SetCount((stack, null), 2));
@@ -36,7 +45,7 @@ public sealed class StackTest : GameTest
         // Setting to 0 deletes the stack
         await Server.WaitPost(() =>_sStackSystem.SetCount((stack, null), 0));
         await Server.WaitRunTicks(1);
-        Assert.That(SEntMan.EntityCount, Is.Zero);
+        Assert.That(SEntMan.EntityCount, Is.EqualTo(baseEntityCount));
     }
 
     [Test]
@@ -44,9 +53,13 @@ public sealed class StackTest : GameTest
     public async Task MergeTest()
     {
         var stacks = new HashSet<EntityUid>();
+        var baseEntityCount = 0;
 
         await Server.WaitPost(() =>
         {
+            // The pair may be recycled, so compare entity counts relative to the pre-test state
+            baseEntityCount = SEntMan.EntityCount;
+
             stacks =
             [
                 SSpawn(StackEnt1),
@@ -67,7 +80,7 @@ public sealed class StackTest : GameTest
             Assert.That(_sStackSystem.GetCount(stacks.First()), Is.EqualTo(3));
 
             // Assert that the other stack was set to zero and deleted
-            Assert.That(SEntMan.EntityCount, Is.EqualTo(1));
+            Assert.That(SEntMan.EntityCount, Is.EqualTo(baseEntityCount + 1));
         }
     }
 
@@ -76,15 +89,19 @@ public sealed class StackTest : GameTest
     public async Task MergeOverflowTest()
     {
         var stacks = new HashSet<EntityUid>();
+        var baseEntityCount = 0;
 
         await Server.WaitPost(() =>
         {
-             stacks =
-             [
-                 SSpawn(StackEnt1),
-                 SSpawn(StackEnt2),
-                 SSpawn(StackEnt30),
-             ];
+            // The pair may be recycled, so compare entity counts relative to the pre-test state
+            baseEntityCount = SEntMan.EntityCount;
+
+            stacks =
+            [
+                SSpawn(StackEnt1),
+                SSpawn(StackEnt2),
+                SSpawn(StackEnt30),
+            ];
 
             _sStackSystem.MergeStacks(ref stacks);
         });
@@ -106,7 +123,7 @@ public sealed class StackTest : GameTest
             // Assert that both stacks were returned
             // And that the empty stack was deleted
             Assert.That(stacks, Has.Count.EqualTo(2));
-            Assert.That(SEntMan.EntityCount, Is.EqualTo(2));
+            Assert.That(SEntMan.EntityCount, Is.EqualTo(baseEntityCount + 2));
 
             // Assert we have the same count as what we spawned
             Assert.That(count, Is.EqualTo(33));
@@ -124,7 +141,7 @@ public sealed class StackTest : GameTest
         var donor = await SpawnAtPosition(StackEnt1, map.GridCoords);
         var receiver = await SpawnAtPosition(StackEnt1, map.GridCoords);
 
-        _sStackSystem.TryMergeToContacts(donor);
+        await Server.WaitPost(() => _sStackSystem.TryMergeToContacts(donor));
 
         // Wait for queue deletion
         await Server.WaitRunTicks(1);


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Naprawia błąd upstreama (https://github.com/space-wizards/space-station-14/issues/44721). PR jest dobry kandydatem do otwarcia na upstreamie.

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
Naprawia błąd upstreama.
closes: #820


## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
1. Relatywne asserty w 3 testach.
2. Poprawka mutacji encji (linia 160 tego testu ma ten wrapper, ale brakowało go w 144).

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->
_Brak_
<!--
---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry.

:cl: nazwa_użytkownika
- add: Dodano zabawę!
- remove: Usunięto zabawę!
- tweak: Zmieniono zabawę!
- fix: Naprawiono zabawę!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Testy**
  * Usprawniono testy operacji na stosach, aby poprawnie uwzględniały początkową liczbę encji.
  * Zaktualizowano testy tworzenia, scalania i przepełnienia stosów.
  * Ujednolicono asynchroniczne wykonywanie operacji podczas testów.
* **Chores**
  * Dodano nagłówki licencyjne SPDX do testów.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->