### PR TITLE
Prwrót StunBatonów

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -54,7 +54,7 @@
   id: BeltSecurityEntityTable
   table: !type:AllSelector
     children:
-    - id: Nightstick # Funky
+    - id: Stunbaton # Funky - Polonium revent - good old non-lethal that doesn't kill
     - id: Handcuffs
       amount: 2
     - id: HoloprojectorSecurity


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->

Zamienia Nightstick w loadoutcie ochrony spworotem an Stunbaton

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->

Bo było ustalone że wracamy na non-lethal (Chyba że mi się coś pomyliło to proszę zamknąć PR)

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
:cl: Koilak
- add: Pałki Ogłuszające dla ochrony
- remove: Pałki Policyjne dla ochrony


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Zmiany**
  * Zaktualizowano zawartość pasa bezpieczeństwa: przedmiot „Nightstick” zastąpiono pałką elektryczną „Stunbaton”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->