### PR TITLE
Bugfix: Light tubes and bulbs break into glass shards

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -68,10 +68,10 @@
   - type: Destructible
     thresholds:
     - trigger: *DamageTrigger10
-      behaviors:
+      behaviors: &BehaviorsSpawnShardGlass
       - !type:SpawnEntitiesBehavior
         spawn:
-          LightBulbBroken:
+          ShardGlass:
             min: 1
             max: 1
 
@@ -87,12 +87,7 @@
   - type: Destructible
     thresholds:
     - trigger: *DamageTrigger10
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          LightTubeBroken:
-            min: 1
-            max: 1
+      behaviors: *BehaviorsSpawnShardGlass
 
 # Lighting color values gathered from
 # https://andi-siess.de/rgb-to-color-temperature/


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->


## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
https://github.com/space-wizards/space-station-14/pull/44895

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
closes: #880

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: haze
- fix: Naprawiono żarówki

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Ulepszenia**
  * Uszkodzone żarówki i świetlówki generują teraz odłamki szkła zamiast osobnych typów pozostałości.
  * Ujednolicono zachowanie tworzenia odłamków dla obu rodzajów oświetlenia.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->