### PR TITLE
Uzupełnienie paska narzędzi dla inżynierów

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -29,7 +29,9 @@
         - id: Wirecutter
         - id: Welder
         - id: Multitool
-
+        - id: GasAnalyzer # Jak na funky
+        - id: ClothingHeadHatWelding # Jak na funky
+        
 - type: entity
   id: ClothingBeltChiefEngineerFilled
   parent: ClothingBeltChiefEngineer
@@ -46,7 +48,8 @@
         - id: HolofanProjector
         - id: GasAnalyzer
         - id: trayScanner
-
+        - id: ClothingHeadHatWelding # Maska spawalniczo gazowa jest zbędna
+        
 - type: entityTable
   id: BeltSecurityEntityTable
   table: !type:AllSelector

--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -48,7 +48,7 @@
         - id: HolofanProjector
         - id: GasAnalyzer
         - id: trayScanner
-        - id: ClothingHeadHatWelding # Maska spawalniczo gazowa jest zbędna
+        - id: ClothingMaskWeldingGas # Jak na funky
         
 - type: entityTable
   id: BeltSecurityEntityTable

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -751,6 +751,7 @@
   - type: Tag
     tags:
     - WhitelistChameleon
+    - WeldingMask
 
 # Entity tables
 - type: entityTable


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Dodano maski spawalnicze do paska inżyniera oraz głównego inżynieria oraz analizator gazów do paska inżyniera
## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
tak mieliśmy na forky i w sumie było to logiczne bo inżynier startuje ze spawarką której nie może używać bezpiecznie.
## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: Czuat

- tweak: Przywrócono maski spawalnicze oraz analizatory gazów do pasków narzędziowych inżynierów



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nowe funkcje**
  * Uzupełniono zawartość wybranych pasów narzędziowych o analizator gazu i dodatkowe wyposażenie spawalnicze.
  * Dodano maskę spawalniczą z filtrem gazowym do pasa głównego inżyniera.
  * Maska spawalnicza jest teraz prawidłowo rozpoznawana jako wyposażenie spawalnicze.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->