### PR TITLE
Dodanie wózka dla inwalidów do Nanomeda i Fabrykatorów

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -75,6 +75,7 @@
     Defibrillator: 2 # Easily shared between several people
     Syringe: 4
     PillCanisterTricordrazine: 4
+    VehicleWheelchair: 2 # Polonium Change
     ClothingOuterHospitalGown: 2 # Not a popular item, so less stock
   contrabandInventory:
     PillCanisterRandom: 3

--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -47,14 +47,15 @@
   - OffsetCane
   - OffsetCaneWood
   - JetInjector
-
+  
 - type: latheRecipePack
   id: RollerBedsStatic
   recipes:
   - RollerBedSpawnFolded
   - CheapRollerBedSpawnFolded
   - EmergencyRollerBedSpawnFolded
-
+  - VehicleWheelchair # Polonium Addition
+  
 - type: latheRecipePack
   id: MedicalClothingStatic
   recipes:

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -201,11 +201,19 @@
   parent: RollerBedSpawnFolded
   id: CheapRollerBedSpawnFolded
   result: CheapRollerBedSpawnFolded
-
+  
 - type: latheRecipe
   parent: RollerBedSpawnFolded
   id: EmergencyRollerBedSpawnFolded
   result: EmergencyRollerBedSpawnFolded
+
+- type: latheRecipe # Polonium Addition
+  id: VehicleWheelchair
+  result: VehicleWheelchair
+  completetime: 4
+  materials:
+    Steel: 600
+    Plastic: 300   
 
 - type: latheRecipe
   id: WhiteCane


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
2 wózki do nanomeda plus
wózek do fabrykatora medycznego oraz autotokarki
## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: Czuat
- add: Dodano wózki inwalidzkie do Nanomeda plus, Fabrykatora medycznego oraz autotokarki




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nowe funkcje**
  * Dodano wózek inwalidzki do asortymentu automatu medycznego NanoMed Plus.
  * Dodano możliwość wytwarzania wózka inwalidzkiego w medycznych fabrykach, z użyciem stali i plastiku.
  * Wózek inwalidzki jest dostępny w odpowiednim pakiecie przepisów.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->