### PR TITLE
Ulepszenia xeno

### DIFF
--- a/Content.IntegrationTests/Tests/_RMC14/Xenonids/XenoSystemsTest.cs
+++ b/Content.IntegrationTests/Tests/_RMC14/Xenonids/XenoSystemsTest.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Numerics;
 using Content.IntegrationTests.Fixtures;
 using Content.IntegrationTests.Fixtures.Attributes;
+using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Acid;
 using Content.Shared._RMC14.Xenonids.Construction;
@@ -274,6 +275,37 @@ public sealed class XenoSystemsTest : GameTest
                 SEntMan.System<AlertsSystem>().IsShowingAlert((drone.Owner, alerts), "XenoPlasma"),
                 Is.True,
                 "Plasma alert should remain after evolution");
+        });
+    }
+
+    [Test]
+    public async Task EvolutionBlockedByCasteLimit()
+    {
+        var map = await Pair.CreateTestMap();
+
+        var coords = map.GridCoords.Offset(new Vector2(0.5f, 0.5f));
+
+        await Pair.Server.WaitPost(() =>
+        {
+            Pair.Server.CfgMan.SetCVar(RMCCVars.RMCXenoEvolutionCasteLimits, "CMXenoRavager=2");
+
+            SSpawnAtPosition("CMXenoRavager", coords);
+            SSpawnAtPosition("CMXenoRavager", coords);
+        });
+
+        await Pair.Server.WaitAssertion(() =>
+        {
+            var evoSys = SEntMan.System<XenoEvolutionSystem>();
+            
+            Assert.That(evoSys.GetAliveCasteCount("CMXenoRavager"), Is.EqualTo(2));
+
+            var lurker = SSpawnAtPosition("CMXenoLurker", coords);
+            var mindSys = SEntMan.System<Content.Shared.Mind.SharedMindSystem>();
+            var mind = mindSys.CreateMind(null, "xeno-limit-test");
+
+            mindSys.TransferTo(mind.Owner, lurker, mind: mind.Comp);
+
+            Assert.That(evoSys.TryForceEvolve(lurker, "CMXenoRavager"), Is.False);
         });
     }
 }

--- a/Content.IntegrationTests/Tests/_RMC14/Xenonids/XenoSystemsTest.cs
+++ b/Content.IntegrationTests/Tests/_RMC14/Xenonids/XenoSystemsTest.cs
@@ -288,24 +288,29 @@ public sealed class XenoSystemsTest : GameTest
         await Pair.Server.WaitPost(() =>
         {
             Pair.Server.CfgMan.SetCVar(RMCCVars.RMCXenoEvolutionCasteLimits, "CMXenoRavager=2");
-
+            SSpawnAtPosition("CMXenoQueen", coords);
             SSpawnAtPosition("CMXenoRavager", coords);
-            SSpawnAtPosition("CMXenoRavager", coords);
-        });
 
-        await Pair.Server.WaitAssertion(() =>
-        {
             var evoSys = SEntMan.System<XenoEvolutionSystem>();
-            
+            var mindSys = SEntMan.System<Content.Shared.Mind.SharedMindSystem>();
+
+            Assert.That(evoSys.GetAliveCasteCount("CMXenoRavager"), Is.EqualTo(1));
+
+            var lurkerOk = SSpawnAtPosition("CMXenoLurker", coords);
+            var mindOk = mindSys.CreateMind(null, "xeno-limit-ok");
+            mindSys.TransferTo(mindOk.Owner, lurkerOk, mind: mindOk.Comp);
+
+            Assert.That(evoSys.TryForceEvolve(lurkerOk, "CMXenoRavager"), Is.True,
+                "Evolution should succeed while under caste limit");
             Assert.That(evoSys.GetAliveCasteCount("CMXenoRavager"), Is.EqualTo(2));
 
-            var lurker = SSpawnAtPosition("CMXenoLurker", coords);
-            var mindSys = SEntMan.System<Content.Shared.Mind.SharedMindSystem>();
-            var mind = mindSys.CreateMind(null, "xeno-limit-test");
+            var lurkerBlocked = SSpawnAtPosition("CMXenoLurker", coords);
+            var mindBlocked = mindSys.CreateMind(null, "xeno-limit-blocked");
+            mindSys.TransferTo(mindBlocked.Owner, lurkerBlocked, mind: mindBlocked.Comp);
 
-            mindSys.TransferTo(mind.Owner, lurker, mind: mind.Comp);
-
-            Assert.That(evoSys.TryForceEvolve(lurker, "CMXenoRavager"), Is.False);
+            Assert.That(evoSys.TryForceEvolve(lurkerBlocked, "CMXenoRavager"), Is.False,
+                "Evolution should be rejected once caste limit is reached");
+            Assert.That(evoSys.GetAliveCasteCount("CMXenoRavager"), Is.EqualTo(2));
         });
     }
 }

--- a/Content.Server/_RMC14/Xenonids/Rank/XenoRankSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Rank/XenoRankSystem.cs
@@ -1,110 +1,68 @@
-using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Xenonids;
-using Content.Shared._RMC14.Xenonids.Name;
+using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared._RMC14.Xenonids.Rank;
-using Content.Shared.Mind;
-using Content.Shared.Mind.Components;
-using Content.Shared.NameModifier.EntitySystems;
-using Content.Shared.Players.PlayTimeTracking;
-using Robust.Server.Player;
-using Robust.Shared.Configuration;
-using Robust.Shared.Player;
+using Content.Shared.FixedPoint;
 
 namespace Content.Server._RMC14.Xenonids.Rank;
 
 public sealed partial class XenoRankSystem : EntitySystem
 {
-    [Dependency] private IConfigurationManager _config = default!;
-    [Dependency] private NameModifierSystem _nameModifier = default!;
-    [Dependency] private ISharedPlaytimeManager _playtime = default!;
-
-    private TimeSpan _rankTwoTime;
-    private TimeSpan _rankThreeTime;
-    private TimeSpan _rankFourTime;
-    private TimeSpan _rankFiveTime;
-    private TimeSpan _rankSixTime;
-
     public override void Initialize()
     {
-        SubscribeLocalEvent<XenoComponent, MindAddedMessage>(OnXenoMindAdded);
-        SubscribeLocalEvent<XenoRankComponent, RefreshNameModifiersEvent>(OnRankRefreshName, before: [typeof(SharedXenoNameSystem)]);
-
-        Subs.CVar(_config, RMCCVars.RMCPlaytimeBronzeMedalTimeHours, v => _rankTwoTime = TimeSpan.FromHours(v), true);
-        Subs.CVar(_config, RMCCVars.RMCPlaytimeSilverMedalTimeHours, v => _rankThreeTime = TimeSpan.FromHours(v), true);
-        Subs.CVar(_config, RMCCVars.RMCPlaytimeGoldMedalTimeHours, v => _rankFourTime = TimeSpan.FromHours(v), true);
-        Subs.CVar(_config, RMCCVars.RMCPlaytimePlatinumMedalTimeHours, v => _rankFiveTime = TimeSpan.FromHours(v), true);
-        Subs.CVar(_config, RMCCVars.RMCPlaytimeRubyMedalTimeHours, v => _rankSixTime = TimeSpan.FromHours(v), true);
+        SubscribeLocalEvent<XenoEvolutionComponent, MapInitEvent>(OnEvolutionMapInit);
+        SubscribeLocalEvent<XenoComponent, AfterNewXenoEvolvedEvent>(OnAfterEvolved);
     }
 
-    private void OnXenoMindAdded(Entity<XenoComponent> xeno, ref MindAddedMessage args)
+    private void OnEvolutionMapInit(Entity<XenoEvolutionComponent> ent, ref MapInitEvent args)
     {
-        if (!TryComp(xeno, out ActorComponent? actor))
-            return;
-
-        UpdateRank(xeno, actor.PlayerSession);
+        UpdateRank(ent.Owner);
     }
 
-    private void OnRankRefreshName(Entity<XenoRankComponent> ent, ref RefreshNameModifiersEvent args)
+    private void OnAfterEvolved(Entity<XenoComponent> ent, ref AfterNewXenoEvolvedEvent args)
     {
-        if (!TryComp<XenoRankNamesComponent>(ent, out var rankNamesComp))
-            return;
-
-        if (!rankNamesComp.RankNames.TryGetValue(ent.Comp.Rank, out var rank))
-            return;
-
-        args.AddModifier(rank);
+        UpdateRank(ent.Owner);
     }
 
-    private void UpdateRank(EntityUid xeno, ICommonSession player)
+    public override void Update(float frameTime)
+    {
+        var query = EntityQueryEnumerator<XenoEvolutionComponent, XenoComponent>();
+        while (query.MoveNext(out var uid, out _, out _))
+            UpdateRank(uid);
+    }
+
+    private void UpdateRank(EntityUid xeno)
     {
         if (!HasComp<XenoComponent>(xeno))
             return;
 
-        var time = GetXenoPlaytime(player);
-
-        int rank;
-        try
-        {
-            if (time > _rankSixTime)
-                rank = 6;
-            else if (time > _rankFiveTime)
-                rank = 5;
-            else if (time > _rankFourTime)
-                rank = 4;
-            else if (time > _rankThreeTime)
-                rank = 3;
-            else if (time > _rankTwoTime)
-                rank = 2;
-            else
-                rank = 0;
-        }
-        catch
-        {
-            rank = 0;
-        }
-
+        var rank = GetEvolutionRank(xeno);
         var rankComp = EnsureComp<XenoRankComponent>(xeno);
         if (rankComp.Rank == rank)
             return;
 
         rankComp.Rank = rank;
         Dirty(xeno, rankComp);
-        _nameModifier.RefreshNameModifiers(xeno);
     }
 
-    private TimeSpan GetXenoPlaytime(ICommonSession player)
+    // same chevron steps as before - just progress to Max instead of playtime
+    private int GetEvolutionRank(EntityUid xeno)
     {
-        var total = TimeSpan.Zero;
-        try
-        {
-            foreach (var (_, time) in _playtime.GetPlayTimes(player))
-                total += time;
-        }
-        catch (Exception e)
-        {
-            Log.Error($"Error reading xeno playtime for rank:\n{e}");
-        }
+        if (!TryComp(xeno, out XenoEvolutionComponent? evolution) || evolution.Max <= FixedPoint2.Zero)
+            return 0;
 
-        return total;
+        var ratio = (evolution.Points / evolution.Max).Float();
+
+        if (ratio >= 1f)
+            return 6;
+        if (ratio > 0.99f)
+            return 5;
+        if (ratio > 0.6f)
+            return 4;
+        if (ratio > 0.4f)
+            return 3;
+        if (ratio > 0.2f)
+            return 2;
+
+        return 0;
     }
 }

--- a/Content.Server/_RMC14/Xenonids/Rank/XenoRankSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Rank/XenoRankSystem.cs
@@ -9,13 +9,7 @@ public sealed partial class XenoRankSystem : EntitySystem
 {
     public override void Initialize()
     {
-        SubscribeLocalEvent<XenoEvolutionComponent, MapInitEvent>(OnEvolutionMapInit);
         SubscribeLocalEvent<XenoComponent, AfterNewXenoEvolvedEvent>(OnAfterEvolved);
-    }
-
-    private void OnEvolutionMapInit(Entity<XenoEvolutionComponent> ent, ref MapInitEvent args)
-    {
-        UpdateRank(ent.Owner);
     }
 
     private void OnAfterEvolved(Entity<XenoComponent> ent, ref AfterNewXenoEvolvedEvent args)

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -46,6 +46,9 @@ public sealed partial class RMCCVars : CVars
     public static readonly CVarDef<float> RMCXenoPlasmaRegenMultiplier =
         CVarDef.Create("rmc.xeno_plasma_regen_multiplier", 1.05f, CVar.REPLICATED | CVar.SERVER);
 
+    public static readonly CVarDef<float> RMCXenoHealthRegenMultiplier =
+        CVarDef.Create("rmc.xeno_health_regen_multiplier", 1f, CVar.REPLICATED | CVar.SERVER);
+
     public static readonly CVarDef<float> RMCXenoQueenEggLayCooldownSeconds =
         CVarDef.Create("rmc.xeno_queen_egg_lay_cooldown_seconds", 300f, CVar.REPLICATED | CVar.SERVER);
 

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -46,12 +46,24 @@ public sealed partial class RMCCVars : CVars
     public static readonly CVarDef<float> RMCXenoPlasmaRegenMultiplier =
         CVarDef.Create("rmc.xeno_plasma_regen_multiplier", 1.05f, CVar.REPLICATED | CVar.SERVER);
 
+    public static readonly CVarDef<float> RMCXenoQueenEggLayCooldownSeconds =
+        CVarDef.Create("rmc.xeno_queen_egg_lay_cooldown_seconds", 300f, CVar.REPLICATED | CVar.SERVER);
+
     // 999 = always accumulate during a normal round
     public static readonly CVarDef<float> RMCEvolutionPointsAccumulateBeforeMinutes =
         CVarDef.Create("rmc.evolution_points_accumulate_before_minutes", 999f, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<float> RMCEvolutionPointsRate =
         CVarDef.Create("rmc.evolution_points_rate", 0.2f, CVar.REPLICATED | CVar.SERVER);
+
+    /// <summary>
+    /// Comma separated caste limits for evolution
+    /// Counts all living xenonids of that prototype. Omitted castes have no limit.
+    /// </summary>
+    public static readonly CVarDef<string> RMCXenoEvolutionCasteLimits =
+        CVarDef.Create("rmc.xeno_evolution_caste_limits",
+            "CMXenoQueen=1,CMXenoRavager=2,CMXenoCrusher=2,CMXenoPraetorian=2",
+            CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<int> RMCPlaytimeBronzeMedalTimeHours =
         CVarDef.Create("rmc.playtime_bronze_medal_time_hours", 10, CVar.REPLICATED | CVar.SERVER);

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -67,19 +67,4 @@ public sealed partial class RMCCVars : CVars
         CVarDef.Create("rmc.xeno_evolution_caste_limits",
             "CMXenoQueen=1,CMXenoRavager=2,CMXenoCrusher=2,CMXenoPraetorian=2",
             CVar.REPLICATED | CVar.SERVER);
-
-    public static readonly CVarDef<int> RMCPlaytimeBronzeMedalTimeHours =
-        CVarDef.Create("rmc.playtime_bronze_medal_time_hours", 10, CVar.REPLICATED | CVar.SERVER);
-
-    public static readonly CVarDef<int> RMCPlaytimeSilverMedalTimeHours =
-        CVarDef.Create("rmc.playtime_silver_medal_time_hours", 25, CVar.REPLICATED | CVar.SERVER);
-
-    public static readonly CVarDef<int> RMCPlaytimeGoldMedalTimeHours =
-        CVarDef.Create("rmc.playtime_gold_medal_time_hours", 70, CVar.REPLICATED | CVar.SERVER);
-
-    public static readonly CVarDef<int> RMCPlaytimePlatinumMedalTimeHours =
-        CVarDef.Create("rmc.playtime_platinum_medal_time_hours", 175, CVar.REPLICATED | CVar.SERVER);
-
-    public static readonly CVarDef<int> RMCPlaytimeRubyMedalTimeHours =
-        CVarDef.Create("rmc.playtime_ruby_medal_time_hours", 350, CVar.REPLICATED | CVar.SERVER);
 }

--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -1,6 +1,8 @@
+using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Map;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Weeds;
+using Content.Shared.Actions;
 using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
 using Content.Shared.Mobs.Components;
@@ -8,15 +10,21 @@ using Content.Shared.Popups;
 using Content.Shared.StepTrigger.Systems;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Configuration;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids.Egg;
 
 public sealed partial class XenoEggSystem : EntitySystem
 {
+    private static readonly EntProtoId LayEggAction = "ActionXenoLayEgg";
+
+    [Dependency] private SharedActionsSystem _actions = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
+    [Dependency] private IConfigurationManager _config = default!;
     [Dependency] private SharedDoAfterSystem _doAfter = default!;
     [Dependency] private SharedXenoHiveSystem _hive = default!;
     [Dependency] private INetManager _net = default!;
@@ -28,6 +36,8 @@ public sealed partial class XenoEggSystem : EntitySystem
 
     private static readonly SoundPathSpecifier EggBurstSound = new("/Audio/_RMC14/Xeno/alien_egg_burst.ogg");
 
+    private TimeSpan _eggLayCooldown = TimeSpan.FromSeconds(300);
+
     public override void Initialize()
     {
         SubscribeLocalEvent<XenoOvipositorCapableComponent, XenoLayEggActionEvent>(OnLayEgg);
@@ -36,6 +46,13 @@ public sealed partial class XenoEggSystem : EntitySystem
         SubscribeLocalEvent<XenoEggComponent, MapInitEvent>(OnEggMapInit);
         SubscribeLocalEvent<XenoEggComponent, StepTriggeredOffEvent>(OnEggStepped);
         SubscribeLocalEvent<XenoEggComponent, ActivateInWorldEvent>(OnEggActivate);
+
+        Subs.CVar(_config, RMCCVars.RMCXenoQueenEggLayCooldownSeconds, OnEggLayCooldownChanged, true);
+    }
+
+    private void OnEggLayCooldownChanged(float seconds)
+    {
+        _eggLayCooldown = TimeSpan.FromSeconds(Math.Max(0, seconds));
     }
 
     private void OnLayEgg(Entity<XenoOvipositorCapableComponent> xeno, ref XenoLayEggActionEvent args)
@@ -43,10 +60,18 @@ public sealed partial class XenoEggSystem : EntitySystem
         if (args.Handled || _timing.ApplyingState)
             return;
 
+        if (IsOnLayCooldown(xeno))
+        {
+            _popup.PopupClient(Loc.GetString("cm-xeno-egg-lay-cooldown"), xeno, xeno);
+            return;
+        }
+
         if (!CanLayEggHere(xeno, popup: true))
             return;
 
         args.Handled = true;
+
+        _popup.PopupClient(Loc.GetString("cm-xeno-egg-lay-start"), xeno, xeno);
 
         var doAfter = new DoAfterArgs(EntityManager, xeno, xeno.Comp.LayDelay, new XenoLayEggDoAfterEvent(), xeno)
         {
@@ -67,6 +92,12 @@ public sealed partial class XenoEggSystem : EntitySystem
 
         args.Handled = true;
 
+        if (IsOnLayCooldown(xeno))
+        {
+            _popup.PopupClient(Loc.GetString("cm-xeno-egg-lay-cooldown"), xeno, xeno);
+            return;
+        }
+
         if (!CanLayEggHere(xeno, popup: true))
             return;
 
@@ -76,6 +107,31 @@ public sealed partial class XenoEggSystem : EntitySystem
         var coords = _rmcMap.SnapToGrid(_transform.GetMoverCoordinates(xeno.Owner));
         var egg = Spawn(xeno.Comp.EggPrototype, coords);
         _hive.SetSameHive(xeno.Owner, egg);
+
+        if (_eggLayCooldown > TimeSpan.Zero)
+        {
+            xeno.Comp.NextLayEgg = _timing.CurTime + _eggLayCooldown;
+            xeno.Comp.LayReadyNotified = false;
+            Dirty(xeno);
+            SetLayEggActionCooldown(xeno.Owner, _eggLayCooldown);
+        }
+    }
+
+    private bool IsOnLayCooldown(Entity<XenoOvipositorCapableComponent> xeno)
+    {
+        return xeno.Comp.NextLayEgg is { } next && _timing.CurTime < next;
+    }
+
+    private void SetLayEggActionCooldown(EntityUid xeno, TimeSpan cooldown)
+    {
+        foreach (var action in _actions.GetActions(xeno))
+        {
+            if (MetaData(action).EntityPrototype?.ID is not { } protoId || protoId != LayEggAction)
+                continue;
+
+            _actions.SetCooldown(action.Owner, cooldown);
+            return;
+        }
     }
 
     private bool CanLayEggHere(EntityUid xeno, bool popup)
@@ -153,6 +209,18 @@ public sealed partial class XenoEggSystem : EntitySystem
             return;
 
         var time = _timing.CurTime;
+
+        var queens = EntityQueryEnumerator<XenoOvipositorCapableComponent>();
+        while (queens.MoveNext(out var uid, out var capable))
+        {
+            if (capable.LayReadyNotified || capable.NextLayEgg is not { } next || time < next)
+                continue;
+
+            capable.LayReadyNotified = true;
+            Dirty(uid, capable);
+            _popup.PopupClient(Loc.GetString("cm-xeno-egg-lay-ready"), uid, uid);
+        }
+
         var eggs = EntityQueryEnumerator<XenoEggComponent>();
         while (eggs.MoveNext(out var uid, out var egg))
         {

--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoOvipositorCapableComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoOvipositorCapableComponent.cs
@@ -1,15 +1,22 @@
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._RMC14.Xenonids.Egg;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
 [Access(typeof(XenoEggSystem))]
 public sealed partial class XenoOvipositorCapableComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public TimeSpan LayDelay = TimeSpan.FromSeconds(30);
+    public TimeSpan LayDelay = TimeSpan.FromSeconds(35);
 
     [DataField, AutoNetworkedField]
     public EntProtoId EggPrototype = "XenoEgg";
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan? NextLayEgg;
+
+    [DataField, AutoNetworkedField]
+    public bool LayReadyNotified = true;
 }

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionComponent.cs
@@ -25,6 +25,9 @@ public sealed partial class XenoEvolutionComponent : Component
     public TimeSpan EvolutionDelay = TimeSpan.FromSeconds(3);
 
     [DataField, AutoNetworkedField]
+    public TimeSpan QueenEvolutionDelay = TimeSpan.FromSeconds(17.5);
+
+    [DataField, AutoNetworkedField]
     public FixedPoint2 Points;
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -353,8 +353,10 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
                     continue;
 
                 if (!hasLivingQueen)
+                {
+                    evolution.LastPointsAt = time;
                     continue;
-
+                }
                 if (evolution.Points >= evolution.Max)
                 {
                     if (!evolution.GotPopup)

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._RMC14.CCVar;
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Announce;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared.Actions;
@@ -38,6 +39,8 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
     private TimeSpan _evolutionAccumulatePointsBefore;
     private float _evolutionPointsRate;
 
+    private Dictionary<EntProtoId, int> _casteLimits = new();
+
     private readonly HashSet<EntityUid> _intersecting = new();
 
     public override void Initialize()
@@ -59,6 +62,56 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
         Subs.CVar(_config, RMCCVars.RMCEvolutionPointsAccumulateBeforeMinutes,
             v => _evolutionAccumulatePointsBefore = TimeSpan.FromMinutes(v), true);
         Subs.CVar(_config, RMCCVars.RMCEvolutionPointsRate, v => _evolutionPointsRate = v, true);
+        Subs.CVar(_config, RMCCVars.RMCXenoEvolutionCasteLimits, OnCasteLimitsChanged, true);
+    }
+
+    private void OnCasteLimitsChanged(string value)
+    {
+        _casteLimits = ParseCasteLimits(value);
+    }
+
+    public static Dictionary<EntProtoId, int> ParseCasteLimits(string value)
+    {
+        var limits = new Dictionary<EntProtoId, int>();
+        if (string.IsNullOrWhiteSpace(value))
+            return limits;
+
+        foreach (var entry in value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var parts = entry.Split('=', 2, StringSplitOptions.TrimEntries);
+            if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[0]) || !int.TryParse(parts[1], out var limit) || limit <= 0)
+                continue;
+
+            limits.TryAdd(new EntProtoId(parts[0]), limit);
+        }
+
+        return limits;
+    }
+
+    public int GetAliveCasteCount(EntProtoId proto)
+    {
+        var count = 0;
+        var query = EntityQueryEnumerator<XenoComponent>();
+        while (query.MoveNext(out var uid, out _))
+        {
+            if (_mobState.IsDead(uid))
+                continue;
+
+            if (MetaData(uid).EntityPrototype?.ID is not { } protoId || protoId != proto)
+                continue;
+
+            count++;
+        }
+
+        return count;
+    }
+
+    public bool IsCasteLimitReached(EntProtoId proto, out int limit)
+    {
+        if (!_casteLimits.TryGetValue(proto, out limit))
+            return false;
+
+        return GetAliveCasteCount(proto) >= limit;
     }
 
     private void OnXenoEvolveMapInit(Entity<XenoEvolutionComponent> ent, ref MapInitEvent args)
@@ -93,12 +146,13 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
         }
 
         var ev = new XenoEvolutionDoAfterEvent(args.Choice);
-        var doAfter = new DoAfterArgs(EntityManager, xeno, xeno.Comp.EvolutionDelay, ev, xeno)
+        var delay = GetEvolutionDelay(xeno, args.Choice);
+        var doAfter = new DoAfterArgs(EntityManager, xeno, delay, ev, xeno)
         {
             BreakOnMove = false,
         };
 
-        if (xeno.Comp.EvolutionDelay > TimeSpan.Zero)
+        if (delay > TimeSpan.Zero)
             _popup.PopupClient(Loc.GetString("cm-xeno-evolution-start"), xeno, xeno);
 
         _doAfter.TryStartDoAfter(doAfter);
@@ -191,7 +245,33 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
             return false;
         }
 
+        if (IsCasteLimitReached(newXeno, out var limit))
+        {
+            if (doPopup)
+            {
+                var casteName = prototype?.Name ?? newXeno.ToString();
+                _popup.PopupEntity(
+                    Loc.GetString("cm-xeno-evolution-failed-caste-limit", ("caste", casteName), ("limit", limit)),
+                    xeno,
+                    xeno,
+                    PopupType.MediumCaution);
+            }
+
+            return false;
+        }
+
         return true;
+    }
+
+    private TimeSpan GetEvolutionDelay(Entity<XenoEvolutionComponent> xeno, EntProtoId choice)
+    {
+        if (_prototypes.TryIndex(choice, out EntityPrototype? prototype) &&
+            prototype.TryGetComponent<XenoEvolutionGranterComponent>(out _, Factory))
+        {
+            return xeno.Comp.QueenEvolutionDelay;
+        }
+
+        return xeno.Comp.EvolutionDelay;
     }
 
     public bool HasLivingGranter()
@@ -261,6 +341,7 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
 
         var time = _timing.CurTime;
         var roundDuration = _gameTicker.RoundDuration();
+        var hasLivingQueen = HasLivingGranter();
 
         // stop accumulating after the cvar cutoff - but still clean newly evolved
         if (roundDuration <= _evolutionAccumulatePointsBefore)
@@ -269,6 +350,9 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
             while (query.MoveNext(out var uid, out var evolution))
             {
                 if (evolution.Max <= FixedPoint2.Zero)
+                    continue;
+
+                if (!hasLivingQueen)
                     continue;
 
                 if (evolution.Points >= evolution.Max)

--- a/Content.Shared/_RMC14/Xenonids/Spit/XenoSlowingSpitActionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Spit/XenoSlowingSpitActionEvent.cs
@@ -1,0 +1,5 @@
+using Content.Shared.Actions;
+
+namespace Content.Shared._RMC14.Xenonids.Spit;
+
+public sealed partial class XenoSlowingSpitActionEvent : WorldTargetActionEvent;

--- a/Content.Shared/_RMC14/Xenonids/Spit/XenoSlowingSpitComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Spit/XenoSlowingSpitComponent.cs
@@ -7,16 +7,16 @@ namespace Content.Shared._RMC14.Xenonids.Spit;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(XenoSpitSystem))]
-public sealed partial class XenoSpitComponent : Component
+public sealed partial class XenoSlowingSpitComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public EntProtoId Projectile = "XenoSpitProjectile";
+    public EntProtoId Projectile = "XenoSlowingSpitProjectile";
 
     [DataField, AutoNetworkedField]
-    public FixedPoint2 PlasmaCost = 25;
+    public FixedPoint2 PlasmaCost = 20;
 
     [DataField, AutoNetworkedField]
-    public float ProjectileSpeed = 20f;
+    public float ProjectileSpeed = 30f;
 
     [DataField, AutoNetworkedField]
     public SoundSpecifier Sound = new SoundCollectionSpecifier("XenoSpitAcid", AudioParams.Default.WithVolume(-10f));

--- a/Content.Shared/_RMC14/Xenonids/Spit/XenoSlowingSpitProjectileComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Spit/XenoSlowingSpitProjectileComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Spit;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(XenoSpitSystem))]
+public sealed partial class XenoSlowingSpitProjectileComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan Paralyze = TimeSpan.FromSeconds(3.5);
+}

--- a/Content.Shared/_RMC14/Xenonids/Spit/XenoSpitProjectileComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Spit/XenoSpitProjectileComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Spit;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class XenoSpitProjectileComponent : Component
+{
+    [DataField]
+    public bool DeleteOnFriendlyXeno = true;
+}

--- a/Content.Shared/_RMC14/Xenonids/Spit/XenoSpitSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Spit/XenoSpitSystem.cs
@@ -1,8 +1,13 @@
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Plasma;
+using Content.Shared.Projectiles;
+using Content.Shared.Stunnable;
 using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids.Spit;
@@ -14,12 +19,17 @@ public sealed partial class XenoSpitSystem : EntitySystem
     [Dependency] private INetManager _net = default!;
     [Dependency] private SharedPhysicsSystem _physics = default!;
     [Dependency] private XenoPlasmaSystem _plasma = default!;
+    [Dependency] private SharedStunSystem _stun = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
 
     public override void Initialize()
     {
         SubscribeLocalEvent<XenoSpitComponent, XenoSpitActionEvent>(OnSpit);
+        SubscribeLocalEvent<XenoSlowingSpitComponent, XenoSlowingSpitActionEvent>(OnSlowingSpit);
+
+        SubscribeLocalEvent<XenoSpitProjectileComponent, ProjectileHitEvent>(OnSpitProjectileHit);
+        SubscribeLocalEvent<XenoSlowingSpitProjectileComponent, ProjectileHitEvent>(OnSlowingSpitProjectileHit);
     }
 
     private void OnSpit(Entity<XenoSpitComponent> xeno, ref XenoSpitActionEvent args)
@@ -31,20 +41,69 @@ public sealed partial class XenoSpitSystem : EntitySystem
             return;
 
         args.Handled = true;
-        _audio.PlayPredicted(xeno.Comp.Sound, xeno, xeno);
+        Shoot(xeno.Owner, args.Target, xeno.Comp.Projectile, xeno.Comp.Sound, xeno.Comp.ProjectileSpeed);
+    }
+
+    private void OnSlowingSpit(Entity<XenoSlowingSpitComponent> xeno, ref XenoSlowingSpitActionEvent args)
+    {
+        if (args.Handled || _timing.ApplyingState)
+            return;
+
+        if (!_plasma.TryRemovePlasmaPopup(xeno.Owner, xeno.Comp.PlasmaCost))
+            return;
+
+        args.Handled = true;
+        Shoot(xeno.Owner, args.Target, xeno.Comp.Projectile, xeno.Comp.Sound, xeno.Comp.ProjectileSpeed);
+    }
+
+    private void Shoot(EntityUid xeno, EntityCoordinates target, EntProtoId projectile, Robust.Shared.Audio.SoundSpecifier sound, float speed)
+    {
+        _audio.PlayPredicted(sound, xeno, xeno);
 
         if (_net.IsClient)
             return;
 
         var fromCoords = Transform(xeno).Coordinates;
         var fromMap = _transform.ToMapCoordinates(fromCoords);
-        var toMap = _transform.ToMapCoordinates(args.Target);
+        var toMap = _transform.ToMapCoordinates(target);
         var direction = toMap.Position - fromMap.Position;
         if (direction == default)
             return;
 
-        var ent = Spawn(xeno.Comp.Projectile, fromMap);
+        var ent = Spawn(projectile, fromMap);
         var userVelocity = _physics.GetMapLinearVelocity(xeno);
-        _gun.ShootProjectile(ent, direction, userVelocity, xeno, xeno, xeno.Comp.ProjectileSpeed);
+        _gun.ShootProjectile(ent, direction, userVelocity, xeno, xeno, speed);
+    }
+
+    private void OnSpitProjectileHit(Entity<XenoSpitProjectileComponent> projectile, ref ProjectileHitEvent args)
+    {
+        if (!projectile.Comp.DeleteOnFriendlyXeno)
+            return;
+
+        if (!IsFriendlyXeno(args.Target))
+            return;
+
+        PredictedQueueDel(projectile);
+    }
+
+    private void OnSlowingSpitProjectileHit(Entity<XenoSlowingSpitProjectileComponent> projectile, ref ProjectileHitEvent args)
+    {
+        var target = args.Target;
+        if (IsFriendlyXeno(target))
+        {
+            PredictedQueueDel(projectile);
+            return;
+        }
+
+        if (_net.IsClient)
+            return;
+
+        if (projectile.Comp.Paralyze > TimeSpan.Zero)
+            _stun.TryAddParalyzeDuration(target, projectile.Comp.Paralyze, visualized: true);
+    }
+
+    private bool IsFriendlyXeno(EntityUid target)
+    {
+        return HasComp<XenoComponent>(target) || HasComp<XenoFriendlyComponent>(target);
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -47,6 +47,7 @@ public sealed partial class XenoSystem : EntitySystem
     private float _xenoDamageReceivedMultiplier = 1f;
     private float _xenoSpeedMultiplier = 1f;
     private float _xenoPlasmaRegenMultiplier = 1.05f;
+    private float _xenoHealthRegenMultiplier = 1f;
 
     public override void Initialize()
     {
@@ -77,6 +78,7 @@ public sealed partial class XenoSystem : EntitySystem
         Subs.CVar(_config, RMCCVars.RMCXenoDamageReceivedMultiplier, v => _xenoDamageReceivedMultiplier = v, true);
         Subs.CVar(_config, RMCCVars.RMCXenoSpeedMultiplier, UpdateXenoSpeedMultiplier, true);
         Subs.CVar(_config, RMCCVars.RMCXenoPlasmaRegenMultiplier, v => _xenoPlasmaRegenMultiplier = v, true);
+        Subs.CVar(_config, RMCCVars.RMCXenoHealthRegenMultiplier, v => _xenoHealthRegenMultiplier = v, true);
     }
 
     private void OnXenoMapInit(Entity<XenoComponent> xeno, ref MapInitEvent args)
@@ -277,6 +279,9 @@ public sealed partial class XenoSystem : EntitySystem
             }
 
             var heal = GetWeedsHealAmount((uid, regen));
+            if (!MathHelper.CloseTo(_xenoHealthRegenMultiplier, 1))
+                heal *= _xenoHealthRegenMultiplier;
+
             if (heal > FixedPoint2.Zero)
                 HealDamage(uid, heal);
 

--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -63,6 +63,7 @@ ssd_sleep_time = 3600
 
 [rmc]
 evolution_points_rate = 5.0
+xeno_evolution_caste_limits = "CMXenoQueen=1,CMXenoRavager=2,CMXenoCrusher=2,CMXenoPraetorian=2"
 
 [database]
 # Change to postgres if needed

--- a/Resources/Locale/en-US/_RMC14/xeno.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno.ftl
@@ -37,6 +37,7 @@ cm-xeno-evolution-start = You begin to evolve...
 cm-xeno-evolution-end = You emerge as a new caste!
 cm-xeno-evolution-failed-points = You need more evolution points!
 cm-xeno-evolution-failed-hive-shaken = The hive is too shaken to evolve further!
+cm-xeno-evolution-failed-caste-limit = The hive already has {$limit} living {$caste} - you cannot evolve into this caste right now.
 cm-xeno-evolution-ready = You feel ready to evolve!
 rmc-xeno-evolution-failed-queen-exists = There is already a Queen!
 rmc-new-queen = A new Queen has risen!
@@ -84,6 +85,8 @@ cm-xeno-egg-failed-must-weeds = The egg must be planted on weeds.
 cm-xeno-egg-failed-need-grid = You need to be on a solid surface to lay an egg.
 cm-xeno-egg-failed-already-there = There's already an egg there.
 cm-xeno-egg-lay-start = You begin laying an egg...
+cm-xeno-egg-lay-cooldown = You must wait before laying another egg.
+cm-xeno-egg-lay-ready = You are ready to lay another egg.
 
 ## Leap
 cm-xeno-leap-cancelled = You stop yourself from leaping!

--- a/Resources/Locale/en-US/prototypes/generated/_RMC14/actions/xeno_actions.ftl
+++ b/Resources/Locale/en-US/prototypes/generated/_RMC14/actions/xeno_actions.ftl
@@ -41,4 +41,6 @@ ent-ActionXenoScreech = Screech
 ent-ActionXenoPheromones = Emit Pheromones
     .desc = Choose a pheromone aura that buffs nearby hive sisters. Costs plasma to start and each second while active.
 ent-ActionXenoLayEgg = Lay Egg
-    .desc = Stand on weeds and after 30 seconds lay a xenonid egg beneath you.
+    .desc = Stand on weeds and after 35 seconds lay a xenonid egg beneath you. Has a cooldown before you can lay again.
+ent-ActionXenoNightVision = Night Vision
+    .desc = Toggle your xenomorph night vision on or off.

--- a/Resources/Locale/pl-PL/_RMC14/xeno.ftl
+++ b/Resources/Locale/pl-PL/_RMC14/xeno.ftl
@@ -37,6 +37,7 @@ cm-xeno-evolution-start = Zaczynasz ewoluować...
 cm-xeno-evolution-end = Wyłaniasz się jako nowa kasta!
 cm-xeno-evolution-failed-points = Potrzebujesz więcej punktów ewolucji!
 cm-xeno-evolution-failed-hive-shaken = Ul jest zbyt wstrząśnięty, by ewoluować dalej!
+cm-xeno-evolution-failed-caste-limit = W ulu jest już {$limit} żywych {$caste} - nie możesz teraz ewoluować w tę kastę.
 cm-xeno-evolution-ready = Czujesz, że jesteś gotowy do ewolucji!
 rmc-xeno-evolution-failed-queen-exists = Królowa już istnieje!
 rmc-new-queen = Powstała nowa Królowa!
@@ -84,6 +85,8 @@ cm-xeno-egg-failed-must-weeds = Jajo musi zostać złożone na chwastach.
 cm-xeno-egg-failed-need-grid = Musisz stać na stałym podłożu, aby złożyć jajo.
 cm-xeno-egg-failed-already-there = Tu już jest jajo.
 cm-xeno-egg-lay-start = Zaczynasz składać jajo...
+cm-xeno-egg-lay-cooldown = Musisz poczekać, zanim złożysz kolejne jajo.
+cm-xeno-egg-lay-ready = Możesz złożyć kolejne jajo.
 
 ## Leap
 cm-xeno-leap-cancelled = Przerywasz skok!

--- a/Resources/Locale/pl-PL/prototypes/generated/_RMC14/actions/xeno_actions.ftl
+++ b/Resources/Locale/pl-PL/prototypes/generated/_RMC14/actions/xeno_actions.ftl
@@ -41,4 +41,6 @@ ent-ActionXenoScreech = Wrzask
 ent-ActionXenoPheromones = Emituj feromony
     .desc = Wybierz aurę feromonów wzmacniającą siostry ula. Kosztuje plazmę na start i co sekundę.
 ent-ActionXenoLayEgg = Złóż jajo
-    .desc = Stań na chwastach i po 30 sekundach złóż jajo ksenomorfa.
+    .desc = Stań na chwastach i po 35 sekundach złóż jajo ksenomorfa. Po złożeniu obowiązuje czas odnowienia.
+ent-ActionXenoNightVision = Noktowizja
+    .desc = Włącz lub wyłącz noktowizję ksenomorfa.

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_actions.yml
@@ -83,7 +83,7 @@
   description: Melt a structure or object with acid.
   components:
   - type: Action
-    useDelay: 1
+    useDelay: 1.5
     itemIconStyle: BigAction
     icon:
       sprite: _RMC14/Actions/xeno_actions.rsi
@@ -107,7 +107,7 @@
   description: Slowly melt a structure or object with weak acid.
   components:
   - type: Action
-    useDelay: 1
+    useDelay: 1.5
     itemIconStyle: BigAction
     icon:
       sprite: _RMC14/Actions/xeno_actions.rsi
@@ -123,3 +123,21 @@
       plasmaCost: 75
       time: 300
       dps: 4
+
+- type: entity
+  parent: BaseAction
+  id: ActionXenoNightVision
+  name: Night Vision
+  description: Toggle your xenomorph night vision on or off.
+  components:
+  - type: Action
+    useDelay: 0.5
+    itemIconStyle: BigAction
+    icon:
+      sprite: _RMC14/Actions/xeno_actions.rsi
+      state: queen_eye
+    iconOn:
+      sprite: _RMC14/Actions/xeno_actions.rsi
+      state: queen_eye
+  - type: InstantAction
+    event: !type:ToggleNightVisionEvent {}

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_combat_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_combat_actions.yml
@@ -5,7 +5,7 @@
   description: Stab a nearby target with your tail.
   components:
   - type: Action
-    useDelay: 8
+    useDelay: 12
     itemIconStyle: BigAction
     icon:
       sprite: _RMC14/Actions/xeno_actions.rsi
@@ -27,7 +27,7 @@
   description: Leap toward a location and knock down nearby hosts.
   components:
   - type: Action
-    useDelay: 6
+    useDelay: 9
     itemIconStyle: BigAction
     icon:
       sprite: _RMC14/Actions/xeno_actions.rsi
@@ -41,20 +41,47 @@
 - type: entity
   parent: BaseAction
   id: ActionXenoSpit
-  name: Spit
-  description: Spit acid at a target location.
+  name: Acid Spit
+  description: Spit acid at a target. Deals moderate damage on impact.
   components:
   - type: Action
-    useDelay: 2
+    useDelay: 3.75
     itemIconStyle: BigAction
     icon:
       sprite: _RMC14/Actions/xeno_actions.rsi
       state: xeno_spit
   - type: TargetAction
-    range: 0
+    range: 7
     checkCanAccess: false
   - type: WorldTargetAction
     event: !type:XenoSpitActionEvent
+
+- type: entity
+  parent: ActionXenoSpit
+  id: ActionXenoSpitPraetorian
+  name: Acid Spit
+  description: Spit concentrated acid at a target. Deals heavy damage on impact.
+  components:
+  - type: Action
+    useDelay: 3
+
+- type: entity
+  parent: BaseAction
+  id: ActionXenoSlowingSpit
+  name: Slowing Spit
+  description: Spit neurotoxin that slows and briefly paralyzes the first enemy hit.
+  components:
+  - type: Action
+    useDelay: 3
+    itemIconStyle: BigAction
+    icon:
+      sprite: _RMC14/Actions/xeno_actions.rsi
+      state: shift_spit_neurotoxin
+  - type: TargetAction
+    range: 5
+    checkCanAccess: false
+  - type: WorldTargetAction
+    event: !type:XenoSlowingSpitActionEvent
 
 - type: entity
   parent: BaseAction
@@ -93,7 +120,7 @@
   description: Charge into a target and knock them back.
   components:
   - type: Action
-    useDelay: 6
+    useDelay: 9
     itemIconStyle: BigAction
     icon:
       sprite: _RMC14/Actions/xeno_actions.rsi
@@ -115,7 +142,7 @@
   description: Sweep your tail around you, knocking down nearby hosts.
   components:
   - type: Action
-    useDelay: 15
+    useDelay: 22.5
     itemIconStyle: BigAction
     icon:
       sprite: _RMC14/Actions/xeno_actions.rsi
@@ -130,7 +157,7 @@
   description: Charge toward a location, knocking down hosts you smash into.
   components:
   - type: Action
-    useDelay: 12
+    useDelay: 18
     itemIconStyle: BigAction
     icon:
       sprite: _RMC14/Actions/xeno_actions.rsi
@@ -148,7 +175,7 @@
   description: Punch a nearby host, knocking them back and slowing them.
   components:
   - type: Action
-    useDelay: 4
+    useDelay: 6
     itemIconStyle: BigAction
     icon:
       sprite: _RMC14/Actions/xeno_actions.rsi
@@ -170,7 +197,7 @@
   description: Lunge at a target, stun them, and drag them to you.
   components:
   - type: Action
-    useDelay: 8
+    useDelay: 12
     itemIconStyle: BigAction
     icon:
       sprite: _RMC14/Actions/xeno_actions.rsi
@@ -193,7 +220,7 @@
   description: Fling a nearby host away, stunning and slowing them.
   components:
   - type: Action
-    useDelay: 8
+    useDelay: 12
     itemIconStyle: BigAction
     icon:
       sprite: _RMC14/Actions/xeno_actions.rsi
@@ -215,7 +242,7 @@
   description: Cloak yourself from sight.
   components:
   - type: Action
-    useDelay: 5
+    useDelay: 7.5
     itemIconStyle: BigAction
     icon:
       sprite: _RMC14/Actions/xeno_actions.rsi
@@ -230,7 +257,7 @@
   description: Unleash a stunning screech.
   components:
   - type: Action
-    useDelay: 50
+    useDelay: 75
     itemIconStyle: BigAction
     icon:
       sprite: _RMC14/Actions/xeno_actions.rsi
@@ -257,10 +284,9 @@
   parent: BaseAction
   id: ActionXenoLayEgg
   name: Lay Egg
-  description: Lay a xenonid egg on weeds beneath you.
+  description: Stand on weeds and after 35 seconds lay a xenonid egg beneath you. Has a cooldown before you can lay again.
   components:
   - type: Action
-    useDelay: 5
     itemIconStyle: BigAction
     icon:
       sprite: _RMC14/Actions/xeno_actions.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -150,6 +150,11 @@
   - type: Examiner
   - type: Eye
   - type: ContentEye
+  - type: NightVision
+    action: ActionXenoNightVision
+    lightingColor: '#4AFF4A26'
+    overlayColor: '#4AFF4A33'
+    noiseAmount: 0.15
   - type: NoSlip
   - type: Pullable
   - type: AssignXenoName
@@ -173,9 +178,3 @@
   - type: Tag
     tags:
     - DoorBumpOpener
-    - FootstepSound
-  - type: FootstepModifier
-    footstepSoundCollection:
-      collection: XenoFootstepLarge
-      params:
-        volume: -4

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
@@ -17,11 +17,13 @@
     actionIds:
     - ActionXenoRest
     - ActionXenoTailStab
-    - ActionXenoSpit
+    - ActionXenoSpitPraetorian
     - ActionXenoAcidNormal
   - type: XenoHeavy
   - type: XenoAcid
   - type: XenoSpit
+    projectile: XenoSpitProjectilePraetorian
+    plasmaCost: 25
   - type: XenoTailStab
   - type: XenoPlasma
     plasma: 800

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -62,6 +62,15 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 1.4
     baseSprintSpeed: 2.5
+  - type: Tag
+    tags:
+    - DoorBumpOpener
+    - FootstepSound
+  - type: FootstepModifier
+    footstepSoundCollection:
+      collection: XenoFootstepLarge
+      params:
+        volume: 0
   - type: MeleeWeapon
     damage:
       types:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
@@ -17,11 +17,11 @@
     actionIds:
     - ActionXenoRest
     - ActionXenoTailStab
-    - ActionXenoSpit
+    - ActionXenoSlowingSpit
     - ActionXenoAcidWeak
   - type: XenoLight
   - type: XenoAcid
-  - type: XenoSpit
+  - type: XenoSlowingSpit
   - type: XenoTailStab
   - type: XenoPlasma
     plasma: 400

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
@@ -22,7 +22,8 @@
   - type: XenoHeavy
   - type: XenoAcid
   - type: XenoSpit
-    plasmaCost: 20
+    projectile: XenoSpitProjectile
+    plasmaCost: 25
   - type: XenoTailStab
   - type: XenoPlasma
     plasma: 600

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
@@ -1,0 +1,54 @@
+- type: entity
+  abstract: true
+  parent: BaseBullet
+  id: RMCXenoSpitProjectileBase
+  name: spit
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    noRot: false
+    sprite: _RMC14/Objects/Xeno/xeno_projectiles.rsi
+  - type: XenoSpitProjectile
+  - type: TimedDespawn
+    lifetime: 3
+
+- type: entity
+  parent: RMCXenoSpitProjectileBase
+  id: XenoSpitProjectile
+  components:
+  - type: Sprite
+    layers:
+    - state: xeno_acid_normal
+      shader: unshaded
+  - type: Projectile
+    damage:
+      types:
+        Caustic: 14
+
+- type: entity
+  parent: RMCXenoSpitProjectileBase
+  id: XenoSpitProjectilePraetorian
+  components:
+  - type: Sprite
+    layers:
+    - state: xeno_acid_strong
+      shader: unshaded
+  - type: Projectile
+    damage:
+      types:
+        Caustic: 24
+
+- type: entity
+  parent: RMCXenoSpitProjectileBase
+  id: XenoSlowingSpitProjectile
+  name: slowing spit
+  components:
+  - type: Sprite
+    layers:
+    - state: neurotoxin
+      shader: unshaded
+  - type: Projectile
+    damage:
+      types:
+        Caustic: 0.95
+  - type: XenoSlowingSpitProjectile


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
:cl: nikita
- tweak: Królowa xeno ma delaye przed następnym składaniem jaj
- tweak: Stopień xeno (medale) zależą teraz od punktów ewolucji
- new: Różne pociski dla różnych kast xeno
- new: Każde xeno ma teraz noktowizję
- fix: Każde xeno ma teraz własne odgłosy kroków

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nowe funkcje**
  * Dodano tryb noktowizji dla ksenosów.
  * Wprowadzono spowalniającą plwocinę, która paraliżuje trafione cele.
  * Dodano konfigurowalne limity żywych przedstawicieli kast przy ewolucji.
  * Dodano cooldown składania jaj i komunikaty o gotowości.
* **Ulepszenia**
  * Rangi ksenosów są teraz wyznaczane na podstawie postępu ewolucji.
  * Zaktualizowano czasy odnowienia wielu akcji bojowych.
  * Dostosowano obrażenia i koszty plazmy wybranych ataków plwociną.
  * Dodano skalowanie regeneracji zdrowia ksenosów.
* **Poprawki**
  * Ewolucja zostaje zablokowana po osiągnięciu limitu danej kasty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->