### PR TITLE
Dodanie Długopisu usuwającego pamięć

### DIFF
--- a/Resources/Locale/en-US/_Polonium/Prototypes/Generated/Entities/Objects/Weapons/CentCom.ftl
+++ b/Resources/Locale/en-US/_Polonium/Prototypes/Generated/Entities/Objects/Weapons/CentCom.ftl
@@ -1,0 +1,5 @@
+
+ent-MindWipingPen = very normal CentCom pen
+    .desc = A VERY normal CentCom Pen. Now please just look here at it.... *click*
+
+mind-wiping-pen-mind-wipe = Everyone around loose memory of the whole shift.

--- a/Resources/Locale/en-US/_Polonium/Prototypes/Generated/Entities/Objects/Weapons/CentCom.ftl
+++ b/Resources/Locale/en-US/_Polonium/Prototypes/Generated/Entities/Objects/Weapons/CentCom.ftl
@@ -2,4 +2,4 @@
 ent-MindWipingPen = very normal CentCom pen
     .desc = A VERY normal CentCom Pen. Now please just look here at it.... *click*
 
-mind-wiping-pen-mind-wipe = Everyone around loose memory of the whole shift.
+mind-wiping-pen-mind-wipe = Everyone around lose memory of the whole shift.

--- a/Resources/Locale/pl-PL/_Polonium/Prototypes/Generated/Entities/Objects/Weapons/CentCom.ftl
+++ b/Resources/Locale/pl-PL/_Polonium/Prototypes/Generated/Entities/Objects/Weapons/CentCom.ftl
@@ -1,0 +1,5 @@
+
+ent-MindWipingPen = bardzo normlany długopis CD
+    .desc = BARDZO normlny długiopis CD. Teraz prosze spójrz tu na niego.... *klik*
+
+mind-wiping = Wszyscy wokół tracą pamięć całej zmiany.

--- a/Resources/Prototypes/_Polonium/Entities/Objects/Weapons/CentCom.yml
+++ b/Resources/Prototypes/_Polonium/Entities/Objects/Weapons/CentCom.yml
@@ -1,0 +1,25 @@
+- type: entity
+  id: MindWipingPen
+  parent: PenCentcom
+  name: very normal CentCom pen
+  description: A VERY normal CentCom Pen. Now please just look here at it.... *click*
+  components:
+  - type: EmitSoundOnUse # Overwrite so it is audiable
+    handle: false
+  - type: UseDelay
+    delay: 1
+  - type: Flash
+    sound:
+      path: /Audio/Items/pen_click.ogg
+      params:
+        volume: 2
+        maxDistance: 5
+    flashOnMelee: false
+    flashingTime: 0
+    aoeFlashDuration: 10
+    range: 10
+    slowTo: 0.1
+  - type: PopupOnUse
+    message: Wszyscy wokół tracą pamięć całej zmiany. # for some reason "mind-wiping" doesn't want to get replaced properly here
+    popupSize: large
+    showToOthers: true

--- a/Resources/Prototypes/_Polonium/Entities/Objects/Weapons/CentCom.yml
+++ b/Resources/Prototypes/_Polonium/Entities/Objects/Weapons/CentCom.yml
@@ -3,6 +3,7 @@
   parent: PenCentcom
   name: very normal CentCom pen
   description: A VERY normal CentCom Pen. Now please just look here at it.... *click*
+  suffix: Admeme, DO NOT MAP
   components:
   - type: EmitSoundOnUse # Overwrite so it is audiable
     handle: false


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->

Dodaje przedmiot Admeme, długopis do usuwania pamięci
Zamyka #870 

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->

Przedmiot Admeme do urzytku pod RP

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->

Długopis CD co przy kliknięciu flashuje i wyświetla "Wszyscy wokół tracą pamięć całej zmiany."

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->
<img width="425" height="98" alt="image" src="https://github.com/user-attachments/assets/b27e8cfe-6258-4c6b-92c6-fcc118088bf6" />

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
<!--
Brak changelogu bo to admeme item, nie ma sensu spamić changelog
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nowe funkcje**
  * Dodano pióro wywołujące efekt utraty pamięci u celów w obszarze działania.
  * Użycie pióra emituje dźwięk, powoduje krótkie opóźnienie i spowalnia trafione cele.
  * Inni gracze otrzymują komunikat o utracie pamięci całej zmiany.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->