### PR TITLE
Fix do elektrolizera gazów

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -59,7 +59,7 @@
     tags:
     - Sheet
     - ConstructionMaterial
-    - SheetPlasma
+    - PlasmaSheet
   - type: PhysicalComposition
     materialComposition:
       Plasma: 100
@@ -172,7 +172,7 @@
     tags:
     - Sheet
     - ConstructionMaterial
-    - SheetUranium
+    - UraniumSheet
   - type: Edible
     transferAmount: 10
     solution: composite

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -55,6 +55,11 @@
   name: plasma
   suffix: Full
   components:
+  - type: Tag
+    tags:
+    - Sheet
+    - ConstructionMaterial
+    - SheetPlasma
   - type: PhysicalComposition
     materialComposition:
       Plasma: 100
@@ -77,7 +82,7 @@
       reagents:
       - ReagentId: Plasma
         Quantity: 10
-
+   
 - type: entity
   parent: SheetPlasma
   id: SheetPlasma10
@@ -163,6 +168,11 @@
   name: uranium
   suffix: Full
   components:
+  - type: Tag
+    tags:
+    - Sheet
+    - ConstructionMaterial
+    - SheetUranium
   - type: Edible
     transferAmount: 10
     solution: composite

--- a/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/electrolyzer.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/electrolyzer.yml
@@ -27,12 +27,12 @@
     slots:
       fuel:
         name: fuel slot
-        insertOnInteract: false
+        insertOnInteract: true
         ejectOnInteract: false
         whitelist:
           tags:
-          - PlasmaSheet
-          - UraniumSheet
+          - SheetPlasma
+          - SheetUranium
         swap: false
   - type: DeviceLinkSink
     ports:

--- a/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/electrolyzer.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/electrolyzer.yml
@@ -31,8 +31,8 @@
         ejectOnInteract: false
         whitelist:
           tags:
-          - SheetPlasma
-          - SheetUranium
+          - PlasmaSheet
+          - UraniumSheet
         swap: false
   - type: DeviceLinkSink
     ports:


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->
closes: #852
## Informacje o PR
<!-- Co zostało zmienione? -->
poprawka tagów whitelisty w elektrolizerze oraz dodanie tych tagów do plazmy oraz uranu aby mogły wejść do niego
## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
elektrolizer jest potrzeby do robienia tych skomplikowanych gazów od funky
## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: Czuat
- fix: Elektrolizer gazów przyjmuje już paliwo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nowe funkcje**
  * Dodano prawidłowe oznaczenia arkuszy plazmowych i uranowych, usprawniające ich rozpoznawanie w systemie.
  * Elektrolizer automatycznie przyjmuje arkusze plazmowe i uranowe po interakcji z odpowiednim slotem paliwa.
  * Zaktualizowano obsługę materiałów konstrukcyjnych w elektrolizerze.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->