### PR TITLE
Dodanie zestawu wybuchowego

### DIFF
--- a/Resources/Locale/en-US/_Polonium/Prototypes/Generated/Entities/Objects/Misc/box.ftl
+++ b/Resources/Locale/en-US/_Polonium/Prototypes/Generated/Entities/Objects/Misc/box.ftl
@@ -1,5 +1,5 @@
 ent-ThermitePack = thermite pack
-    .desc = A box for tactical deployment of thermite based breaching. On the side there is writen: ONLY FOR PEACE SPREADING!
+    .desc = A box for tactical deployment of thermite based breaching. On the side there is written: ONLY FOR PEACE SPREADING!
 
 ent-ExplosivePack = explosive pack
-    .desc = A box for tactical deployment of explosive based breaching. On the side there is writen: ONLY FOR PEACE SPREADING!
+    .desc = A box for tactical deployment of explosive based breaching. On the side there is written: ONLY FOR PEACE SPREADING!

--- a/Resources/Locale/en-US/_Polonium/Prototypes/Generated/Entities/Objects/Misc/box.ftl
+++ b/Resources/Locale/en-US/_Polonium/Prototypes/Generated/Entities/Objects/Misc/box.ftl
@@ -1,2 +1,5 @@
 ent-ThermitePack = thermite pack
-    .desc = A box for tactical deployment of thermite based breaching. On the side there is write: ONLY FOR PEACE SPREADING!
+    .desc = A box for tactical deployment of thermite based breaching. On the side there is writen: ONLY FOR PEACE SPREADING!
+
+ent-ExplosivePack = explosive pack
+    .desc = A box for tactical deployment of explosive based breaching. On the side there is writen: ONLY FOR PEACE SPREADING!

--- a/Resources/Locale/pl-PL/_Polonium/Prototypes/Generated/Entities/Objects/Misc/box.ftl
+++ b/Resources/Locale/pl-PL/_Polonium/Prototypes/Generated/Entities/Objects/Misc/box.ftl
@@ -1,2 +1,5 @@
 ent-ThermitePack = zestaw termitowy
-    .desc = Pudełko zawierające wszystko co potrzebne do zlokalizowanego użytku termitu. Na boku widnieje napis: TYLKO KU CELOM POKOJOWYM!
+    .desc = Pudełko do taktycznego włamywania przy użyciu termitu. Na boku jest napisane: TYLKO KU CELOM POKOJOWYM!
+
+ent-ExplosivePack = zestaw wybuchowy
+    .desc = Pudełko do taktycznego włamywania przy użyciu materiałów wybuchowych. Na boku jest napisane: TYLKO KU CELOM POKOJOWYM!

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -335,9 +335,12 @@
     - id: WeaponDisabler
     - id: WantedListCartridge
     - id: DrinkHosFlask
-    - id: ThermitePack
     - id: PlushieLizardJobHeadofsecurity
       prob: 0.02
+    - !type:GroupSelector
+      children:
+      - id: ExplosivePack
+      - id: ThermitePack
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -337,10 +337,11 @@
     - id: DrinkHosFlask
     - id: PlushieLizardJobHeadofsecurity
       prob: 0.02
-    - !type:GroupSelector
+    - !type:GroupSelector # Polonium addition
       children:
+      - id: ExplosivePack # 66.666%
       - id: ExplosivePack
-      - id: ThermitePack
+      - id: ThermitePack # 33.333%
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable

--- a/Resources/Prototypes/_Polonium/Entities/Objects/Misc/Box.yml
+++ b/Resources/Prototypes/_Polonium/Entities/Objects/Misc/Box.yml
@@ -1,3 +1,6 @@
+
+# Thermite Pack
+
 - type: entity
   parent: BoxBase
   id: BaseThermitePack
@@ -31,8 +34,8 @@
 - type: entity
   parent: BaseThermitePack
   id: ThermitePack
-  name: Thermite Pack
-  description: "A box for tactical deployment of thermite based breaching. On the side there is write: ONLY FOR PEACE SPREADING!"
+  name: thermite pack
+  description: "A box for tactical deployment of thermite based breaching. On the side there is writen: ONLY FOR PEACE SPREADING!"
   components:
   - type: EntityTableContainerFill
     containers:
@@ -42,3 +45,45 @@
         - id: ThermiteSparyer
         - id: TacticalIgniter
         - id: PillDermaline
+
+# Explosive Pack
+
+- type: entity
+  parent: BoxBase
+  id: BaseExplosivePack
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Appearance
+  - type: Storage
+    maxItemSize: Normal
+    grid:
+    - 0,0,3,1
+  - type: PhysicalComposition
+    materialComposition:
+      Cardboard: 50
+      Steel: 50 # hey it is explosion resistant in the end
+      Cloth: 10
+  - type: StaticPrice
+    price: 15
+  - type: Sprite
+    layers:
+      - state: box
+      - state: flare
+  - type: Item
+    shape:
+    - 0,0,3,2 # Downside of the explosive proofness
+
+- type: entity
+  parent: BaseThermitePack
+  id: ExplosivePack
+  name: explosive pack
+  description: "A box for tactical deployment of explosive based breaching. On the side there is writen: ONLY FOR PEACE SPREADING!"
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+       children:
+        - id: WiredDetonator
+          amount: 2
+        - id: RemoteSignaller
+        - id: CableDetStack10

--- a/Resources/Prototypes/_Polonium/Entities/Objects/Misc/Box.yml
+++ b/Resources/Prototypes/_Polonium/Entities/Objects/Misc/Box.yml
@@ -74,7 +74,7 @@
     - 0,0,3,2 # Downside of the explosive proofness
 
 - type: entity
-  parent: BaseThermitePack
+  parent: BaseExplosivePack
   id: ExplosivePack
   name: explosive pack
   description: "A box for tactical deployment of explosive based breaching. On the side there is writen: ONLY FOR PEACE SPREADING!"

--- a/Resources/Prototypes/_Polonium/Entities/Objects/Misc/Box.yml
+++ b/Resources/Prototypes/_Polonium/Entities/Objects/Misc/Box.yml
@@ -57,7 +57,7 @@
   - type: Storage
     maxItemSize: Normal
     grid:
-    - 0,0,3,1
+    - 0,0,3,2
   - type: PhysicalComposition
     materialComposition:
       Cardboard: 50
@@ -71,7 +71,14 @@
       - state: flare
   - type: Item
     shape:
-    - 0,0,3,2 # Downside of the explosive proofness
+    - 0,0,3,3 # Downside of the explosive proofness
+    whitelist:
+      components:
+      - Explosive
+      tags:
+      - Payload
+  - type: ExplosionResistance
+    damageCoefficient: 0.3 # 70%, so not the best, 
 
 - type: entity
   parent: BaseExplosivePack
@@ -83,7 +90,10 @@
     containers:
       storagebase: !type:AllSelector
        children:
-        - id: WiredDetonator
+        - id: EmptyDetonator
           amount: 2
         - id: RemoteSignaller
-        - id: CableDetStack10
+        - id: CableDetStack10 # 2 for completing the detonators, 8 left for KABOOM!
+        - id: SignalTrigger
+          amount: 2
+        - id: NetworkConfigurator # So its not a prop hunt once it is needed

--- a/Resources/Prototypes/_Polonium/Entities/Objects/Misc/Box.yml
+++ b/Resources/Prototypes/_Polonium/Entities/Objects/Misc/Box.yml
@@ -35,7 +35,7 @@
   parent: BaseThermitePack
   id: ThermitePack
   name: thermite pack
-  description: "A box for tactical deployment of thermite based breaching. On the side there is writen: ONLY FOR PEACE SPREADING!"
+  description: "A box for tactical deployment of thermite based breaching. On the side there is written: ONLY FOR PEACE SPREADING!"
   components:
   - type: EntityTableContainerFill
     containers:
@@ -58,6 +58,12 @@
     maxItemSize: Normal
     grid:
     - 0,0,3,2
+    whitelist:
+      components:
+      - Explosive
+      - NetworkConfigurator # Will work with multitool too in case you want to upgrade.
+      tags:
+      - Payload
   - type: PhysicalComposition
     materialComposition:
       Cardboard: 50
@@ -73,11 +79,6 @@
     size: Huge
     shape:
     - 0,0,3,3 # Downside of the explosive proofness
-    whitelist:
-      components:
-      - Explosive
-      tags:
-      - Payload
   - type: ExplosionResistance
     damageCoefficient: 0.3 # 70%, so not the best, 
 
@@ -85,7 +86,7 @@
   parent: BaseExplosivePack
   id: ExplosivePack
   name: explosive pack
-  description: "A box for tactical deployment of explosive based breaching. On the side there is writen: ONLY FOR PEACE SPREADING!"
+  description: "A box for tactical deployment of explosive based breaching. On the side there is written: ONLY FOR PEACE SPREADING!"
   components:
   - type: EntityTableContainerFill
     containers:

--- a/Resources/Prototypes/_Polonium/Entities/Objects/Misc/Box.yml
+++ b/Resources/Prototypes/_Polonium/Entities/Objects/Misc/Box.yml
@@ -61,6 +61,8 @@
     whitelist:
       components:
       - Explosive
+      - PayloadCase
+      - PayloadTrigger
       - NetworkConfigurator # Will work with multitool too in case you want to upgrade.
       tags:
       - Payload

--- a/Resources/Prototypes/_Polonium/Entities/Objects/Misc/Box.yml
+++ b/Resources/Prototypes/_Polonium/Entities/Objects/Misc/Box.yml
@@ -70,6 +70,7 @@
       - state: box
       - state: flare
   - type: Item
+    size: Huge
     shape:
     - 0,0,3,3 # Downside of the explosive proofness
     whitelist:


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->

Dodano Zestaw Wybuchowy dla HOSa

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->

Poniewarz termit jest śmieszny i fajny, ale ochona jest dedykowana bardziej pod kable wybuchowe

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->

Dodano do szafki HOSa zestaw wybuchowy (może się zespawnować albo zestaw termitory (33.333%), albo zestaw wybuchowy(66.666%), trochę RNG). Zawiera on, 2 puste detonatory, 1 zdalny sygnalizator, 10 kabla wybuchowego, 2 triggery sygnałowe, 1 konfigurator sieci
Pudełko ma 70% odporności na wybuchy ale akceptuje tylko przedmioty z tagami payload lub komponentem explosive. Jest też wielkim obiektem 4x4 z wewnętrzną pojemnością 3x4.

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->
<img width="164" height="137" alt="image" src="https://github.com/user-attachments/assets/d76322ce-a805-41f3-82e6-9dc428fd4226" />

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
:cl: Koilak
- add: zestaw wybuchowy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nowe funkcje**
  * Dodano zestaw wybuchowy w wytrzymałym pudełku z większą przestrzenią przechowywania.
  * Zawartość zestawu ograniczono do elementów wybuchowych i ładunków.
  * Wyposażenie szefa ochrony może teraz losowo zawierać dwa zestawy wybuchowe lub jeden zestaw termitowy.

* **Ulepszenia**
  * Zaktualizowano nazwę i opis zestawu termitowego.
  * Zestaw termitowy zawiera teraz również lek Dermaline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->