### PR TITLE
Cherry-pick upstream PR #44081: windoors fix

### DIFF
--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -301,6 +301,20 @@ public sealed partial class DoorComponent : Component
     [DataField]
     public bool ClickOpen = true;
 
+    /// <summary>
+    /// If true, the door closing check will try to match only entities intersecting the door's first fixture.
+    /// If false, the door will check the full tile the door is on.
+    /// </summary>
+    [DataField]
+    public bool CheckFixtureCollision;
+
+    /// <summary>
+    /// If true, the door will be able to close over entities with the MachineLayer fixture layer.
+    /// Useful for windoors or other thin doors.
+    /// </summary>
+    [DataField]
+    public bool AllowMachineLayer;
+
     [DataField(customTypeSerializer: typeof(ConstantSerializer<DrawDepthTag>))]
     public int OpenDrawDepth = (int) DrawDepth.DrawDepth.Doors;
 

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -23,7 +23,9 @@ using Robust.Shared.Timing;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Physics;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Doors.Systems;
 
@@ -53,8 +55,6 @@ public abstract partial class SharedDoorSystem : EntitySystem
     ///     A set of doors that are currently opening, closing, or just queued to open/close after some delay.
     /// </summary>
     private readonly HashSet<Entity<DoorComponent>> _activeDoors = new();
-
-    private readonly HashSet<Entity<PhysicsComponent>> _doorIntersecting = new();
 
     public override void Initialize()
     {
@@ -450,7 +450,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
         if (!HasAccess(uid, user, door))
             return false;
 
-        return !ev.PerformCollisionCheck || !GetColliding(uid).Any();
+        return !ev.PerformCollisionCheck || !GetColliding(uid, null, null, door.CheckFixtureCollision, door.PerformCollisionCheck).Any();
     }
 
     public void StartClosing(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
@@ -522,7 +522,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
     }
 
     /// <summary>
-    /// Crushes everyone colliding with us by more than <see cref="IntersectPercentage"/>%.
+    /// Crushes everyone colliding with the door.
     /// </summary>
     public void Crush(EntityUid uid, DoorComponent? door = null, PhysicsComponent? physics = null)
     {
@@ -532,9 +532,9 @@ public abstract partial class SharedDoorSystem : EntitySystem
         if (!door.CanCrush)
             return;
 
-        // Find entities and apply curshing effects
+        // Find entities and apply crushing effects
         var stunTime = door.DoorStunTime + door.OpenTimeOne;
-        foreach (var entity in GetColliding(uid, physics))
+        foreach (var entity in GetColliding(uid, physics, null, door.CheckFixtureCollision, door.AllowMachineLayer))
         {
             door.CurrentlyCrushing.Add(entity);
             if (door.CrushDamage != null)
@@ -552,11 +552,17 @@ public abstract partial class SharedDoorSystem : EntitySystem
     }
 
     /// <summary>
-    ///     Get all entities that collide with this door by more than <see cref="IntersectPercentage"/> percent.\
+    /// Checks if there are any entities colliding with the door, passing them back out to use e.g. to prevent closing.
     /// </summary>
-    public IEnumerable<EntityUid> GetColliding(EntityUid uid, PhysicsComponent? physics = null)
+    /// <param name="uid">The door entity to check.</param>
+    /// <param name="physics">The door's <see cref="PhysicsComponent"/>.</param>
+    /// <param name="checkFixtureCollision">If true, the door will do a more exact check based on its first fixture.</param>
+    /// <param name="fixtures">The door's <see cref="FixturesComponent"/>.</param>
+    /// <param name="allowMachineLayer">The door will be able to close over <see cref="CollisionGroup.MachineLayer"/>.</param>
+    /// <returns>The list of entities inside the door.</returns>
+    public IEnumerable<EntityUid> GetColliding(EntityUid uid, PhysicsComponent? physics = null, FixturesComponent? fixtures = null, bool checkFixtureCollision = false, bool allowMachineLayer = false)
     {
-        if (!Resolve(uid, ref physics))
+        if (!Resolve(uid, ref physics) || !Resolve(uid, ref fixtures))
             yield break;
 
         var xform = Transform(uid);
@@ -566,13 +572,27 @@ public abstract partial class SharedDoorSystem : EntitySystem
             yield break;
         var tileRef = _mapSystem.GetTileRef(xform.GridUid.Value, mapGridComp, xform.Coordinates);
 
-        _doorIntersecting.Clear();
-        _entityLookup.GetLocalEntitiesIntersecting(xform.GridUid.Value, tileRef.GridIndices, _doorIntersecting, gridComp: mapGridComp, flags: (LookupFlags.All & ~LookupFlags.Sensors));
+        var doorIntersecting = new HashSet<Entity<PhysicsComponent>>();
+
+        if (checkFixtureCollision && fixtures.Fixtures.TryFirstOrNull(out var fixture))
+        {
+            var fixtureToWorld = PhysicsSystem.GetPhysicsTransform(uid, xform);
+
+            _entityLookup.GetEntitiesIntersecting(xform.MapID,
+                fixture.Value.Value.Shape,
+                fixtureToWorld,
+                doorIntersecting,
+                flags: LookupFlags.All & ~(LookupFlags.Sensors | LookupFlags.Contained));
+        }
+        else
+        {
+            _entityLookup.GetLocalEntitiesIntersecting(xform.GridUid.Value, tileRef.GridIndices, doorIntersecting, gridComp: mapGridComp, flags: LookupFlags.All & ~(LookupFlags.Sensors | LookupFlags.Contained));
+        }
 
         // TODO SLOTH fix electro's code.
         // ReSharper disable once InconsistentNaming
 
-        foreach (var otherPhysics in _doorIntersecting)
+        foreach (var otherPhysics in doorIntersecting)
         {
             if (otherPhysics.Comp == physics)
                 continue;
@@ -591,6 +611,10 @@ public abstract partial class SharedDoorSystem : EntitySystem
 
             //For when doors need to close over conveyor belts
             if (otherPhysics.Comp.CollisionLayer == (int) CollisionGroup.ConveyorMask)
+                continue;
+
+            // We want windoors to be able to close over machines
+            if (allowMachineLayer && otherPhysics.Comp.CollisionLayer == (int) CollisionGroup.MachineLayer)
                 continue;
 
             if ((physics.CollisionMask & otherPhysics.Comp.CollisionLayer) == 0 && (otherPhysics.Comp.CollisionMask & physics.CollisionLayer) == 0)

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -107,6 +107,8 @@
       path: /Audio/Machines/windoor_open.ogg
     denySound:
       path: /Audio/Machines/airlock_deny.ogg
+    checkFixtureCollision: true
+    allowMachineLayer: true
   - type: Airlock
     keepOpenIfClicked: true
     openPanelVisible: true


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
https://github.com/space-wizards/space-station-14/pull/44081

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
closes: #823 

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: haze
- fix: Naprawiono windoory



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Ulepszenia**
  * Usprawniono wykrywanie kolizji podczas zamykania drzwi.
  * Drzwi mogą teraz zamykać się nad obiektami należącymi do warstwy maszyn.
  * Dodano dokładniejsze sprawdzanie elementów konstrukcyjnych drzwi.
  * Zaktualizowano konfigurację windoorów, aby korzystały z nowych zasad kolizji.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->