### PR TITLE
Przywrócienie hurtowych skrzynek stali, szkła i plastiku do zamówień cargo

### DIFF
--- a/Resources/Prototypes/_Funkystation/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/_Funkystation/Catalog/Cargo/cargo_materials.yml
@@ -8,7 +8,7 @@
     sprite: Objects/Materials/Sheets/glass.rsi
     state: glass_3
   product: CrateMaterialGlassBulk
-  cost: 4250
+  cost: 5400
   category: cargoproduct-category-name-materials
   group: market
 
@@ -18,7 +18,7 @@
     sprite: Objects/Materials/Sheets/metal.rsi
     state: steel_3
   product: CrateMaterialSteelBulk
-  cost: 4250
+  cost: 5400
   category: cargoproduct-category-name-materials
   group: market
 
@@ -28,6 +28,6 @@
     sprite: Objects/Materials/Sheets/other.rsi
     state: plastic_3
   product: CrateMaterialPlasticBulk
-  cost: 5500
+  cost: 6900
   category: cargoproduct-category-name-materials
   group: market

--- a/Resources/Prototypes/_Funkystation/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/_Funkystation/Catalog/Cargo/cargo_materials.yml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 ThatOneMoon <juozas.dringelis@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: cargoProduct
+  id: MaterialGlassBulk
+  icon:
+    sprite: Objects/Materials/Sheets/glass.rsi
+    state: glass_3
+  product: CrateMaterialGlassBulk
+  cost: 4250
+  category: cargoproduct-category-name-materials
+  group: market
+
+- type: cargoProduct
+  id: MaterialSteelBulk
+  icon:
+    sprite: Objects/Materials/Sheets/metal.rsi
+    state: steel_3
+  product: CrateMaterialSteelBulk
+  cost: 4250
+  category: cargoproduct-category-name-materials
+  group: market
+
+- type: cargoProduct
+  id: MaterialPlasticBulk
+  icon:
+    sprite: Objects/Materials/Sheets/other.rsi
+    state: plastic_3
+  product: CrateMaterialPlasticBulk
+  cost: 5500
+  category: cargoproduct-category-name-materials
+  group: market


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Przywrócenie możliwości zamówień skrzynek stali, szkła i plastiku po 270 sztuk w środku tak jak było przed rebase'm.
Oryginalnie też była możliwość zamówienia bulk plazmy jak i drewna, ale jako że te skrzynki nie dostały w ogóle przeportowane (w porównaniu do tych), postanowiłem je pominąć jako że nie wiem czy nie było to spowodowane inną decyzją

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
~~Plecy mnie bolą~~
Zdaża się że nie ma górników (albo są ale podąrzają za chwałą). W takim momencie przydają się takie skrzynki. Ponieważ zamiast tachania 3/4 tachasz jedną. Oszczędność czasu

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
Dodanie pliku Resources\Prototypes\_Funkystation\Catalog\Cargo\cargo_materials.yml gdzie są definicje produktów (prosto sprzed rebase'a)

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->
<img width="551" height="110" alt="Content Client_Qp5zeXXcf1" src="https://github.com/user-attachments/assets/0a079d9b-a9c1-4fdf-8384-1a2ab4c3c09f" />
<img width="389" height="125" alt="Content Client_eD78Z3ZG4U" src="https://github.com/user-attachments/assets/2f9e41b3-7d9f-40cf-b74b-a7fe9cae87de" />

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: Yaket
- add: Przywrócenie hurtowych skrzynek stali, szkła i plastiku do logistyki!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nowe funkcje**
  * Dodano do katalogu cargo materiały dostępne w sprzedaży: szkło, stal oraz plastik.
  * Każdy materiał ma własną ikonę, nazwę i cenę (szkło i stal: 5400, plastik: 6900).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->