### PR TITLE
Poprawki regresji RandomMetadataSystem

### DIFF
--- a/Content.Server/RandomMetadata/RandomMetadataSystem.cs
+++ b/Content.Server/RandomMetadata/RandomMetadataSystem.cs
@@ -18,21 +18,10 @@ public sealed partial class RandomMetadataSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<RandomMetadataComponent, MapInitEvent>(OnMapInit);
-        SubscribeLocalEvent<RandomMetadataComponent, ComponentStartup>(OnStartup);
-    }
-
-    private void OnStartup(EntityUid uid, RandomMetadataComponent component, ComponentStartup args)
-    {
-        ApplyRandomMetadata(uid, component);
     }
 
     // This is done on map init so that map-placed entities have it randomized each time the map loads, for fun.
     private void OnMapInit(EntityUid uid, RandomMetadataComponent component, MapInitEvent args)
-    {
-        ApplyRandomMetadata(uid, component);
-    }
-
-    private void ApplyRandomMetadata(EntityUid uid, RandomMetadataComponent component)
     {
         var meta = MetaData(uid);
 

--- a/Content.Server/RandomMetadata/RandomMetadataSystem.cs
+++ b/Content.Server/RandomMetadata/RandomMetadataSystem.cs
@@ -1,3 +1,21 @@
+// SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
+// SPDX-FileCopyrightText: 2022 Moony <moonheart08@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 Visne <39844191+Visne@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 Ed <96445749+TheShuEd@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 Łukasz Mędrek <lukasz@lukaszm.xyz>
+// SPDX-FileCopyrightText: 2025 Tayrtahn <tayrtahn@gmail.com>
+// SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 Nikita (Nick) <174215049+nikitosych@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+// SPDX-FileCopyrightText: 2026 Whatstone <166147148+whatston3@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 maciejwalendziuk <15122746+maciejwalendziuk@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 nikitosych <174215049+nikitosych@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 taydeo <tay@funkystation.org>
+// SPDX-FileCopyrightText: 2026 taydeo <td12233a@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared.Dataset;
 using Content.Shared.Random.Helpers;
 using JetBrains.Annotations;


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Poprawki regresji RandomMetadataSystem

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
Poprawki regresji RandomMetadataSystem
fixes: #826 
closes: #829

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
Usunięto subskrypcję ComponentStartup i handler OnStartup. Plik cofa zmiany do stanu sprzed #826, zgodnego z upstreamem. Naprawia (regresję) generowanie imion ERT z #826 - RobustToolbox sam wysyła MapInitEvent do komponentu dodanego do encji będącej już w MapInitialized. ComponentStartup **nie** był potrzebny. 

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->
_Brak_

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: haze
- fix: Naprawiono generowanie losowych imion ERT

