### PR TITLE
Aparat fotograficzny

### DIFF
--- a/Content.Client/Administration/UI/Tabs/AdminbusTab/AdminbusTab.xaml
+++ b/Content.Client/Administration/UI/Tabs/AdminbusTab/AdminbusTab.xaml
@@ -12,5 +12,6 @@
         <Button Name="LoadGamePrototypeButton" Text="{Loc 'load-game-prototype'}"/>
         <cc:UICommandButton Name="LoadBlueprintsButton" Command="loadbp" Text="{Loc 'load-blueprints'}" WindowType="{x:Type abt:LoadBlueprintsWindow}"/>
         <cc:CommandButton Command="deleteewc Singularity" Name="DeleteSingulos" Text="{Loc 'delete-singularities'}"/>
+        <cc:CommandButton Command="photos" Name="ViewPhotosButton" Text="{Loc 'admin-view-photos-button'}"/>
     </GridContainer>
 </Control>

--- a/Content.Client/Outline/InteractionOutlineSystem.cs
+++ b/Content.Client/Outline/InteractionOutlineSystem.cs
@@ -30,6 +30,13 @@ public sealed partial class InteractionOutlineSystem : EntitySystem
     private bool _enabled = true;
 
     /// <summary>
+    ///     POLONIUM CHANGE!
+    ///     Current value of the temporary-disable flag, so a caller that disables the
+    ///     outline can restore the prior state instead of clobbering another system's disable.
+    /// </summary>
+    public bool Enabled => _enabled;
+
+    /// <summary>
     ///     Whether to draw the outline at all. Overrides <see cref="_enabled"/>.
     /// </summary>
     private bool _cvarEnabled = true;

--- a/Content.Client/_Polonium/Photography/AdminPhotoEui.cs
+++ b/Content.Client/_Polonium/Photography/AdminPhotoEui.cs
@@ -1,0 +1,36 @@
+using Content.Client.Eui;
+using Content.Shared._Polonium.Photography;
+using Content.Shared.Eui;
+using JetBrains.Annotations;
+
+namespace Content.Client._Polonium.Photography;
+
+/// <summary>Client half of the admin photo viewer. Named to match the server EUI.</summary>
+[UsedImplicitly]
+public sealed class AdminPhotoEui : BaseEui
+{
+    private readonly AdminPhotoWindow _window = new();
+
+    public AdminPhotoEui()
+    {
+        _window.OnSelect += id => SendMessage(new AdminPhotoSelectMessage(id));
+        _window.OnDelete += id => SendMessage(new AdminPhotoDeleteMessage(id));
+        _window.OnClose += () => SendMessage(new CloseEuiMessage());
+    }
+
+    public override void Opened()
+    {
+        _window.OpenCentered();
+    }
+
+    public override void Closed()
+    {
+        _window.Close();
+    }
+
+    public override void HandleState(EuiStateBase state)
+    {
+        if (state is AdminPhotoEuiState cast)
+            _window.Populate(cast);
+    }
+}

--- a/Content.Client/_Polonium/Photography/AdminPhotoWindow.cs
+++ b/Content.Client/_Polonium/Photography/AdminPhotoWindow.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Content.Shared._Polonium.Photography;
+using Robust.Client.Graphics;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared.IoC;
+using Robust.Shared.Maths;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Content.Client._Polonium.Photography;
+
+/// <summary>Admin window listing every photo captured this round.</summary>
+public sealed class AdminPhotoWindow : DefaultWindow
+{
+    [Dependency] private readonly IClyde _clyde = default!;
+
+    private const int Size = PhotographyConstants.PhotoSizePixels;
+    private const int Scale = 2;
+
+    private readonly ItemList _list;
+    private readonly TextureRect _image;
+    private readonly Label _info;
+    private readonly Button _delete;
+
+    private readonly List<int> _ids = new();
+    private int? _shownId;
+    private OwnedTexture? _texture;
+
+    public event Action<int>? OnSelect;
+    public event Action<int>? OnDelete;
+
+    public AdminPhotoWindow()
+    {
+        IoCManager.InjectDependencies(this);
+
+        Title = Loc.GetString("admin-photo-title");
+        MinSize = new Vector2(560, 400);
+
+        _list = new ItemList
+        {
+            SelectMode = ItemList.ItemListSelectMode.Single,
+            HorizontalExpand = true,
+            VerticalExpand = true,
+            MinWidth = 260,
+        };
+        _list.OnItemSelected += args =>
+        {
+            if (args.ItemIndex < _ids.Count)
+                OnSelect?.Invoke(_ids[args.ItemIndex]);
+        };
+
+        _image = new TextureRect
+        {
+            HorizontalAlignment = HAlignment.Center,
+            Stretch = TextureRect.StretchMode.KeepAspectCentered,
+            TextureScale = new Vector2(Scale, Scale),
+            MinSize = new Vector2(Size * Scale, Size * Scale),
+        };
+
+        _info = new Label
+        {
+            HorizontalAlignment = HAlignment.Center,
+            Margin = new Thickness(0, 8),
+        };
+
+        _delete = new Button
+        {
+            Text = Loc.GetString("admin-photo-delete"),
+            Disabled = true,
+        };
+        _delete.OnPressed += _ =>
+        {
+            if (_shownId is { } id)
+                OnDelete?.Invoke(id);
+        };
+
+        var right = new BoxContainer
+        {
+            Orientation = BoxContainer.LayoutOrientation.Vertical,
+            HorizontalExpand = true,
+            Children = { _image, _info, _delete },
+        };
+
+        Contents.AddChild(new BoxContainer
+        {
+            Orientation = BoxContainer.LayoutOrientation.Horizontal,
+            Children = { _list, right },
+        });
+    }
+
+    public void Populate(AdminPhotoEuiState state)
+    {
+        _list.Clear();
+        _ids.Clear();
+        foreach (var p in state.Photos)
+        {
+            var subject = string.IsNullOrEmpty(p.Subject) ? Loc.GetString("admin-photo-no-subject") : p.Subject;
+            _list.AddItem(Loc.GetString("admin-photo-list-item", ("id", p.Id), ("shooter", p.Shooter), ("subject", subject)));
+            _ids.Add(p.Id);
+        }
+
+        _shownId = state.SelectedId;
+        _delete.Disabled = _shownId == null;
+        ShowImage(state.SelectedData);
+    }
+
+    private void ShowImage(byte[]? data)
+    {
+        _texture?.Dispose();
+        _texture = null;
+
+        if (data == null || data.Length != PhotographyConstants.PhotoByteLength)
+        {
+            _image.Texture = null;
+            _info.Text = Loc.GetString(_shownId == null ? "admin-photo-select" : "admin-photo-unavailable");
+            return;
+        }
+
+        var owned = _clyde.CreateBlankTexture<Rgba32>(new Vector2i(Size, Size));
+        owned.SetSubImage(Vector2i.Zero, new Vector2i(Size, Size), PhotoCodec.ToPixels(data));
+        _texture = owned;
+        _image.Texture = owned;
+        _info.Text = Loc.GetString("admin-photo-number", ("id", _shownId ?? 0));
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _texture?.Dispose();
+            _texture = null;
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/Content.Client/_Polonium/Photography/AdminPhotoWindow.cs
+++ b/Content.Client/_Polonium/Photography/AdminPhotoWindow.cs
@@ -12,11 +12,11 @@ using SixLabors.ImageSharp.PixelFormats;
 namespace Content.Client._Polonium.Photography;
 
 /// <summary>Admin window listing every photo captured this round.</summary>
-public sealed class AdminPhotoWindow : DefaultWindow
+public sealed partial class AdminPhotoWindow : DefaultWindow
 {
-    [Dependency] private readonly IClyde _clyde = default!;
+    [Dependency] private IClyde _clyde = default!;
 
-    private const int Size = PhotographyConstants.PhotoSizePixels;
+    private new const int Size = PhotographyConstants.PhotoSizePixels;
     private const int Scale = 2;
 
     private readonly ItemList _list;

--- a/Content.Client/_Polonium/Photography/AdminPhotoWindow.cs
+++ b/Content.Client/_Polonium/Photography/AdminPhotoWindow.cs
@@ -27,6 +27,7 @@ public sealed partial class AdminPhotoWindow : DefaultWindow
     private readonly List<int> _ids = new();
     private int? _shownId;
     private OwnedTexture? _texture;
+    private bool _populating;
 
     public event Action<int>? OnSelect;
     public event Action<int>? OnDelete;
@@ -47,6 +48,8 @@ public sealed partial class AdminPhotoWindow : DefaultWindow
         };
         _list.OnItemSelected += args =>
         {
+            if (_populating)
+                return;
             if (args.ItemIndex < _ids.Count)
                 OnSelect?.Invoke(_ids[args.ItemIndex]);
         };
@@ -92,6 +95,8 @@ public sealed partial class AdminPhotoWindow : DefaultWindow
 
     public void Populate(AdminPhotoEuiState state)
     {
+        _populating = true;
+
         _list.Clear();
         _ids.Clear();
         foreach (var p in state.Photos)
@@ -103,7 +108,17 @@ public sealed partial class AdminPhotoWindow : DefaultWindow
 
         _shownId = state.SelectedId;
         _delete.Disabled = _shownId == null;
+
+        if (_shownId is { } sel)
+        {
+            var index = _ids.IndexOf(sel);
+            if (index >= 0)
+                _list[index].Selected = true;
+        }
+
         ShowImage(state.SelectedData);
+
+        _populating = false;
     }
 
     private void ShowImage(byte[]? data)

--- a/Content.Client/_Polonium/Photography/CameraStatusControl.cs
+++ b/Content.Client/_Polonium/Photography/CameraStatusControl.cs
@@ -12,14 +12,14 @@ namespace Content.Client._Polonium.Photography;
 public sealed class CameraStatusControl : Control
 {
     private readonly EntityUid _owner;
-    private readonly IEntityManager _entMan;
+    private readonly ItemToggleSystem _toggle;
     private readonly RichTextLabel _label;
     private bool? _lastState;
 
     public CameraStatusControl(EntityUid owner, IEntityManager entMan)
     {
         _owner = owner;
-        _entMan = entMan;
+        _toggle = entMan.System<ItemToggleSystem>();
         _label = new RichTextLabel { StyleClasses = { StyleNano.StyleClassItemStatus } };
         AddChild(_label);
         Update();
@@ -33,7 +33,7 @@ public sealed class CameraStatusControl : Control
 
     private void Update()
     {
-        var on = _entMan.System<ItemToggleSystem>().IsActivated(_owner);
+        var on = _toggle.IsActivated(_owner);
         if (_lastState == on)
             return;
 

--- a/Content.Client/_Polonium/Photography/CameraStatusControl.cs
+++ b/Content.Client/_Polonium/Photography/CameraStatusControl.cs
@@ -1,0 +1,43 @@
+using Content.Client.Stylesheets;
+using Content.Shared.Item.ItemToggle;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Content.Client._Polonium.Photography;
+
+/// <summary>In-hand item-status line for the camera's flash. Polls ItemToggle each frame so it updates live while held.</summary>
+public sealed class CameraStatusControl : Control
+{
+    private readonly EntityUid _owner;
+    private readonly IEntityManager _entMan;
+    private readonly RichTextLabel _label;
+    private bool? _lastState;
+
+    public CameraStatusControl(EntityUid owner, IEntityManager entMan)
+    {
+        _owner = owner;
+        _entMan = entMan;
+        _label = new RichTextLabel { StyleClasses = { StyleNano.StyleClassItemStatus } };
+        AddChild(_label);
+        Update();
+    }
+
+    protected override void FrameUpdate(FrameEventArgs args)
+    {
+        base.FrameUpdate(args);
+        Update();
+    }
+
+    private void Update()
+    {
+        var on = _entMan.System<ItemToggleSystem>().IsActivated(_owner);
+        if (_lastState == on)
+            return;
+
+        _lastState = on;
+        _label.SetMessage(FormattedMessage.FromMarkupOrThrow(Loc.GetString(on ? "camera-flash-on" : "camera-flash-off")));
+    }
+}

--- a/Content.Client/_Polonium/Photography/CameraViewfinderOverlay.cs
+++ b/Content.Client/_Polonium/Photography/CameraViewfinderOverlay.cs
@@ -9,12 +9,12 @@ using Robust.Shared.Prototypes;
 namespace Content.Client._Polonium.Photography;
 
 /// <summary>Screen-space viewfinder: via <c>camera_viewfinder.swsl</c>, dims + blurs everything except the sharp window around the shot's target. <see cref="CameraViewfinderSystem"/> updates the window each frame; this overlay feeds it to the shader.</summary>
-public sealed class CameraViewfinderOverlay : Overlay
+public sealed partial class CameraViewfinderOverlay : Overlay
 {
     private static readonly ProtoId<ShaderPrototype> ShaderProto = "PoloniumCameraViewfinder";
 
-    [Dependency] private readonly IEyeManager _eye = default!;
-    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private IEyeManager _eye = default!;
+    [Dependency] private IPrototypeManager _proto = default!;
 
     private readonly ShaderInstance _shader;
 

--- a/Content.Client/_Polonium/Photography/CameraViewfinderOverlay.cs
+++ b/Content.Client/_Polonium/Photography/CameraViewfinderOverlay.cs
@@ -1,0 +1,66 @@
+using System.Numerics;
+using Content.Shared._Polonium.Photography;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+using Robust.Shared.IoC;
+using Robust.Shared.Maths;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client._Polonium.Photography;
+
+/// <summary>Screen-space viewfinder: via <c>camera_viewfinder.swsl</c>, dims + blurs everything except the sharp window around the shot's target. <see cref="CameraViewfinderSystem"/> updates the window each frame; this overlay feeds it to the shader.</summary>
+public sealed class CameraViewfinderOverlay : Overlay
+{
+    private static readonly ProtoId<ShaderPrototype> ShaderProto = "PoloniumCameraViewfinder";
+
+    [Dependency] private readonly IEyeManager _eye = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+
+    private readonly ShaderInstance _shader;
+
+    public override bool RequestScreenTexture => true;
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+
+    public Vector2 CenterWorld;
+    public Color BorderColor = Color.Black;
+
+    public float Dim = 0.15f;
+    public float Blur = 4.5f;
+    public float BorderWidth = 1.5f;
+
+    public CameraViewfinderOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+        _shader = _proto.Index(ShaderProto).InstanceUnique();
+    }
+
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        return args.Viewport.Eye == _eye.CurrentEye;
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        if (ScreenTexture == null)
+            return;
+
+        // Window rect in viewport render-target pixels (matches the shader's px).
+        var vp = args.Viewport;
+        var centerPx = vp.WorldToLocal(CenterWorld);
+        var pxPerTile = (vp.WorldToLocal(CenterWorld + new Vector2(1f, 0f)) - centerPx).Length();
+        var halfPx = PhotographyConstants.TilesPerSide / 2f * pxPerTile;
+
+        _shader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
+        _shader.SetParameter("CENTER_PX", centerPx);
+        _shader.SetParameter("HALF_PX", new Vector2(halfPx, halfPx));
+        _shader.SetParameter("DIM", Dim);
+        _shader.SetParameter("BLUR", Blur);
+        _shader.SetParameter("BORDER_PX", BorderWidth);
+        _shader.SetParameter("BORDER_COLOR", new Vector3(BorderColor.R, BorderColor.G, BorderColor.B));
+
+        var handle = args.WorldHandle;
+        handle.UseShader(_shader);
+        handle.DrawRect(args.WorldBounds, Color.White);
+        handle.UseShader(null);
+    }
+}

--- a/Content.Client/_Polonium/Photography/CameraViewfinderSystem.cs
+++ b/Content.Client/_Polonium/Photography/CameraViewfinderSystem.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Numerics;
+using Content.Client.Gameplay;
+using Content.Client.Viewport;
+using Content.Shared._Polonium.Photography;
+using Content.Shared.Examine;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Inventory;
+using Robust.Client.Graphics;
+using Robust.Client.Input;
+using Robust.Client.Player;
+using Robust.Client.State;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+
+namespace Content.Client._Polonium.Photography;
+
+/// <summary>Drives the <see cref="CameraViewfinderOverlay"/> while a camera is in the active hand and the cursor is over the game view: each frame resolves the target (entity under cursor, else cursor tile), eases the window toward it, and reddens the border when the shot is blocked by line of sight / range.</summary>
+public sealed class CameraViewfinderSystem : EntitySystem
+{
+    [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly IUserInterfaceManager _ui = default!;
+    [Dependency] private readonly IInputManager _input = default!;
+    [Dependency] private readonly IOverlayManager _overlay = default!;
+    [Dependency] private readonly IStateManager _state = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly ExamineSystemShared _examine = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
+
+    private const float LerpFactor = 20f;
+
+    private CameraViewfinderOverlay _viewfinder = default!;
+    private bool _added;
+
+    private Vector2 _center;
+    private MapId _centerMap = MapId.Nullspace;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _viewfinder = new CameraViewfinderOverlay();
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        Hide();
+    }
+
+    public override void FrameUpdate(float frameTime)
+    {
+        base.FrameUpdate(frameTime);
+
+        if (!TryGetTarget(out var player, out var target, out var onEntity))
+        {
+            Hide();
+            return;
+        }
+
+        if (_centerMap != target.MapId)
+        {
+            _center = target.Position;
+            _centerMap = target.MapId;
+        }
+        else
+        {
+            _center = Vector2.Lerp(_center, target.Position, MathF.Min(1f, LerpFactor * frameTime));
+        }
+
+        var valid = _examine.InRangeUnOccluded(player, target, PhotographyConstants.PhotoMaxRange);
+        var border = !valid ? Color.Red : onEntity ? Color.Blue : Color.Black;
+
+        Show(_center, border);
+    }
+
+    private bool TryGetTarget(out EntityUid player, out MapCoordinates target, out bool onEntity)
+    {
+        player = default;
+        target = default;
+        onEntity = false;
+
+        if (_player.LocalSession?.AttachedEntity is not { } p)
+            return false;
+        player = p;
+
+        if (_hands.GetActiveItem(player) is not { } item || !HasComp<PoloniumCameraComponent>(item))
+            return false;
+
+        if (_inventory.TryGetSlotEntity(player, SharedPoloniumPhotographySystem.EyeSlot, out _))
+            return false;
+
+        if (_state.CurrentState is not GameplayStateBase screen)
+            return false;
+        if (_ui.CurrentlyHovered is not IViewportControl vp || !_input.MouseScreenPosition.IsValid)
+            return false;
+
+        var mousePos = vp.PixelToMap(_input.MouseScreenPosition.Position);
+        if (mousePos.MapId == MapId.Nullspace)
+            return false;
+
+        var entity = _input.IsKeyDown(Keyboard.Key.Shift)
+            ? null
+            : vp is ScalingViewport svp
+                ? screen.GetClickedEntity(mousePos, svp.Eye)
+                : screen.GetClickedEntity(mousePos);
+
+        if (entity is { } e && !Deleted(e))
+        {
+            target = _transform.GetMapCoordinates(e);
+            onEntity = true;
+        }
+        else
+        {
+            target = mousePos;
+        }
+
+        return true;
+    }
+
+    private void Show(Vector2 centerWorld, Color border)
+    {
+        if (!_added)
+        {
+            _overlay.AddOverlay(_viewfinder);
+            _added = true;
+        }
+
+        _viewfinder.CenterWorld = centerWorld;
+        _viewfinder.BorderColor = border;
+    }
+
+    private void Hide()
+    {
+        if (_added)
+        {
+            _overlay.RemoveOverlay(_viewfinder);
+            _added = false;
+        }
+
+        _centerMap = MapId.Nullspace;
+    }
+}

--- a/Content.Client/_Polonium/Photography/CameraViewfinderSystem.cs
+++ b/Content.Client/_Polonium/Photography/CameraViewfinderSystem.cs
@@ -18,17 +18,17 @@ using Robust.Shared.Maths;
 namespace Content.Client._Polonium.Photography;
 
 /// <summary>Drives the <see cref="CameraViewfinderOverlay"/> while a camera is in the active hand and the cursor is over the game view: each frame resolves the target (entity under cursor, else cursor tile), eases the window toward it, and reddens the border when the shot is blocked by line of sight / range.</summary>
-public sealed class CameraViewfinderSystem : EntitySystem
+public sealed partial class CameraViewfinderSystem : EntitySystem
 {
-    [Dependency] private readonly IPlayerManager _player = default!;
-    [Dependency] private readonly IUserInterfaceManager _ui = default!;
-    [Dependency] private readonly IInputManager _input = default!;
-    [Dependency] private readonly IOverlayManager _overlay = default!;
-    [Dependency] private readonly IStateManager _state = default!;
-    [Dependency] private readonly SharedHandsSystem _hands = default!;
-    [Dependency] private readonly ExamineSystemShared _examine = default!;
-    [Dependency] private readonly SharedTransformSystem _transform = default!;
-    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private IPlayerManager _player = default!;
+    [Dependency] private IUserInterfaceManager _ui = default!;
+    [Dependency] private IInputManager _input = default!;
+    [Dependency] private IOverlayManager _overlay = default!;
+    [Dependency] private IStateManager _state = default!;
+    [Dependency] private SharedHandsSystem _hands = default!;
+    [Dependency] private ExamineSystemShared _examine = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private InventorySystem _inventory = default!;
 
     private const float LerpFactor = 20f;
 

--- a/Content.Client/_Polonium/Photography/PhotoCodec.cs
+++ b/Content.Client/_Polonium/Photography/PhotoCodec.cs
@@ -1,0 +1,53 @@
+using Content.Shared._Polonium.Photography;
+using Robust.Client.Utility;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Content.Client._Polonium.Photography;
+
+/// <summary>Converts between a rendered <see cref="Rgba32"/> image and the compact RGB565 wire format (<see cref="PhotographyConstants.PhotoByteLength"/> bytes): one 16-bit color per pixel, big-endian, row-major, no palette. The fixed size is the point - the server validates by length and never runs an image decoder.</summary>
+public static class PhotoCodec
+{
+    private const int Size = PhotographyConstants.PhotoSizePixels;
+
+    /// <summary>Pack the image to RGB565.</summary>
+    public static byte[] ToRgb565(Image<Rgba32> image)
+    {
+        var src = image.GetPixelSpan();
+        var packed = new byte[PhotographyConstants.PhotoByteLength];
+
+        var count = Size * Size;
+        for (var i = 0; i < count; i++)
+        {
+            var p = PhotoGrade.Apply(src[i], i % Size, i / Size);
+            var value = (ushort) (((p.R >> 3) << 11) | ((p.G >> 2) << 5) | (p.B >> 3));
+            packed[i * 2] = (byte) (value >> 8);
+            packed[i * 2 + 1] = (byte) (value & 0xFF);
+        }
+
+        return packed;
+    }
+
+    /// <summary>Unpack a validated RGB565 blob back into an <see cref="Rgba32"/> buffer for display.</summary>
+    public static Rgba32[] ToPixels(byte[] packed)
+    {
+        var pixels = new Rgba32[Size * Size];
+
+        for (var i = 0; i < pixels.Length; i++)
+        {
+            var value = (ushort) ((packed[i * 2] << 8) | packed[i * 2 + 1]);
+
+            var r5 = (value >> 11) & 0x1F;
+            var g6 = (value >> 5) & 0x3F;
+            var b5 = value & 0x1F;
+
+            var r = (byte) ((r5 << 3) | (r5 >> 2));
+            var g = (byte) ((g6 << 2) | (g6 >> 4));
+            var b = (byte) ((b5 << 3) | (b5 >> 2));
+
+            pixels[i] = new Rgba32(r, g, b, 255);
+        }
+
+        return pixels;
+    }
+}

--- a/Content.Client/_Polonium/Photography/PhotoGrade.cs
+++ b/Content.Client/_Polonium/Photography/PhotoGrade.cs
@@ -1,0 +1,68 @@
+using System;
+using Content.Shared._Polonium.Photography;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Content.Client._Polonium.Photography;
+
+/// <summary>Cheap "analog film" color grade applied per pixel before RGB565 quantization: desaturation, warm tint, lifted/compressed blacks, soft vignette, deterministic grain. Purely cosmetic and client-side.</summary>
+public static class PhotoGrade
+{
+    private const int Size = PhotographyConstants.PhotoSizePixels;
+
+    private const float Saturation = 0.82f;    // 1 = untouched, 0 = grayscale
+    private const float WarmR = 1.07f;
+    private const float WarmG = 1.01f;
+    private const float WarmB = 0.90f;
+    private const float Contrast = 0.88f;      // <1 softens
+    private const float Lift = 14f;            // Raised black floor, in 0..255
+    private const float Vignette = 0.55f;      // Corner darkening strength (0 = none)
+    private const float Grain = 6f;            // Peak grain amplitude, in 0..255
+
+    private static readonly float CenterX = (Size - 1) / 2f;
+    private static readonly float CenterY = (Size - 1) / 2f;
+
+    /// <summary>Grade one pixel at (<paramref name="x"/>, <paramref name="y"/>).</summary>
+    public static Rgba32 Apply(Rgba32 p, int x, int y)
+    {
+        float r = p.R, g = p.G, b = p.B;
+
+        var luma = 0.299f * r + 0.587f * g + 0.114f * b;
+        r = luma + (r - luma) * Saturation;
+        g = luma + (g - luma) * Saturation;
+        b = luma + (b - luma) * Saturation;
+
+        r *= WarmR;
+        g *= WarmG;
+        b *= WarmB;
+
+        r = (r - 128f) * Contrast + 128f + Lift;
+        g = (g - 128f) * Contrast + 128f + Lift;
+        b = (b - 128f) * Contrast + 128f + Lift;
+
+        var dx = (x - CenterX) / CenterX;
+        var dy = (y - CenterY) / CenterY;
+        var vignette = 1f - Vignette * (dx * dx + dy * dy) * 0.5f;
+        r *= vignette;
+        g *= vignette;
+        b *= vignette;
+
+        var grain = (Hash(x, y) / 255f - 0.5f) * Grain;
+        r += grain;
+        g += grain;
+        b += grain;
+
+        return new Rgba32(Clamp(r), Clamp(g), Clamp(b), 255);
+    }
+
+    private static byte Clamp(float v)
+    {
+        return (byte) Math.Clamp(v, 0f, 255f);
+    }
+
+    private static int Hash(int x, int y)
+    {
+        var h = (x * 73856093) ^ (y * 19349663);
+        h ^= h >> 13;
+        return h & 0xFF;
+    }
+}

--- a/Content.Client/_Polonium/Photography/PhotoViewerBoundUserInterface.cs
+++ b/Content.Client/_Polonium/Photography/PhotoViewerBoundUserInterface.cs
@@ -1,0 +1,30 @@
+using System;
+using Content.Shared._Polonium.Photography;
+using JetBrains.Annotations;
+using Robust.Client.UserInterface;
+
+namespace Content.Client._Polonium.Photography;
+
+[UsedImplicitly]
+public sealed class PhotoViewerBoundUserInterface : BoundUserInterface
+{
+    private PhotoViewerWindow? _window;
+
+    public PhotoViewerBoundUserInterface(EntityUid owner, Enum uiKey) : base(owner, uiKey)
+    {
+    }
+
+    protected override void Open()
+    {
+        base.Open();
+        _window = this.CreateWindow<PhotoViewerWindow>();
+    }
+
+    protected override void UpdateState(BoundUserInterfaceState state)
+    {
+        base.UpdateState(state);
+
+        if (state is PhotoViewerBoundUserInterfaceState cast)
+            _window?.Populate(cast.Data);
+    }
+}

--- a/Content.Client/_Polonium/Photography/PhotoViewerWindow.cs
+++ b/Content.Client/_Polonium/Photography/PhotoViewerWindow.cs
@@ -1,0 +1,151 @@
+using System.Numerics;
+using Content.Shared._Polonium.Photography;
+using Robust.Client.Graphics;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared.IoC;
+using Robust.Shared.Maths;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Content.Client._Polonium.Photography;
+
+/// <summary>Shows a developed photograph as a bare polaroid - no window chrome, just the card: pixel image in a dark inset on off-white paper, fat bottom caption strip, top-right X, drag-to-move. Texture is built from the unpacked RGB565 blob (no image decoder runs).</summary>
+public sealed class PhotoViewerWindow : BaseWindow
+{
+    [Dependency] private IClyde _clyde = default!;
+
+    private const int Size = PhotographyConstants.PhotoSizePixels;
+    private const int Scale = 3;
+
+    private static readonly Color PaperColor = Color.FromHex("#F3EFE4");
+    private static readonly Color InsetColor = Color.FromHex("#1A1A1A");
+
+    private readonly TextureRect _image;
+    private readonly PanelContainer _photoInset;
+    private readonly Label _caption;
+    private readonly Label _empty;
+    private OwnedTexture? _texture;
+
+    public PhotoViewerWindow()
+    {
+        IoCManager.InjectDependencies(this);
+
+        MouseFilter = MouseFilterMode.Stop;
+        Resizable = false;
+
+        _image = new TextureRect
+        {
+            HorizontalAlignment = HAlignment.Center,
+            VerticalAlignment = VAlignment.Center,
+            Stretch = TextureRect.StretchMode.KeepAspectCentered,
+            TextureScale = new Vector2(Scale, Scale),
+            MinSize = new Vector2(Size * Scale, Size * Scale),
+        };
+
+        _photoInset = new PanelContainer
+        {
+            PanelOverride = new StyleBoxFlat
+            {
+                BackgroundColor = InsetColor,
+                ContentMarginLeftOverride = 2,
+                ContentMarginRightOverride = 2,
+                ContentMarginTopOverride = 2,
+                ContentMarginBottomOverride = 2,
+            },
+            Children = { _image },
+        };
+
+        _empty = new Label
+        {
+            Text = Loc.GetString("photo-viewer-empty"),
+            HorizontalAlignment = HAlignment.Center,
+            VerticalAlignment = VAlignment.Center,
+            MinSize = new Vector2(Size * Scale, Size * Scale),
+            Visible = false,
+        };
+
+        _caption = new Label
+        {
+            Text = string.Empty,
+            HorizontalAlignment = HAlignment.Center,
+            Margin = new Thickness(0, 8, 0, 0),
+        };
+
+        var column = new BoxContainer
+        {
+            Orientation = BoxContainer.LayoutOrientation.Vertical,
+            Children = { _photoInset, _empty, _caption },
+        };
+
+        var card = new PanelContainer
+        {
+            PanelOverride = new StyleBoxFlat
+            {
+                BackgroundColor = PaperColor,
+                ContentMarginLeftOverride = 16,
+                ContentMarginRightOverride = 16,
+                ContentMarginTopOverride = 16,
+                ContentMarginBottomOverride = 44,
+            },
+            Children = { column },
+        };
+
+        var close = new Button
+        {
+            Text = "✕",
+            MinSize = new Vector2(24, 24),
+        };
+        close.OnPressed += _ => Close();
+
+        var header = new BoxContainer
+        {
+            Orientation = BoxContainer.LayoutOrientation.Horizontal,
+            Children = { new Control { HorizontalExpand = true }, close },
+        };
+
+        var root = new BoxContainer
+        {
+            Orientation = BoxContainer.LayoutOrientation.Vertical,
+            Children = { header, card },
+        };
+
+        AddChild(root);
+    }
+
+    protected override DragMode GetDragModeFor(Vector2 relativeMousePos)
+    {
+        return DragMode.Move;
+    }
+
+    public void Populate(byte[]? data)
+    {
+        if (data == null || data.Length != PhotographyConstants.PhotoByteLength)
+        {
+            _photoInset.Visible = false;
+            _empty.Visible = true;
+            return;
+        }
+
+        _texture?.Dispose();
+
+        var owned = _clyde.CreateBlankTexture<Rgba32>(new Vector2i(Size, Size));
+        owned.SetSubImage(Vector2i.Zero, new Vector2i(Size, Size), PhotoCodec.ToPixels(data));
+
+        _texture = owned;
+        _image.Texture = owned;
+        _photoInset.Visible = true;
+        _empty.Visible = false;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _texture?.Dispose();
+            _texture = null;
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/Content.Client/_Polonium/Photography/PhotoViewerWindow.cs
+++ b/Content.Client/_Polonium/Photography/PhotoViewerWindow.cs
@@ -11,11 +11,11 @@ using SixLabors.ImageSharp.PixelFormats;
 namespace Content.Client._Polonium.Photography;
 
 /// <summary>Shows a developed photograph as a bare polaroid - no window chrome, just the card: pixel image in a dark inset on off-white paper, fat bottom caption strip, top-right X, drag-to-move. Texture is built from the unpacked RGB565 blob (no image decoder runs).</summary>
-public sealed class PhotoViewerWindow : BaseWindow
+public sealed partial class PhotoViewerWindow : BaseWindow
 {
     [Dependency] private IClyde _clyde = default!;
 
-    private const int Size = PhotographyConstants.PhotoSizePixels;
+    private new const int Size = PhotographyConstants.PhotoSizePixels;
     private const int Scale = 3;
 
     private static readonly Color PaperColor = Color.FromHex("#F3EFE4");

--- a/Content.Client/_Polonium/Photography/PhotographyCaptureControl.cs
+++ b/Content.Client/_Polonium/Photography/PhotographyCaptureControl.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Content.Client.Outline;
+using Content.Shared._Polonium.Photography;
+using Robust.Client.Graphics;
+using Robust.Client.UserInterface;
+using Robust.Client.Utility;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Content.Client._Polonium.Photography;
+
+/// <summary>
+/// Hidden control that renders queued photo captures. Render-to-texture + pixel readback can only happen inside the render loop, so the work runs in <see cref="Draw"/> - the same trick <c>ContentSpriteSystem</c> uses.
+/// Rendered from the PLAYER's eye with FOV on, then cropped to a <see cref="PhotographyConstants.PhotoSizePixels"/>-square around the target, so the camera sees exactly what the player sees (walls occlude, glass shows through) and never ends up "inside" a wall the way an eye at the subject would.
+/// Flash captures spawn a client-only point light at the target just before <c>Render()</c> and delete it right after; it lands this frame because the light-tree query flushes pending inserts before rendering and <c>Render()</c> is synchronous.
+/// </summary>
+public sealed class PhotographyCaptureControl : Control, IDisposable
+{
+    private const int Crop = PhotographyConstants.PhotoSizePixels;
+    private const int Tile = PhotographyConstants.PixelsPerTile;
+
+    // Render-square sizing. The player sits at the render centre and FOV coverage scales
+    // with the viewport size (maxDist = size / 32 tiles), so the square must reach from
+    // the player out to the target plus a margin for the crop. Sized per shot (bucketed
+    // to a few sizes so the viewport isn't rebuilt every capture) to keep close shots
+    // cheap and FOV crisp, capped at what PhotoMaxRange needs.
+    private const int SizeStep = 256;
+    private static readonly int MaxRender =
+        RoundUp(((int) PhotographyConstants.PhotoMaxRange + 3) * 2 * Tile, SizeStep);
+
+    [Dependency] private IEntityManager _entMan = default!;
+    [Dependency] private IEyeManager _eyeManager = default!;
+
+    private readonly IClyde _clyde;
+    private readonly Action<int, Image<Rgba32>> _onCaptured;
+
+    private readonly Queue<(int CaptureId, MapCoordinates Target, bool Flash)> _queue = new();
+
+    // Reused across captures; created lazily on the render thread.
+    private IClydeViewport? _viewport;
+    private readonly FixedEye _eye = new();
+    private bool _disposed;
+
+    public PhotographyCaptureControl(IClyde clyde, Action<int, Image<Rgba32>> onCaptured)
+    {
+        IoCManager.InjectDependencies(this);
+        _clyde = clyde;
+        _onCaptured = onCaptured;
+        // Render with FOV so the photo occludes exactly like vision does: walls and closed
+        // doors block, transparent glass / open doors don't. Zoom 1 keeps the photo at a
+        // fixed 32 px/tile regardless of the player's own zoom.
+        _eye.DrawFov = true;
+        _eye.Zoom = Vector2.One;
+    }
+
+    public void Enqueue(int captureId, MapCoordinates target, bool flash)
+    {
+        _queue.Enqueue((captureId, target, flash));
+    }
+
+    protected override void Draw(DrawingHandleScreen handle)
+    {
+        base.Draw(handle);
+
+        while (_queue.TryDequeue(out var job))
+        {
+            // Shoot from the player's own eye, so the photo matches their view exactly.
+            var playerEye = _eyeManager.CurrentEye;
+            var playerPos = playerEye.Position;
+            if (playerPos.MapId == MapId.Nullspace || playerPos.MapId != job.Target.MapId)
+                continue;
+
+            var renderSize = RenderSizeFor(playerPos.Position, job.Target.Position);
+            if (_viewport == null || _viewport.Size.X != renderSize)
+            {
+                _viewport?.Dispose();
+                _viewport = _clyde.CreateViewport(new Vector2i(renderSize, renderSize), name: "photo-capture");
+            }
+
+            _eye.Position = playerPos;
+            _eye.Rotation = playerEye.Rotation;
+            _viewport.Eye = _eye;
+
+            // Strip the hover outline for this frame so the entity you're aiming at isn't
+            // baked into the photo with a selection highlight; re-applied next FrameUpdate.
+            // Restore the PRIOR value, not a hardcoded true, so we don't clobber another
+            // system (e.g. drag-drop) that's currently holding the outline disabled.
+            var outline = _entMan.System<InteractionOutlineSystem>();
+            var outlineWasEnabled = outline.Enabled;
+            outline.SetEnabled(false);
+
+            // Client-only flash light at the subject, alive only for this render. try/finally
+            // so a throw during Render can't leak the light (or the outline) permanently.
+            var light = job.Flash ? SpawnFlashLight(job.Target) : (EntityUid?) null;
+            try
+            {
+                _viewport.Render();
+            }
+            finally
+            {
+                if (light is { } lightUid)
+                    _entMan.DeleteEntity(lightUid);
+                outline.SetEnabled(outlineWasEnabled);
+            }
+
+            // The engine's CopyPixelsToMemory subRegion only clamps size (it always reads
+            // from the corner), so read the whole render and crop the target window in CPU.
+            var pixel = _viewport.WorldToLocal(job.Target.Position);
+            var captureId = job.CaptureId;
+            _viewport.RenderTarget.CopyPixelsToMemory<Rgba32>(image =>
+            {
+                // Dispose the (viewport-sized) source image the engine hands us either way;
+                // skip the submit if we've been torn down since the readback was queued.
+                using (image)
+                {
+                    if (_disposed)
+                        return;
+
+                    using var cropped = CropAround(image, pixel);
+                    _onCaptured(captureId, cropped);
+                }
+            });
+        }
+    }
+
+    // Big enough to hold the player (centre) and the target plus a crop margin, bucketed.
+    private static int RenderSizeFor(Vector2 player, Vector2 target)
+    {
+        var distTiles = (target - player).Length();
+        var neededPx = ((int) MathF.Ceiling(distTiles) + 3) * 2 * Tile;
+        return Math.Clamp(RoundUp(neededPx, SizeStep), SizeStep, MaxRender);
+    }
+
+    // Copy the Crop-sized window centred on <paramref name="pixel"/> out of the full
+    // render, clamped so an edge target still yields a full frame the codec can pack.
+    private static Image<Rgba32> CropAround(Image<Rgba32> src, Vector2 pixel)
+    {
+        var origin = CropOrigin(pixel, src.Width, src.Height);
+
+        var dst = new Image<Rgba32>(Crop, Crop);
+        var s = src.GetPixelSpan();
+        var d = dst.GetPixelSpan();
+        for (var row = 0; row < Crop; row++)
+        {
+            var srcRow = (origin.Y + row) * src.Width + origin.X;
+            s.Slice(srcRow, Crop).CopyTo(d.Slice(row * Crop, Crop));
+        }
+
+        return dst;
+    }
+
+    /// <summary>Top-left origin of the Crop-sized window centred on <paramref name="pixel"/>, clamped to stay fully inside a <paramref name="width"/> x <paramref name="height"/> image (never negative). Pure geometry - split out so it can be unit-tested without a render.</summary>
+    public static Vector2i CropOrigin(Vector2 pixel, int width, int height)
+    {
+        const int half = Crop / 2;
+        var x0 = Math.Clamp((int) MathF.Round(pixel.X) - half, 0, Math.Max(0, width - Crop));
+        var y0 = Math.Clamp((int) MathF.Round(pixel.Y) - half, 0, Math.Max(0, height - Crop));
+        return new Vector2i(x0, y0);
+    }
+
+    private static int RoundUp(int value, int step)
+    {
+        return (value + step - 1) / step * step;
+    }
+
+    private EntityUid SpawnFlashLight(MapCoordinates coords)
+    {
+        var light = _entMan.Spawn(null, coords);
+        PhotoFlash.Configure(_entMan.System<SharedPointLightSystem>(), light);
+        return light;
+    }
+
+    public void Dispose()
+    {
+        _disposed = true;
+        _queue.Clear();
+        _viewport?.Dispose();
+        _viewport = null;
+    }
+}

--- a/Content.Client/_Polonium/Photography/PhotographyCaptureControl.cs
+++ b/Content.Client/_Polonium/Photography/PhotographyCaptureControl.cs
@@ -20,7 +20,7 @@ namespace Content.Client._Polonium.Photography;
 /// Rendered from the PLAYER's eye with FOV on, then cropped to a <see cref="PhotographyConstants.PhotoSizePixels"/>-square around the target, so the camera sees exactly what the player sees (walls occlude, glass shows through) and never ends up "inside" a wall the way an eye at the subject would.
 /// Flash captures spawn a client-only point light at the target just before <c>Render()</c> and delete it right after; it lands this frame because the light-tree query flushes pending inserts before rendering and <c>Render()</c> is synchronous.
 /// </summary>
-public sealed class PhotographyCaptureControl : Control, IDisposable
+public sealed partial class PhotographyCaptureControl : Control, IDisposable
 {
     private const int Crop = PhotographyConstants.PhotoSizePixels;
     private const int Tile = PhotographyConstants.PixelsPerTile;
@@ -176,7 +176,7 @@ public sealed class PhotographyCaptureControl : Control, IDisposable
         return light;
     }
 
-    public void Dispose()
+    public new void Dispose()
     {
         _disposed = true;
         _queue.Clear();

--- a/Content.Client/_Polonium/Photography/PoloniumPhotographySystem.cs
+++ b/Content.Client/_Polonium/Photography/PoloniumPhotographySystem.cs
@@ -1,0 +1,59 @@
+using Content.Client.Items;
+using Content.Shared._Polonium.Photography;
+using Robust.Client.Graphics;
+using Robust.Client.UserInterface;
+using Robust.Shared.Map;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Content.Client._Polonium.Photography;
+
+/// <summary>Client half: on a server capture request, hands the target to the capture control, which renders the player's view, crops around the target, grades + packs to RGB565, and sends it up.</summary>
+public sealed class PoloniumPhotographySystem : SharedPoloniumPhotographySystem
+{
+    [Dependency] private IClyde _clyde = default!;
+    [Dependency] private IUserInterfaceManager _ui = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
+
+    private PhotographyCaptureControl _control = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _control = new PhotographyCaptureControl(_clyde, PackAndSubmit);
+        _ui.RootControl.AddChild(_control);
+
+        SubscribeNetworkEvent<RequestPhotoCaptureEvent>(OnCaptureRequested);
+
+        Subs.ItemStatus<PoloniumCameraComponent>(ent => new CameraStatusControl(ent.Owner, EntityManager));
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+
+        _ui.RootControl.RemoveChild(_control);
+        _control.Dispose();
+    }
+
+    private void OnCaptureRequested(RequestPhotoCaptureEvent ev)
+    {
+        var entCoords = GetCoordinates(ev.Coordinates);
+        if (!entCoords.IsValid(EntityManager))
+            return;
+
+        var mapCoords = _transform.ToMapCoordinates(entCoords);
+        if (mapCoords.MapId == MapId.Nullspace)
+            return;
+
+        _control.Enqueue(ev.CaptureId, mapCoords, ev.Flash);
+    }
+
+    /// <summary>Pack the read-back pixels to RGB565 and send them up. Runs inside the capture control's Draw (GPU thread) via the read-back callback.</summary>
+    private void PackAndSubmit(int captureId, Image<Rgba32> image)
+    {
+        var packed = PhotoCodec.ToRgb565(image);
+        RaiseNetworkEvent(new SubmitPhotoEvent(captureId, packed));
+    }
+}

--- a/Content.Client/_Polonium/Photography/PoloniumPhotographySystem.cs
+++ b/Content.Client/_Polonium/Photography/PoloniumPhotographySystem.cs
@@ -9,7 +9,7 @@ using SixLabors.ImageSharp.PixelFormats;
 namespace Content.Client._Polonium.Photography;
 
 /// <summary>Client half: on a server capture request, hands the target to the capture control, which renders the player's view, crops around the target, grades + packs to RGB565, and sends it up.</summary>
-public sealed class PoloniumPhotographySystem : SharedPoloniumPhotographySystem
+public sealed partial class PoloniumPhotographySystem : SharedPoloniumPhotographySystem
 {
     [Dependency] private IClyde _clyde = default!;
     [Dependency] private IUserInterfaceManager _ui = default!;

--- a/Content.IntegrationTests/Tests/_Polonium/Photography/PhotoCodecTest.cs
+++ b/Content.IntegrationTests/Tests/_Polonium/Photography/PhotoCodecTest.cs
@@ -1,0 +1,55 @@
+using Content.Client._Polonium.Photography;
+using Content.Shared._Polonium.Photography;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Content.IntegrationTests.Tests._Polonium.Photography;
+
+/// <summary>
+/// Guards the wire-format invariant the security model rests on: a captured photo is ALWAYS
+/// exactly <see cref="PhotographyConstants.PhotoByteLength"/> bytes of RGB565, so the server
+/// validates by length and never runs an image decoder.
+/// </summary>
+[TestOf(typeof(PhotoCodec))]
+public sealed class PhotoCodecTest
+{
+    private const int Size = PhotographyConstants.PhotoSizePixels;
+
+    [Test]
+    public void PackedIsAlwaysFixedLength()
+    {
+        using var img = new Image<Rgba32>(Size, Size, new Rgba32(123, 45, 67, 255));
+        Assert.That(PhotoCodec.ToRgb565(img), Has.Length.EqualTo(PhotographyConstants.PhotoByteLength));
+    }
+
+    [Test]
+    public void UnpackYieldsFullPixelCount()
+    {
+        var blob = new byte[PhotographyConstants.PhotoByteLength];
+        Assert.That(PhotoCodec.ToPixels(blob), Has.Length.EqualTo(PhotographyConstants.PhotoPixelCount));
+    }
+
+    /// <summary>
+    /// The RGB565 endpoints decode to full-scale channels (big-endian on the wire).
+    /// </summary>
+    [Test]
+    public void EndpointsDecodeToFullScale()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(FirstPixel(0xF8, 0x00), Is.EqualTo(new Rgba32(255, 0, 0, 255)), "0xF800 = pure red.");
+            Assert.That(FirstPixel(0x07, 0xE0), Is.EqualTo(new Rgba32(0, 255, 0, 255)), "0x07E0 = pure green.");
+            Assert.That(FirstPixel(0x00, 0x1F), Is.EqualTo(new Rgba32(0, 0, 255, 255)), "0x001F = pure blue.");
+            Assert.That(FirstPixel(0xFF, 0xFF), Is.EqualTo(new Rgba32(255, 255, 255, 255)), "0xFFFF = white.");
+            Assert.That(FirstPixel(0x00, 0x00), Is.EqualTo(new Rgba32(0, 0, 0, 255)), "0x0000 = black.");
+        });
+    }
+
+    private static Rgba32 FirstPixel(byte hi, byte lo)
+    {
+        var blob = new byte[PhotographyConstants.PhotoByteLength];
+        blob[0] = hi;
+        blob[1] = lo;
+        return PhotoCodec.ToPixels(blob)[0];
+    }
+}

--- a/Content.IntegrationTests/Tests/_Polonium/Photography/PhotoCropTest.cs
+++ b/Content.IntegrationTests/Tests/_Polonium/Photography/PhotoCropTest.cs
@@ -1,0 +1,45 @@
+using System.Numerics;
+using Content.Client._Polonium.Photography;
+using Content.Shared._Polonium.Photography;
+using Robust.Shared.Maths;
+
+namespace Content.IntegrationTests.Tests._Polonium.Photography;
+
+/// <summary>
+/// Covers the crop-window geometry that decides where a photo is cut out of the full render.
+/// It's the one geometry-sensitive piece of the render path integration tests can't reach
+/// (Draw never runs headless), so a clamp regression here would slip through as an
+/// out-of-bounds read.
+/// </summary>
+[TestOf(typeof(PhotographyCaptureControl))]
+public sealed class PhotoCropTest
+{
+    private const int Crop = PhotographyConstants.PhotoSizePixels; // 128
+    private const int Half = Crop / 2;
+
+    [Test]
+    public void CentredTargetCentresTheWindow()
+    {
+        var origin = PhotographyCaptureControl.CropOrigin(new Vector2(256, 256), 512, 512);
+        Assert.That(origin, Is.EqualTo(new Vector2i(256 - Half, 256 - Half)));
+    }
+
+    [Test]
+    public void EdgeTargetsClampInsideTheImage()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(PhotographyCaptureControl.CropOrigin(new Vector2(0, 0), 512, 512),
+                Is.EqualTo(Vector2i.Zero));
+            Assert.That(PhotographyCaptureControl.CropOrigin(new Vector2(512, 512), 512, 512),
+                Is.EqualTo(new Vector2i(512 - Crop, 512 - Crop)));
+        });
+    }
+
+    [Test]
+    public void ImageSmallerThanCropNeverGoesNegative()
+    {
+        var origin = PhotographyCaptureControl.CropOrigin(new Vector2(10, 10), 100, 100);
+        Assert.That(origin, Is.EqualTo(Vector2i.Zero));
+    }
+}

--- a/Content.IntegrationTests/Tests/_Polonium/Photography/PhotoGradeTest.cs
+++ b/Content.IntegrationTests/Tests/_Polonium/Photography/PhotoGradeTest.cs
@@ -1,0 +1,46 @@
+using Content.Client._Polonium.Photography;
+using Content.Shared._Polonium.Photography;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Content.IntegrationTests.Tests._Polonium.Photography;
+
+/// <summary>
+/// Checks the analog film grade does its four visible things - warm tint, lifted blacks,
+/// vignette, determinism - so a look regression is caught without a live client to eyeball.
+/// </summary>
+[TestOf(typeof(PhotoGrade))]
+public sealed class PhotoGradeTest
+{
+    private const int Size = PhotographyConstants.PhotoSizePixels;
+    private const int Center = Size / 2;
+
+    [Test]
+    public void WarmsNeutralTonesTowardRed()
+    {
+        var graded = PhotoGrade.Apply(new Rgba32(128, 128, 128, 255), Center, Center);
+        Assert.That(graded.R, Is.GreaterThan(graded.B), "A warm grade pushes red above blue on a neutral input.");
+    }
+
+    [Test]
+    public void LiftsBlacks()
+    {
+        var graded = PhotoGrade.Apply(new Rgba32(0, 0, 0, 255), Center, Center);
+        Assert.That(graded.R, Is.GreaterThan(0), "Faded film never reaches pure black.");
+    }
+
+    [Test]
+    public void VignetteDarkensCorners()
+    {
+        var center = PhotoGrade.Apply(new Rgba32(255, 255, 255, 255), Center, Center);
+        var corner = PhotoGrade.Apply(new Rgba32(255, 255, 255, 255), 0, 0);
+        Assert.That(corner.R, Is.LessThan(center.R), "Corners are darker than the center.");
+    }
+
+    [Test]
+    public void IsDeterministic()
+    {
+        var a = PhotoGrade.Apply(new Rgba32(60, 120, 200, 255), 40, 90);
+        var b = PhotoGrade.Apply(new Rgba32(60, 120, 200, 255), 40, 90);
+        Assert.That(a, Is.EqualTo(b), "The same pixel grades identically every time (no RNG).");
+    }
+}

--- a/Content.IntegrationTests/Tests/_Polonium/Photography/PhotographSubjectNameTest.cs
+++ b/Content.IntegrationTests/Tests/_Polonium/Photography/PhotographSubjectNameTest.cs
@@ -1,0 +1,99 @@
+using System.Numerics;
+using Content.IntegrationTests.Tests.Interaction;
+using Content.Server._Polonium.Photography;
+using Content.Server.Examine;
+using Content.Shared._Polonium.Photography;
+using Content.Shared.IdentityManagement;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests._Polonium.Photography;
+
+/// <summary>
+/// Covers the auto-describe path: on capture the server freezes the clicked subject's name
+/// (<see cref="Identity.Name"/> - identity-aware for humanoids, plain entity name otherwise)
+/// and surfaces it on examine. A bare-tile shot has no subject and must stay silent. We
+/// answer the capture token by hand with a correctly-sized payload so the server
+/// store/examine path runs headlessly.
+/// </summary>
+[TestOf(typeof(PoloniumPhotographySystem))]
+public sealed class PhotographSubjectNameTest : InteractionTest
+{
+    private const string CameraProto = "PoloniumCamera";
+    private const string TargetProto = "Wrench";
+
+    [Test]
+    public async Task ExamineNamesTheClickedSubject()
+    {
+        var sys = SEntMan.System<PoloniumPhotographySystem>();
+
+        await SpawnTarget(TargetProto);
+        await PlaceInHands(CameraProto);
+
+        // Shoot the target: issues capture token #1 with the subject name frozen.
+        await Interact();
+
+        string expected = default!;
+        await Server.WaitPost(() => expected = Identity.Name(STarget!.Value, SEntMan));
+
+        // Answer token id 1 (deterministic first shot of a fresh round) with a valid-length,
+        // content-irrelevant payload; no GPU render. StoredCount below fails loudly if wrong.
+        await SubmitPhoto(1);
+
+        Assert.That(sys.StoredCount, Is.EqualTo(1), "The hand-submitted photo must have been stored.");
+
+        var text = await ExaminePhotograph();
+        Assert.That(text, Does.Contain(expected),
+            "Examining the photograph must name its clicked subject.");
+    }
+
+    [Test]
+    public async Task BareTileShotHasNoSubjectLine()
+    {
+        var sys = SEntMan.System<PoloniumPhotographySystem>();
+
+        await PlaceInHands(CameraProto);
+
+        // Click an empty tile a step away (in range, clear LOS): a subjectless capture.
+        var tile = MapData.GridCoords.Offset(new Vector2(1f, 0f));
+        await Interact(null, tile);
+
+        await SubmitPhoto(1);
+        Assert.That(sys.StoredCount, Is.EqualTo(1), "The hand-submitted photo must have been stored.");
+
+        var text = await ExaminePhotograph();
+        Assert.That(text, Does.Not.Contain("A photograph of"),
+            "A photograph of nothing must not carry a subject line.");
+    }
+
+    /// <summary>Send a <see cref="SubmitPhotoEvent"/> from the client session, bypassing
+    /// the client render, and let it land server-side.</summary>
+    private async Task SubmitPhoto(int captureId)
+    {
+        var blob = new byte[PhotographyConstants.PhotoByteLength];
+        await Client.WaitPost(() =>
+            CEntMan.EntityNetManager!.SendSystemNetworkMessage(new SubmitPhotoEvent(captureId, blob)));
+        await RunTicks(5);
+    }
+
+    /// <summary>Examine text of the single photograph spawned this round, as the player.</summary>
+    private async Task<string> ExaminePhotograph()
+    {
+        var text = string.Empty;
+        await Server.WaitPost(() =>
+        {
+            var photo = EntityUid.Invalid;
+            var query = SEntMan.EntityQueryEnumerator<PoloniumPhotographComponent>();
+            while (query.MoveNext(out var uid, out _))
+            {
+                photo = uid;
+                break;
+            }
+
+            Assert.That(photo, Is.Not.EqualTo(EntityUid.Invalid), "A photograph must have spawned.");
+            text = SEntMan.System<ExamineSystem>()
+                .GetExamineText(photo, SEntMan.GetEntity(Player))
+                .ToString();
+        });
+        return text;
+    }
+}

--- a/Content.IntegrationTests/Tests/_Polonium/Photography/PhotographyTriggerTest.cs
+++ b/Content.IntegrationTests/Tests/_Polonium/Photography/PhotographyTriggerTest.cs
@@ -1,0 +1,79 @@
+using System.Numerics;
+using Content.IntegrationTests.Tests.Interaction;
+using Content.Server._Polonium.Photography;
+using Content.Shared._Polonium.Photography;
+using Content.Shared.Item.ItemToggle;
+
+namespace Content.IntegrationTests.Tests._Polonium.Photography;
+
+/// <summary>
+/// Exercises the server half end-to-end (minus the client render): left-click with the
+/// camera must reach our trigger and issue exactly one capture token to the shooter's
+/// session, flash on or off. This is the wiring (camera prototype, interaction, our system,
+/// session-targeted token) that can't be seen by reading the code. The flash-on case also
+/// drives the world-burst path (spawn light + area blind) so a crash there is caught.
+/// </summary>
+[TestOf(typeof(PoloniumPhotographySystem))]
+public sealed class PhotographyTriggerTest : InteractionTest
+{
+    private const string CameraProto = "PoloniumCamera";
+    private const string TargetProto = "Wrench";
+
+    [Test]
+    public async Task ShutterIssuesOneCaptureToken()
+    {
+        var sys = SEntMan.System<PoloniumPhotographySystem>();
+
+        await SpawnTarget(TargetProto);
+        await PlaceInHands(CameraProto);
+
+        int before = default;
+        await Server.WaitPost(() => before = sys.PendingCount);
+        Assert.That(before, Is.Zero);
+
+        // Left-click / ranged-interact the target with the camera in hand -> capture token.
+        await Interact();
+
+        int after = default;
+        await Server.WaitPost(() => after = sys.PendingCount);
+        Assert.That(after, Is.EqualTo(1), "Firing the shutter must issue exactly one capture token.");
+    }
+
+    [Test]
+    public async Task FlashOnStillCapturesAndFiresBurst()
+    {
+        var sys = SEntMan.System<PoloniumPhotographySystem>();
+        var toggle = SEntMan.System<ItemToggleSystem>();
+
+        await SpawnTarget(TargetProto);
+        var cam = await PlaceInHands(CameraProto);
+
+        // Arm the flash, then shoot. This runs the world-burst path (light + area blind);
+        // the assertion is that a token is still issued and nothing threw.
+        await Server.WaitPost(() => toggle.TrySetActive(ToServer(cam), true));
+        await RunTicks(1);
+
+        await Interact();
+
+        int after = default;
+        await Server.WaitPost(() => after = sys.PendingCount);
+        Assert.That(after, Is.EqualTo(1), "A flash-on shot still issues exactly one capture token.");
+    }
+
+    [Test]
+    public async Task OutOfRangeTargetTakesNoPhoto()
+    {
+        var sys = SEntMan.System<PoloniumPhotographySystem>();
+
+        await PlaceInHands(CameraProto);
+
+        // A click far beyond PhotoMaxRange fails the line-of-sight/range gate, so no
+        // capture token is issued. (Wall occlusion at closer range is a live-client check.)
+        var far = MapData.GridCoords.Offset(new Vector2(PhotographyConstants.PhotoMaxRange + 5f, 0.5f));
+        await Interact(null, far);
+
+        int after = default;
+        await Server.WaitPost(() => after = sys.PendingCount);
+        Assert.That(after, Is.Zero, "A target beyond view range yields no photo.");
+    }
+}

--- a/Content.IntegrationTests/Tests/_Polonium/Photography/PhotographyTriggerTest.cs
+++ b/Content.IntegrationTests/Tests/_Polonium/Photography/PhotographyTriggerTest.cs
@@ -50,7 +50,9 @@ public sealed class PhotographyTriggerTest : InteractionTest
 
         // Arm the flash, then shoot. This runs the world-burst path (light + area blind);
         // the assertion is that a token is still issued and nothing threw.
-        await Server.WaitPost(() => toggle.TrySetActive(ToServer(cam), true));
+        var armed = false;
+        await Server.WaitPost(() => armed = toggle.TrySetActive(ToServer(cam), true));
+        Assert.That(armed, Is.True, "The flash must arm before the flash-on shot, or this degrades to a flash-off test.");
         await RunTicks(1);
 
         await Interact();

--- a/Content.Server/Administration/Logs/AdminLogManager.cs
+++ b/Content.Server/Administration/Logs/AdminLogManager.cs
@@ -512,6 +512,10 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
 
             if (CreateCordLinks(coords, out var cordLinks))
                 _chat.SendAdminAlertNoFormatOrEscape(cordLinks);
+
+            // POLONIUM CHANGE: clickable "open this photo" link (impl in AdminLogManager.PhotoLinks.cs).
+            if (CreatePhotoLinks(GetPhotoIds(handler.Values), out var photoLinks))
+                _chat.SendAdminAlertNoFormatOrEscape(photoLinks);
         }
     }
 

--- a/Content.Server/_Polonium/Photography/AdminLogManager.PhotoLinks.cs
+++ b/Content.Server/_Polonium/Photography/AdminLogManager.PhotoLinks.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using Content.Shared._Polonium.Photography;
+
+namespace Content.Server.Administration.Logs;
+
+/// <summary>
+/// POLONIUM CHANGE!
+/// Photography half of <see cref="AdminLogManager"/>: turns a <see cref="LoggablePhotoId"/> carried
+/// in a capture log's structured values into a clickable admin-chat link that opens the photo viewer
+/// focused on it. Kept in a partial file under _Polonium so the only edit to the upstream file is the
+/// one call site in <c>DoAdminAlerts</c>. Mirrors the shape of <c>GetCoordinates</c>/<c>CreateCordLinks</c>.
+/// </summary>
+public sealed partial class AdminLogManager
+{
+    /// <summary>Pulls captured-photo ids out of a log's structured values (by type, like GetCoordinates).</summary>
+    private List<int> GetPhotoIds(Dictionary<string, object?> values)
+    {
+        var ids = new List<int>();
+        foreach (var value in values.Values)
+        {
+            if (value is LoggablePhotoId photo)
+                ids.Add(photo.Id);
+        }
+
+        return ids;
+    }
+
+    /// <summary>Builds cmdlinks that open the admin photo viewer focused on each id (mirrors CreateTpLinks).</summary>
+    private bool CreatePhotoLinks(List<int> photoIds, out string outString)
+    {
+        outString = string.Empty;
+
+        if (photoIds.Count == 0)
+            return false;
+
+        outString = Loc.GetString("admin-alert-photo-header");
+
+        for (var i = 0; i < photoIds.Count; i++)
+        {
+            outString += $"[cmdlink=\"{photoIds[i]}\" command=\"photos {photoIds[i]}\"/]";
+
+            if (i < photoIds.Count - 1)
+                outString += ", ";
+        }
+
+        return true;
+    }
+}

--- a/Content.Server/_Polonium/Photography/AdminPhotoEui.cs
+++ b/Content.Server/_Polonium/Photography/AdminPhotoEui.cs
@@ -22,10 +22,11 @@ public sealed partial class AdminPhotoEui : BaseEui
 
     private int? _selected;
 
-    public AdminPhotoEui()
+    public AdminPhotoEui(int? focus = null)
     {
         IoCManager.InjectDependencies(this);
         _photography = _entMan.System<PoloniumPhotographySystem>();
+        _selected = focus;
     }
 
     public override void Opened()

--- a/Content.Server/_Polonium/Photography/AdminPhotoEui.cs
+++ b/Content.Server/_Polonium/Photography/AdminPhotoEui.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using Content.Server.Administration.Logs;
+using Content.Server.Administration.Managers;
+using Content.Server.EUI;
+using Content.Shared._Polonium.Photography;
+using Content.Shared.Administration;
+using Content.Shared.Database;
+using Content.Shared.Eui;
+using JetBrains.Annotations;
+
+namespace Content.Server._Polonium.Photography;
+
+/// <summary>Server half of the admin photo viewer.</summary>
+[UsedImplicitly]
+public sealed class AdminPhotoEui : BaseEui
+{
+    [Dependency] private readonly IEntityManager _entMan = default!;
+    [Dependency] private readonly IAdminManager _admin = default!;
+    [Dependency] private readonly IAdminLogManager _adminLog = default!;
+
+    private readonly PoloniumPhotographySystem _photography;
+
+    private int? _selected;
+
+    public AdminPhotoEui()
+    {
+        IoCManager.InjectDependencies(this);
+        _photography = _entMan.System<PoloniumPhotographySystem>();
+    }
+
+    public override void Opened()
+    {
+        base.Opened();
+        StateDirty();
+    }
+
+    public override EuiStateBase GetNewState()
+    {
+        var photos = new List<AdminPhotoEntry>();
+        foreach (var (id, shooter, subject) in _photography.GetStoredPhotos())
+        {
+            photos.Add(new AdminPhotoEntry { Id = id, Shooter = shooter, Subject = subject });
+        }
+
+        var data = _selected is { } sel ? _photography.GetStoredPhoto(sel) : null;
+        if (data == null)
+            _selected = null;
+
+        return new AdminPhotoEuiState(photos, _selected, data);
+    }
+
+    public override void HandleMessage(EuiMessageBase msg)
+    {
+        base.HandleMessage(msg);
+
+        if (!_admin.HasAdminFlag(Player, AdminFlags.Admin))
+            return;
+
+        switch (msg)
+        {
+            case AdminPhotoSelectMessage select:
+                _selected = select.PhotoId;
+                StateDirty();
+                break;
+
+            case AdminPhotoDeleteMessage delete:
+                if (_photography.DeleteStoredPhoto(delete.PhotoId))
+                {
+                    _adminLog.Add(LogType.Action, LogImpact.High,
+                        $"{Player.Name} deleted stored photo id {delete.PhotoId}");
+                }
+
+                if (_selected == delete.PhotoId)
+                    _selected = null;
+                StateDirty();
+                break;
+        }
+    }
+}

--- a/Content.Server/_Polonium/Photography/AdminPhotoEui.cs
+++ b/Content.Server/_Polonium/Photography/AdminPhotoEui.cs
@@ -12,11 +12,11 @@ namespace Content.Server._Polonium.Photography;
 
 /// <summary>Server half of the admin photo viewer.</summary>
 [UsedImplicitly]
-public sealed class AdminPhotoEui : BaseEui
+public sealed partial class AdminPhotoEui : BaseEui
 {
-    [Dependency] private readonly IEntityManager _entMan = default!;
-    [Dependency] private readonly IAdminManager _admin = default!;
-    [Dependency] private readonly IAdminLogManager _adminLog = default!;
+    [Dependency] private IEntityManager _entMan = default!;
+    [Dependency] private IAdminManager _admin = default!;
+    [Dependency] private IAdminLogManager _adminLog = default!;
 
     private readonly PoloniumPhotographySystem _photography;
 

--- a/Content.Server/_Polonium/Photography/PhotosCommand.cs
+++ b/Content.Server/_Polonium/Photography/PhotosCommand.cs
@@ -13,7 +13,7 @@ public sealed partial class PhotosCommand : IConsoleCommand
 
     public string Command => "photos";
     public string Description => "Open the admin viewer for photos captured with cameras this round.";
-    public string Help => "photos";
+    public string Help => "photos [id] - pass an id to open focused on that photo (falls back to the list if it's gone).";
 
     public void Execute(IConsoleShell shell, string argStr, string[] args)
     {
@@ -23,6 +23,7 @@ public sealed partial class PhotosCommand : IConsoleCommand
             return;
         }
 
-        _eui.OpenEui(new AdminPhotoEui(), player);
+        int? focus = args.Length > 0 && int.TryParse(args[0], out var id) ? id : null;
+        _eui.OpenEui(new AdminPhotoEui(focus), player);
     }
 }

--- a/Content.Server/_Polonium/Photography/PhotosCommand.cs
+++ b/Content.Server/_Polonium/Photography/PhotosCommand.cs
@@ -1,0 +1,28 @@
+using Content.Server.Administration;
+using Content.Server.EUI;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Server._Polonium.Photography;
+
+/// <summary>Opens the admin photo viewer to review and delete this round's captured photos.</summary>
+[AdminCommand(AdminFlags.Admin)]
+public sealed class PhotosCommand : IConsoleCommand
+{
+    [Dependency] private readonly EuiManager _eui = default!;
+
+    public string Command => "photos";
+    public string Description => "Open the admin viewer for photos captured with cameras this round.";
+    public string Help => "photos";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (shell.Player is not { } player)
+        {
+            shell.WriteError(Loc.GetString("shell-cannot-run-command-from-server"));
+            return;
+        }
+
+        _eui.OpenEui(new AdminPhotoEui(), player);
+    }
+}

--- a/Content.Server/_Polonium/Photography/PhotosCommand.cs
+++ b/Content.Server/_Polonium/Photography/PhotosCommand.cs
@@ -7,9 +7,9 @@ namespace Content.Server._Polonium.Photography;
 
 /// <summary>Opens the admin photo viewer to review and delete this round's captured photos.</summary>
 [AdminCommand(AdminFlags.Admin)]
-public sealed class PhotosCommand : IConsoleCommand
+public sealed partial class PhotosCommand : IConsoleCommand
 {
-    [Dependency] private readonly EuiManager _eui = default!;
+    [Dependency] private EuiManager _eui = default!;
 
     public string Command => "photos";
     public string Description => "Open the admin viewer for photos captured with cameras this round.";

--- a/Content.Server/_Polonium/Photography/PoloniumPhotographySystem.cs
+++ b/Content.Server/_Polonium/Photography/PoloniumPhotographySystem.cs
@@ -150,8 +150,8 @@ public sealed partial class PoloniumPhotographySystem : SharedPoloniumPhotograph
             _photoNames[photoId] = name;
         _photoShooters[photoId] = pending.Session.Name;
 
-        _adminLog.Add(LogType.Action, LogImpact.High,
-            $"{ToPrettyString(pending.User):actor} took photo id {photoId} (subject: {pending.SubjectName ?? "none"})");
+        _adminLog.Add(LogType.Action, LogImpact.Extreme,
+            $"{pending.Session:player} took photo id {new LoggablePhotoId(photoId)} (subject: {pending.SubjectName ?? "none"})");
 
         var spawned = Spawn(pending.Photograph, pending.Coords);
         var photoComp = EnsureComp<PoloniumPhotographComponent>(spawned);

--- a/Content.Server/_Polonium/Photography/PoloniumPhotographySystem.cs
+++ b/Content.Server/_Polonium/Photography/PoloniumPhotographySystem.cs
@@ -1,0 +1,265 @@
+using System;
+using System.Collections.Generic;
+using Content.Server.Administration.Logs;
+using Content.Shared._Polonium.Photography;
+using Content.Shared.Database;
+using Content.Shared.Examine;
+using Content.Shared.Flash;
+using Content.Shared.GameTicking;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Item.ItemToggle;
+using Robust.Server.GameObjects;
+using Robust.Server.Player;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Enums;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Spawners;
+using Robust.Shared.Utility;
+
+namespace Content.Server._Polonium.Photography;
+
+/// <summary>
+/// Server half. Shutter press issues a one-shot capture token to the shooter's client. On
+/// answer, token and payload length are re-validated before bytes are stored (per-round, in
+/// memory) and a photograph entity carrying only the storage id is spawned. The blob streams
+/// to a single viewer via the BUI state, never an auto-networked field.
+/// </summary>
+public sealed class PoloniumPhotographySystem : SharedPoloniumPhotographySystem
+{
+    [Dependency] private UserInterfaceSystem _ui = default!;
+    [Dependency] private SharedHandsSystem _hands = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private SharedPointLightSystem _pointLight = default!;
+    [Dependency] private SharedFlashSystem _flash = default!;
+    [Dependency] private ItemToggleSystem _toggle = default!;
+    [Dependency] private SharedAudioSystem _audio = default!;
+    [Dependency] private IPlayerManager _playerManager = default!;
+    [Dependency] private IAdminLogManager _adminLog = default!;
+
+    private static readonly SoundSpecifier ShutterSound = new SoundPathSpecifier("/Audio/Misc/camera_snap.ogg");
+
+    private sealed record PendingCapture(ICommonSession Session, EntityUid User, EntityCoordinates Coords, EntProtoId Photograph, string? SubjectName);
+
+    // Per-round state, pruned incrementally: blobs freed when their photograph terminates,
+    // pending tokens when the shooter answers, fires again, or disconnects.
+    private readonly Dictionary<int, byte[]> _photos = new();
+    // Subject name frozen at click time (Identity name for humanoids, else entity name),
+    // freed with its blob. Absent = no nameable subject.
+    private readonly Dictionary<int, string> _photoNames = new();
+    private readonly Dictionary<int, string> _photoShooters = new();
+    private readonly Dictionary<int, PendingCapture> _pending = new();
+
+    private int _nextCaptureId = 1;
+    private int _nextPhotoId = 1;
+
+    public int PendingCount => _pending.Count;
+
+    public int StoredCount => _photos.Count;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeNetworkEvent<SubmitPhotoEvent>(OnSubmitPhoto);
+        SubscribeLocalEvent<PoloniumPhotographComponent, EntityTerminatingEvent>(OnPhotoTerminating);
+        SubscribeLocalEvent<PoloniumPhotographComponent, ExaminedEvent>(OnPhotoExamined);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnCleanup);
+
+        _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+
+        _playerManager.PlayerStatusChanged -= OnPlayerStatusChanged;
+    }
+
+    protected override bool StartCapture(Entity<PoloniumCameraComponent> camera, EntityUid user, EntityCoordinates targetCoords, EntityUid? target)
+    {
+        if (!TryComp<ActorComponent>(user, out var actor))
+            return false;
+
+        var coords = targetCoords;
+        var flash = _toggle.IsActivated(camera.Owner);
+
+        // Freeze the subject name now. Identity.Name gives the disguise-respecting identity
+        // for humanoids (viewer null = not see-through), else the plain entity name; a
+        // bare-tile click (no target) leaves the photo subjectless.
+        string? subjectName = null;
+        if (target is { } subject && !TerminatingOrDeleted(subject))
+            subjectName = Identity.Name(subject, EntityManager);
+
+        // One outstanding capture per session: drop any earlier unanswered token so
+        // _pending can't accumulate.
+        RemovePendingForSession(actor.PlayerSession);
+
+        var captureId = _nextCaptureId++;
+        _pending[captureId] = new PendingCapture(actor.PlayerSession, user, coords, camera.Comp.Photograph, subjectName);
+
+        _audio.PlayPvs(ShutterSound, camera.Owner);
+
+        if (flash)
+            FireFlash(user, coords);
+
+        RaiseNetworkEvent(new RequestPhotoCaptureEvent(captureId, GetNetCoordinates(coords), flash), actor.PlayerSession);
+        return true;
+    }
+
+    /// <summary>
+    /// World side of a flash shot: a short-lived point light everyone in PVS sees (matching
+    /// the client capture light's params) plus an area blind around that spot. The photo's
+    /// own lighting is done separately on the capturing client.
+    /// </summary>
+    private void FireFlash(EntityUid user, EntityCoordinates coords)
+    {
+        var mapCoords = _transform.ToMapCoordinates(coords);
+        if (mapCoords.MapId == MapId.Nullspace)
+            return;
+
+        var burst = Spawn(null, mapCoords);
+        PhotoFlash.Configure(_pointLight, burst);
+        EnsureComp<TimedDespawnComponent>(burst).Lifetime = PhotographyConstants.FlashBurstLifetime;
+
+        _flash.FlashArea(burst, user, PhotographyConstants.FlashBlindRange, TimeSpan.FromSeconds(4), displayPopup: true);
+    }
+
+    private void OnSubmitPhoto(SubmitPhotoEvent ev, EntitySessionEventArgs args)
+    {
+        // Token must match a pending capture that THIS session was authorized for.
+        if (!_pending.TryGetValue(ev.CaptureId, out var pending) || pending.Session != args.SenderSession)
+            return;
+
+        _pending.Remove(ev.CaptureId);
+
+        // Fixed-size, non-null payload only, rejected without decoding (a crafted null
+        // would otherwise NRE the handler).
+        if (ev.Data is not { } data || data.Length != PhotographyConstants.PhotoByteLength)
+            return;
+
+        if (!pending.Coords.IsValid(EntityManager))
+            return;
+
+        var photoId = _nextPhotoId++;
+        _photos[photoId] = data;
+        if (pending.SubjectName is { } name)
+            _photoNames[photoId] = name;
+        _photoShooters[photoId] = pending.Session.Name;
+
+        _adminLog.Add(LogType.Action, LogImpact.High,
+            $"{ToPrettyString(pending.User):actor} took photo id {photoId} (subject: {pending.SubjectName ?? "none"})");
+
+        var spawned = Spawn(pending.Photograph, pending.Coords);
+        var photoComp = EnsureComp<PoloniumPhotographComponent>(spawned);
+        photoComp.PhotoId = photoId;
+        Dirty(spawned, photoComp);
+
+        _ui.SetUiState(spawned, PhotoViewerUiKey.Key, new PhotoViewerBoundUserInterfaceState(data));
+
+        if (!TerminatingOrDeleted(pending.User))
+            _hands.PickupOrDrop(pending.User, spawned, dropNear: true);
+    }
+
+    private void OnPhotoTerminating(Entity<PoloniumPhotographComponent> ent, ref EntityTerminatingEvent args)
+    {
+        _photos.Remove(ent.Comp.PhotoId);
+        _photoNames.Remove(ent.Comp.PhotoId);
+        _photoShooters.Remove(ent.Comp.PhotoId);
+    }
+
+    /// <summary>Metadata for every photo stored this round, ordered by id.</summary>
+    public List<(int Id, string Shooter, string? Subject)> GetStoredPhotos()
+    {
+        var list = new List<(int, string, string?)>(_photos.Count);
+        foreach (var id in _photos.Keys)
+        {
+            var shooter = _photoShooters.GetValueOrDefault(id, "unknown");
+            var subject = _photoNames.GetValueOrDefault(id);
+            list.Add((id, shooter, subject));
+        }
+
+        list.Sort((a, b) => a.Item1.CompareTo(b.Item1));
+        return list;
+    }
+
+    /// <summary>The raw RGB565 blob for one stored photo, or null if it's gone.</summary>
+    public byte[]? GetStoredPhoto(int id) => _photos.GetValueOrDefault(id);
+
+    /// <summary>
+    /// Admin removal of an abusive photo: deletes the photograph entity carrying this id
+    /// (its terminating handler frees the blob), and clears the store directly for the rare
+    /// case where the blob outlived its entity. False if nothing matched.
+    /// </summary>
+    public bool DeleteStoredPhoto(int id)
+    {
+        var found = false;
+        var query = EntityQueryEnumerator<PoloniumPhotographComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (comp.PhotoId != id)
+                continue;
+            QueueDel(uid);
+            found = true;
+        }
+
+        if (_photos.Remove(id))
+        {
+            _photoNames.Remove(id);
+            _photoShooters.Remove(id);
+            found = true;
+        }
+
+        return found;
+    }
+
+    private void OnPhotoExamined(Entity<PoloniumPhotographComponent> ent, ref ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+
+        // Subjectless photos examine like any plain item.
+        if (!_photoNames.TryGetValue(ent.Comp.PhotoId, out var name))
+            return;
+
+        // Identity names are player-typed and may contain markup characters.
+        args.PushMarkup(Loc.GetString("photograph-examine-subject", ("name", FormattedMessage.EscapeText(name))));
+    }
+
+    private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs e)
+    {
+        if (e.NewStatus == SessionStatus.Disconnected)
+            RemovePendingForSession(e.Session);
+    }
+
+    private void RemovePendingForSession(ICommonSession session)
+    {
+        List<int>? stale = null;
+        foreach (var (id, pending) in _pending)
+        {
+            if (pending.Session != session)
+                continue;
+            stale ??= new List<int>();
+            stale.Add(id);
+        }
+
+        if (stale == null)
+            return;
+
+        foreach (var id in stale)
+            _pending.Remove(id);
+    }
+
+    private void OnCleanup(RoundRestartCleanupEvent ev)
+    {
+        _photos.Clear();
+        _photoNames.Clear();
+        _photoShooters.Clear();
+        _pending.Clear();
+        _nextCaptureId = 1;
+        _nextPhotoId = 1;
+    }
+}

--- a/Content.Server/_Polonium/Photography/PoloniumPhotographySystem.cs
+++ b/Content.Server/_Polonium/Photography/PoloniumPhotographySystem.cs
@@ -28,7 +28,7 @@ namespace Content.Server._Polonium.Photography;
 /// memory) and a photograph entity carrying only the storage id is spawned. The blob streams
 /// to a single viewer via the BUI state, never an auto-networked field.
 /// </summary>
-public sealed class PoloniumPhotographySystem : SharedPoloniumPhotographySystem
+public sealed partial class PoloniumPhotographySystem : SharedPoloniumPhotographySystem
 {
     [Dependency] private UserInterfaceSystem _ui = default!;
     [Dependency] private SharedHandsSystem _hands = default!;

--- a/Content.Shared/_Polonium/Photography/AdminPhotoEui.cs
+++ b/Content.Shared/_Polonium/Photography/AdminPhotoEui.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using Content.Shared.Eui;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Polonium.Photography;
+
+/// <summary>State for the admin photo viewer.</summary>
+[Serializable, NetSerializable]
+public sealed class AdminPhotoEuiState : EuiStateBase
+{
+    public readonly List<AdminPhotoEntry> Photos;
+    public readonly int? SelectedId;
+    public readonly byte[]? SelectedData;
+
+    public AdminPhotoEuiState(List<AdminPhotoEntry> photos, int? selectedId, byte[]? selectedData)
+    {
+        Photos = photos;
+        SelectedId = selectedId;
+        SelectedData = selectedData;
+    }
+}
+
+[Serializable, NetSerializable]
+public struct AdminPhotoEntry
+{
+    public int Id;
+    public string Shooter;
+    public string? Subject;
+}
+
+/// <summary>Admin asked to view a specific stored photo.</summary>
+[Serializable, NetSerializable]
+public sealed class AdminPhotoSelectMessage : EuiMessageBase
+{
+    public readonly int PhotoId;
+
+    public AdminPhotoSelectMessage(int photoId)
+    {
+        PhotoId = photoId;
+    }
+}
+
+/// <summary>Admin asked to delete a stored photo (and the photograph entity holding it).</summary>
+[Serializable, NetSerializable]
+public sealed class AdminPhotoDeleteMessage : EuiMessageBase
+{
+    public readonly int PhotoId;
+
+    public AdminPhotoDeleteMessage(int photoId)
+    {
+        PhotoId = photoId;
+    }
+}

--- a/Content.Shared/_Polonium/Photography/LoggablePhotoId.cs
+++ b/Content.Shared/_Polonium/Photography/LoggablePhotoId.cs
@@ -1,0 +1,12 @@
+namespace Content.Shared._Polonium.Photography;
+
+/// <summary>
+/// Wraps a captured-photo id in an admin log's structured <c>Values</c> so the photography
+/// half of <c>AdminLogManager</c> (see AdminLogManager.PhotoLinks.cs) can build a "jump to
+/// this photo" chat link - the same way <c>SerializablePlayer</c> drives tpto links. Extracted
+/// by type, not key. <see cref="ToString"/> returns the bare number so the log text reads naturally.
+/// </summary>
+public readonly record struct LoggablePhotoId(int Id)
+{
+    public override string ToString() => Id.ToString();
+}

--- a/Content.Shared/_Polonium/Photography/PhotoFlash.cs
+++ b/Content.Shared/_Polonium/Photography/PhotoFlash.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared._Polonium.Photography;
+
+/// <summary>Shared point-light setup for the flash, so server world burst and client capture light stay visually identical.</summary>
+public static class PhotoFlash
+{
+    public static void Configure(SharedPointLightSystem lights, EntityUid light)
+    {
+        lights.EnsureLight(light);
+        lights.SetRadius(light, PhotographyConstants.FlashRadius);
+        lights.SetEnergy(light, PhotographyConstants.FlashEnergy);
+        lights.SetColor(light, PhotographyConstants.FlashColor);
+        lights.SetEnabled(light, true);
+    }
+}

--- a/Content.Shared/_Polonium/Photography/PhotographyConstants.cs
+++ b/Content.Shared/_Polonium/Photography/PhotographyConstants.cs
@@ -1,0 +1,44 @@
+using Robust.Shared.Maths;
+
+namespace Content.Shared._Polonium.Photography;
+
+/// <summary>Fixed geometry of a captured photo, in one place because client (renders/bitpacks) and server (validates payload length) must agree exactly.</summary>
+public static class PhotographyConstants
+{
+    /// <summary>Region captured, in tiles, per side.</summary>
+    public const int TilesPerSide = 4;
+
+    /// <summary>Rendered pixels per tile. Matches <c>EyeManager.PixelsPerMeter</c>.</summary>
+    public const int PixelsPerTile = 32;
+
+    /// <summary>Width/height of the captured image in pixels (square).</summary>
+    public const int PhotoSizePixels = TilesPerSide * PixelsPerTile; // 128
+
+    /// <summary>Total pixels in a photo.</summary>
+    public const int PhotoPixelCount = PhotoSizePixels * PhotoSizePixels; // 16384
+
+    /// <summary>Bytes per pixel on the wire: RGB565 packed color.</summary>
+    public const int BytesPerPixel = 2;
+
+    /// <summary>
+    /// Photo length in bytes: one RGB565 value per pixel, big-endian. Server rejects any
+    /// submission whose Data.Length differs, removing the malformed-image / decompression-bomb
+    /// class since the payload is raw fixed-size color data and no image decoder ever runs.
+    /// </summary>
+    public const int PhotoByteLength = PhotoPixelCount * BytesPerPixel; // 32768
+
+    // Flashlight params shared by server world burst and client capture light so the photo
+    // matches the burst bystanders saw. Point source at camera: ~3-tile reach, high energy.
+    public const float FlashRadius = 3f;
+    public const float FlashEnergy = 6f;
+    public static readonly Color FlashColor = Color.FromHex("#F2F5FF");
+
+    /// <summary>Lifetime of the server-side world burst light, seconds.</summary>
+    public const float FlashBurstLifetime = 0.3f;
+
+    /// <summary>Range (tiles) the flash blinds when it fires.</summary>
+    public const float FlashBlindRange = 4f;
+
+    /// <summary>Max aim distance (tiles). Generous so line-of-sight is the real limit; just stops absurd cross-map clicks.</summary>
+    public const float PhotoMaxRange = 15f;
+}

--- a/Content.Shared/_Polonium/Photography/PhotographyEvents.cs
+++ b/Content.Shared/_Polonium/Photography/PhotographyEvents.cs
@@ -1,0 +1,47 @@
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Polonium.Photography;
+
+/// <summary>
+/// Server tells the single shutter-pressing client to render around <see cref="Coordinates"/>
+/// and send pixels back. <see cref="CaptureId"/> is a one-shot token held pending; a submission
+/// not matching a pending token for that session is rejected, so a client can't upload
+/// photos it was never authorized to take.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class RequestPhotoCaptureEvent : EntityEventArgs
+{
+    public readonly int CaptureId;
+
+    /// <summary>Center of the region to photograph (usually the camera's tile).</summary>
+    public readonly NetCoordinates Coordinates;
+
+    /// <summary>If on, the client lights its capture render.</summary>
+    public readonly bool Flash;
+
+    public RequestPhotoCaptureEvent(int captureId, NetCoordinates coordinates, bool flash)
+    {
+        CaptureId = captureId;
+        Coordinates = coordinates;
+        Flash = flash;
+    }
+}
+
+/// <summary>
+/// Client's answer to a <see cref="RequestPhotoCaptureEvent"/>: the given token plus an RGB565
+/// image of exactly <see cref="PhotographyConstants.PhotoByteLength"/> bytes. Server validates
+/// length and token before storing anything.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class SubmitPhotoEvent : EntityEventArgs
+{
+    public readonly int CaptureId;
+    public readonly byte[] Data;
+
+    public SubmitPhotoEvent(int captureId, byte[] data)
+    {
+        CaptureId = captureId;
+        Data = data;
+    }
+}

--- a/Content.Shared/_Polonium/Photography/PhotographyUi.cs
+++ b/Content.Shared/_Polonium/Photography/PhotographyUi.cs
@@ -1,0 +1,26 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Polonium.Photography;
+
+[Serializable, NetSerializable]
+public enum PhotoViewerUiKey : byte
+{
+    Key
+}
+
+/// <summary>
+/// State pushed to photograph viewers, carrying the packed blob directly. Riding the BUI state,
+/// it reaches only sessions with THIS photograph's UI open (and later openers), not every PVS
+/// observer as an auto-networked component field would. <see cref="Data"/> is null when the
+/// photo has no image yet.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class PhotoViewerBoundUserInterfaceState : BoundUserInterfaceState
+{
+    public readonly byte[]? Data;
+
+    public PhotoViewerBoundUserInterfaceState(byte[]? data)
+    {
+        Data = data;
+    }
+}

--- a/Content.Shared/_Polonium/Photography/PoloniumCameraComponent.cs
+++ b/Content.Shared/_Polonium/Photography/PoloniumCameraComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Polonium.Photography;
+
+/// <summary>Marks an item as a real pixel-capturing camera: unlike upstream <c>PictureTaker</c>'s examine-text photo, it asks the shooting client to render and submit an actual image.</summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class PoloniumCameraComponent : Component
+{
+    /// <summary>Photograph entity spawned once a valid image comes back; the blob is stored server-side by id, this entity only carries the id.</summary>
+    [DataField]
+    public EntProtoId Photograph = "PoloniumPhotograph";
+}

--- a/Content.Shared/_Polonium/Photography/PoloniumPhotographComponent.cs
+++ b/Content.Shared/_Polonium/Photography/PoloniumPhotographComponent.cs
@@ -12,6 +12,6 @@ namespace Content.Shared._Polonium.Photography;
 public sealed partial class PoloniumPhotographComponent : Component
 {
     /// <summary>Key into the server's <c>PhotoStorageManager</c>. 0 means "no image yet" (e.g. the client never answered a capture request).</summary>
-    [DataField, AutoNetworkedField]
+    [AutoNetworkedField]
     public int PhotoId;
 }

--- a/Content.Shared/_Polonium/Photography/PoloniumPhotographComponent.cs
+++ b/Content.Shared/_Polonium/Photography/PoloniumPhotographComponent.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Polonium.Photography;
+
+/// <summary>
+/// A developed photograph. Carries ONLY the storage id, never the pixel bytes: the blob lives
+/// in the server-side per-round store and is streamed to a single viewer via BUI state on open.
+/// A <c>byte[]</c> on an <c>AutoNetworkedField</c> would replicate to every PVS client and
+/// re-send for each new observer.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class PoloniumPhotographComponent : Component
+{
+    /// <summary>Key into the server's <c>PhotoStorageManager</c>. 0 means "no image yet" (e.g. the client never answered a capture request).</summary>
+    [DataField, AutoNetworkedField]
+    public int PhotoId;
+}

--- a/Content.Shared/_Polonium/Photography/SharedPoloniumPhotographySystem.cs
+++ b/Content.Shared/_Polonium/Photography/SharedPoloniumPhotographySystem.cs
@@ -1,0 +1,125 @@
+using Content.Shared.Charges.Systems;
+using Content.Shared.Examine;
+using Content.Shared.Interaction;
+using Content.Shared.Inventory;
+using Content.Shared.Item.ItemToggle;
+using Content.Shared.Item.ItemToggle.Components;
+using Content.Shared.Popups;
+using Content.Shared.Timing;
+using Content.Shared.Verbs;
+using Robust.Shared.Map;
+
+namespace Content.Shared._Polonium.Photography;
+
+/// <summary>
+/// Shared half of the pixel-photography feature. A picture is a plain ranged interaction
+/// (left-click) so it works regardless of flash; the flash is a separate
+/// <see cref="ItemToggleComponent"/> layer toggled from a right-click verb. Actual capture is
+/// a server-only override that issues a token to the shutter-presser's client.
+/// </summary>
+public abstract partial class SharedPoloniumPhotographySystem : EntitySystem
+{
+    [Dependency] private ItemToggleSystem _toggle = default!;
+    [Dependency] private UseDelaySystem _useDelay = default!;
+    [Dependency] private SharedChargesSystem _charges = default!;
+    [Dependency] private ExamineSystemShared _examine = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
+    [Dependency] private InventorySystem _inventory = default!;
+
+    /// <summary>The inventory slot that must be empty to use the camera (its viewfinder).</summary>
+    public const string EyeSlot = "eyes";
+
+    /// <summary>Whether something is worn in the eye slot (glasses/HUD), blocking the camera.</summary>
+    public bool EyesCovered(EntityUid user)
+    {
+        return _inventory.TryGetSlotEntity(user, EyeSlot, out _);
+    }
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PoloniumCameraComponent, BeforeRangedInteractEvent>(OnRangedInteract);
+        SubscribeLocalEvent<PoloniumCameraComponent, GetVerbsEvent<AlternativeVerb>>(OnGetAltVerbs);
+        SubscribeLocalEvent<PoloniumCameraComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnRangedInteract(Entity<PoloniumCameraComponent> ent, ref BeforeRangedInteractEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        // Anything worn over the eyes (glasses / HUD) blocks the shot, keeping HUD overlays out of it (hack).
+        if (EyesCovered(args.User))
+        {
+            _popup.PopupClient(Loc.GetString("camera-eyes-covered"), ent.Owner, args.User);
+            return;
+        }
+
+        var targetCoords = args.Target is { } target && !TerminatingOrDeleted(target)
+            ? Transform(target).Coordinates
+            : args.ClickLocation;
+
+        // Require an unoccluded sightline via vision occlusion (opaque walls / closed doors block),
+        // not physical collision, so glass and open doors let the shot through as the player sees it.
+        // Gate before the throttle so a blocked click isn't punished with cooldown.
+        if (!_examine.InRangeUnOccluded(args.User, targetCoords, range: PhotographyConstants.PhotoMaxRange))
+        {
+            _popup.PopupClient(Loc.GetString("camera-no-line-of-sight"), ent.Owner, args.User);
+            return;
+        }
+
+        // Out of film? Gate before the throttle so an empty click isn't punished with cooldown.
+        if (_charges.IsEmpty(ent.Owner))
+        {
+            _popup.PopupClient(Loc.GetString("camera-no-film"), ent.Owner, args.User);
+            return;
+        }
+
+        // Shutter throttle; if still cooling down, let the interaction fall through.
+        if (!_useDelay.TryResetDelay(ent.Owner, checkDelayed: true))
+            return;
+
+        // Swallow the interaction only if a capture started, so a non-player holder (no session) doesn't dead-end normal interactions.
+        if (StartCapture(ent, args.User, targetCoords, args.Target))
+        {
+            _charges.TryUseCharge(ent.Owner);
+            args.Handled = true;
+        }
+    }
+
+    private void OnGetAltVerbs(Entity<PoloniumCameraComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        var user = args.User;
+        AlternativeVerb verb = new()
+        {
+            Act = () => _toggle.Toggle(ent.Owner, user),
+            Text = Loc.GetString("camera-toggle-flash-verb"),
+            Priority = 10,
+        };
+        args.Verbs.Add(verb);
+    }
+
+    private void OnExamined(Entity<PoloniumCameraComponent> ent, ref ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+
+        var on = _toggle.IsActivated(ent.Owner);
+        args.PushMarkup(Loc.GetString(on ? "camera-flash-on" : "camera-flash-off"));
+    }
+
+    /// <summary>
+    /// Begin a capture for <paramref name="user"/>, framed on <paramref name="targetCoords"/>
+    /// (resolved at click time - the photo freezes the instant it was taken). <paramref name="target"/>
+    /// is the clicked entity, if any, so the server can name the subject. Returns true if a capture
+    /// started. Server-only; the shared base does nothing so the client never originates a capture.
+    /// </summary>
+    protected virtual bool StartCapture(Entity<PoloniumCameraComponent> camera, EntityUid user, EntityCoordinates targetCoords, EntityUid? target)
+    {
+        return false;
+    }
+}

--- a/Resources/Locale/en-US/_Polonium/photography/photography.ftl
+++ b/Resources/Locale/en-US/_Polonium/photography/photography.ftl
@@ -1,0 +1,18 @@
+photo-viewer-title = photograph
+photo-viewer-empty = The photograph is blank.
+photograph-examine-subject = A photograph of {$name}.
+
+camera-toggle-flash-verb = Toggle flash
+camera-flash-on = Flash: [color=green]on[/color]
+camera-flash-off = Flash: [color=red]off[/color]
+camera-no-line-of-sight = You can't get a clear shot of that.
+camera-no-film = Out of film.
+camera-eyes-covered = You need a clear eye to look through the viewfinder.
+
+admin-photo-title = Captured Photos
+admin-photo-delete = Delete photo
+admin-photo-select = Select a photo.
+admin-photo-unavailable = Photo unavailable.
+admin-photo-number = Photo #{$id}
+admin-photo-no-subject = no subject
+admin-photo-list-item = #{$id} - {$shooter} - {$subject}

--- a/Resources/Locale/en-US/_Polonium/photography/photography.ftl
+++ b/Resources/Locale/en-US/_Polonium/photography/photography.ftl
@@ -16,3 +16,5 @@ admin-photo-unavailable = Photo unavailable.
 admin-photo-number = Photo #{$id}
 admin-photo-no-subject = no subject
 admin-photo-list-item = #{$id} - {$shooter} - {$subject}
+
+admin-alert-photo-header = Photo:{" "}

--- a/Resources/Locale/en-US/administration/ui/tabs/adminbus-tab/adminbus-tab.ftl
+++ b/Resources/Locale/en-US/administration/ui/tabs/adminbus-tab/adminbus-tab.ftl
@@ -2,3 +2,4 @@ delete-singularities = Delete Singularities
 open-station-events = Station Events
 load-game-prototype = Load Prototype
 load-blueprints = Load Blueprints
+admin-view-photos-button = View Photos

--- a/Resources/Locale/pl-PL/_Polonium/Prototypes/Generated/Entities/Objects/Devices/camera.ftl
+++ b/Resources/Locale/pl-PL/_Polonium/Prototypes/Generated/Entities/Objects/Devices/camera.ftl
@@ -1,0 +1,4 @@
+ent-PoloniumCamera = aparat
+    .desc = Robi zdjęcia. Duh?
+ent-PoloniumPhotograph = zdjęcie
+    .desc = Wywołane zdjęcie.

--- a/Resources/Locale/pl-PL/_Polonium/photography/photography.ftl
+++ b/Resources/Locale/pl-PL/_Polonium/photography/photography.ftl
@@ -1,0 +1,18 @@
+photo-viewer-title = zdjęcie
+photo-viewer-empty = Zdjęcie jest puste.
+photograph-examine-subject = Zdjęcie przedstawia {$name}.
+
+camera-toggle-flash-verb = Przełącz lampę błyskową
+camera-flash-on = Lampa: [color=green]włączona[/color]
+camera-flash-off = Lampa: [color=red]wyłączona[/color]
+camera-no-line-of-sight = Nie masz czystego ujęcia na to.
+camera-no-film = Koniec kliszy.
+camera-eyes-covered = Musisz mieć wolne oczy, by spojrzeć przez wizjer.
+
+admin-photo-title = Zrobione Zdjęcia
+admin-photo-delete = Usuń zdjęcie
+admin-photo-select = Wybierz zdjęcie.
+admin-photo-unavailable = Zdjęcie niedostępne.
+admin-photo-number = Zdjęcie #{$id}
+admin-photo-no-subject = brak obiektu
+admin-photo-list-item = #{$id} - {$shooter} - {$subject}

--- a/Resources/Locale/pl-PL/_Polonium/photography/photography.ftl
+++ b/Resources/Locale/pl-PL/_Polonium/photography/photography.ftl
@@ -16,3 +16,5 @@ admin-photo-unavailable = Zdjęcie niedostępne.
 admin-photo-number = Zdjęcie #{$id}
 admin-photo-no-subject = brak obiektu
 admin-photo-list-item = #{$id} - {$shooter} - {$subject}
+
+admin-alert-photo-header = Zdjęcie:{" "}

--- a/Resources/Locale/pl-PL/administration/ui/tabs/adminbus-tab/adminbus-tab.ftl
+++ b/Resources/Locale/pl-PL/administration/ui/tabs/adminbus-tab/adminbus-tab.ftl
@@ -2,3 +2,4 @@ delete-singularities = Usuń Syngularności
 open-station-events = Wydarzenia Stacyjne
 load-game-prototype = Załaduj Prototyp
 load-blueprints = Załaduj Schematy
+admin-view-photos-button = Zobacz Zdjęcia

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -161,7 +161,7 @@
     - id: FlippoEngravedLighter
     - id: FlashlightSeclite
     - id: ForensicScanner
-    - id: PoloniumCamera
+    - id: PoloniumCamera # POLONIUM CHANGE
     - id: LogProbeCartridge
     - id: BoxForensicPad
     - id: DrinkDetFlask

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -161,6 +161,7 @@
     - id: FlippoEngravedLighter
     - id: FlashlightSeclite
     - id: ForensicScanner
+    - id: PoloniumCamera
     - id: LogProbeCartridge
     - id: BoxForensicPad
     - id: DrinkDetFlask

--- a/Resources/Prototypes/_Polonium/Entities/Objects/Devices/camera.yml
+++ b/Resources/Prototypes/_Polonium/Entities/Objects/Devices/camera.yml
@@ -1,0 +1,55 @@
+- type: entity
+  parent: BaseItem
+  id: PoloniumCamera
+  name: camera
+  description: Captures photos. Duh?
+  components:
+  - type: PoloniumCamera
+  - type: LimitedCharges
+    maxCharges: 8
+  - type: Sprite
+    sprite: Objects/Devices/travel_camera.rsi
+    state: icon
+  - type: ItemToggle
+    onUse: false
+    onActivate: false
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 0
+  - type: UseDelay
+  - type: StaticPrice
+    price: 100
+  - type: Clothing
+    slots:
+    - NECK
+    sprite: Objects/Devices/travel_camera.rsi
+
+- type: entity
+  parent: BaseItem
+  id: PoloniumPhotograph
+  name: photograph
+  description: A developed photograph. Activate it in hand to look at the picture.
+  components:
+  - type: PoloniumPhotograph
+  - type: Sprite
+    sprite: Objects/Misc/photograph.rsi
+    layers:
+    - state: black
+  - type: RandomSprite
+    available:
+      - "0":
+          black:
+          red:
+          blue:
+          green:
+          yellow:
+          purple:
+          rainbow:
+  - type: ActivatableUI
+    key: enum.PhotoViewerUiKey.Key
+    requiresComplex: false
+  - type: UserInterface
+    interfaces:
+      enum.PhotoViewerUiKey.Key:
+        type: PhotoViewerBoundUserInterface

--- a/Resources/Prototypes/_Polonium/Shaders/camera.yml
+++ b/Resources/Prototypes/_Polonium/Shaders/camera.yml
@@ -1,0 +1,4 @@
+- type: shader
+  id: PoloniumCameraViewfinder
+  kind: source
+  path: "/Textures/Shaders/_Polonium/camera_viewfinder.swsl"

--- a/Resources/Textures/Shaders/_Polonium/camera_viewfinder.swsl
+++ b/Resources/Textures/Shaders/_Polonium/camera_viewfinder.swsl
@@ -7,22 +7,23 @@ uniform highp float BORDER_PX;     // border thickness, px
 uniform highp vec3 BORDER_COLOR;   // border colour
 
 void fragment() {
-    highp vec3 orig = texture(SCREEN_TEXTURE, UV).xyz;
+    highp vec2 suv = FRAGCOORD.xy * SCREEN_PIXEL_SIZE;
+    highp vec3 orig = zTextureSpec(SCREEN_TEXTURE, suv).xyz;
 
     highp vec2 o = SCREEN_PIXEL_SIZE * BLUR;
     highp vec3 blurred = orig;
-    blurred += texture(SCREEN_TEXTURE, UV + vec2(o.x, 0.0)).xyz;
-    blurred += texture(SCREEN_TEXTURE, UV + vec2(-o.x, 0.0)).xyz;
-    blurred += texture(SCREEN_TEXTURE, UV + vec2(0.0, o.y)).xyz;
-    blurred += texture(SCREEN_TEXTURE, UV + vec2(0.0, -o.y)).xyz;
-    blurred += texture(SCREEN_TEXTURE, UV + vec2(o.x, o.y)).xyz;
-    blurred += texture(SCREEN_TEXTURE, UV + vec2(-o.x, o.y)).xyz;
-    blurred += texture(SCREEN_TEXTURE, UV + vec2(o.x, -o.y)).xyz;
-    blurred += texture(SCREEN_TEXTURE, UV + vec2(-o.x, -o.y)).xyz;
+    blurred += zTextureSpec(SCREEN_TEXTURE, suv + vec2(o.x, 0.0)).xyz;
+    blurred += zTextureSpec(SCREEN_TEXTURE, suv + vec2(-o.x, 0.0)).xyz;
+    blurred += zTextureSpec(SCREEN_TEXTURE, suv + vec2(0.0, o.y)).xyz;
+    blurred += zTextureSpec(SCREEN_TEXTURE, suv + vec2(0.0, -o.y)).xyz;
+    blurred += zTextureSpec(SCREEN_TEXTURE, suv + vec2(o.x, o.y)).xyz;
+    blurred += zTextureSpec(SCREEN_TEXTURE, suv + vec2(-o.x, o.y)).xyz;
+    blurred += zTextureSpec(SCREEN_TEXTURE, suv + vec2(o.x, -o.y)).xyz;
+    blurred += zTextureSpec(SCREEN_TEXTURE, suv + vec2(-o.x, -o.y)).xyz;
     blurred /= 9.0;
     blurred *= DIM;
 
-    highp vec2 px = vec2(UV.x, 1.0 - UV.y) / SCREEN_PIXEL_SIZE;
+    highp vec2 px = vec2(suv.x, 1.0 - suv.y) / SCREEN_PIXEL_SIZE;
     highp vec2 d = abs(px - CENTER_PX) - HALF_PX;
     highp float outside = max(d.x, d.y);
 

--- a/Resources/Textures/Shaders/_Polonium/camera_viewfinder.swsl
+++ b/Resources/Textures/Shaders/_Polonium/camera_viewfinder.swsl
@@ -1,0 +1,56 @@
+uniform sampler2D SCREEN_TEXTURE;
+uniform highp vec2 CENTER_PX;      // window centre, screen px
+uniform highp vec2 HALF_PX;        // window half-extents, screen px
+uniform highp float DIM;           // outside brightness multiplier (0..1)
+uniform highp float BLUR;          // blur sample offset scale, px
+uniform highp float BORDER_PX;     // border thickness, px
+uniform highp vec3 BORDER_COLOR;   // border colour
+
+void fragment() {
+    highp vec3 orig = texture(SCREEN_TEXTURE, UV).xyz;
+
+    highp vec2 o = SCREEN_PIXEL_SIZE * BLUR;
+    highp vec3 blurred = orig;
+    blurred += texture(SCREEN_TEXTURE, UV + vec2(o.x, 0.0)).xyz;
+    blurred += texture(SCREEN_TEXTURE, UV + vec2(-o.x, 0.0)).xyz;
+    blurred += texture(SCREEN_TEXTURE, UV + vec2(0.0, o.y)).xyz;
+    blurred += texture(SCREEN_TEXTURE, UV + vec2(0.0, -o.y)).xyz;
+    blurred += texture(SCREEN_TEXTURE, UV + vec2(o.x, o.y)).xyz;
+    blurred += texture(SCREEN_TEXTURE, UV + vec2(-o.x, o.y)).xyz;
+    blurred += texture(SCREEN_TEXTURE, UV + vec2(o.x, -o.y)).xyz;
+    blurred += texture(SCREEN_TEXTURE, UV + vec2(-o.x, -o.y)).xyz;
+    blurred /= 9.0;
+    blurred *= DIM;
+
+    highp vec2 px = vec2(UV.x, 1.0 - UV.y) / SCREEN_PIXEL_SIZE;
+    highp vec2 d = abs(px - CENTER_PX) - HALF_PX;
+    highp float outside = max(d.x, d.y);
+
+    highp float mask = step(0.0, outside);
+    highp vec3 col = mix(orig, blurred, mask);
+
+    highp vec2 rel = px - CENTER_PX;
+    highp vec2 a = abs(rel);
+    highp float t = BORDER_PX;                       // line half-thickness, px
+    highp float base = min(HALF_PX.x, HALF_PX.y);    // square-safe scale
+
+    highp float armO = base * 0.28;
+    highp float vO = step(abs(a.x - HALF_PX.x), t) * step(HALF_PX.y - armO, a.y) * step(a.y, HALF_PX.y + t);
+    highp float hO = step(abs(a.y - HALF_PX.y), t) * step(HALF_PX.x - armO, a.x) * step(a.x, HALF_PX.x + t);
+    highp float outerB = max(vO, hO);
+
+    highp vec2 innerH = HALF_PX * 0.42;
+    highp float armI = base * 0.14;
+    highp float vI = step(abs(a.x - innerH.x), t) * step(innerH.y - armI, a.y) * step(a.y, innerH.y + t);
+    highp float hI = step(abs(a.y - innerH.y), t) * step(innerH.x - armI, a.x) * step(a.x, innerH.x + t);
+    highp float innerB = max(vI, hI);
+
+    highp float rad = base * 0.14;
+    highp float ring = step(abs(length(rel) - rad), t);
+    highp float circle = ring * step(base * 0.05, a.x);
+
+    highp float reticle = max(max(outerB, innerB), circle);
+    col = mix(col, BORDER_COLOR, reticle);
+
+    COLOR = vec4(col, 1.0);
+}


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
To dla moich braci fotografów (tak, tacy też istnieją).

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
Ugotowano dla Polonium.

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
Jak działa:
1. Walidacja po stronie serwera:
- Slot na oczy pusty
- linia wzroku - ściany/zamknięte drzwi zasłaniają, szkło i otwarte drzwi przepuszczają
- zasięg =< 15
- stan kliszy
- throttlowanie migawki
2. Serwer wystawia jednorazowy token
3. Klient renderuje kadr z oka gracza, przycina kwadrat 128x128px (4 kafle x 32 px). Aparat widzi dokładnie to co widzi gracz.
4. Klient koloryzuje - PhotoGrade -> desaturacja, ciepły tint, ziarno, winieta, pakuje do RGB565 przy użyciu PhotoCodec - stały rozmiar 32768B i wysyła
5. Serwer rewaliduje token i długość payloadu zapisuje blob w pamięci per-runda, spawnuje encje PoloniumPhotograph, która trzyma tylko PhotoId.
---
Bezpieczeństwo 

- Stały rozmiar - brak dekodera obrazu. Eliminujemy problemy związane z malformed-image i decompression-bomb.
- Per-session token - klient nie prześle zdjęcia, do którego wysyłki nie został autoryzowany.
- Payload przyjmowany tylko o dokładnej długości i musi być non-null.
- Nazwa fotografowanego (tak się mówi?) zamrażana w momencie kliknięcia - bierzemy Identity.Name więc respektujemy przebrania itd. Escapujemy przy examine.
---
Flesz

- Serwer tworzy światło punktowe i oślepienie obszarowe. Klient dokłada identyczne światło do renderu zdjęcia.
- Flesz można włączyć z menu PPM lub ALT click na aparat.
---
Viewfinder

- shader camera_viewfinder.swsl - ramka celownika podąża za kursorem, czerwienieje gdy zdjęcie nie jest możliwe do zrobienia - (LoS lub zasięg).
- viewfinder przykleja się do encji. po przyklejeniu zmienia kolor ramki na niebieski. można to anulować przytrzymując SHIFT.
---
Admin logi

- Dodano komende `photos`. Otwiera EUI przeglądu i usuwania zdjęć z tej rundy. Dodatkowo dodano przycisk w Adminbusie.
---
Cleanup

- Blob jest zwalniany gdy encja fotografii ginie. Tokeny niszczone przy odpowiedzi/rozłączeniu/ponownym strzale. Pełny reset na restarcie rundy.


## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->
<img width="528" height="537" alt="image" src="https://github.com/user-attachments/assets/92de5b6b-4a76-41d6-ba16-db5be768c678" />
<img width="1935" height="1831" alt="image" src="https://github.com/user-attachments/assets/e1ff94ac-3f8f-43b8-affc-6b3b44986f13" />
<img width="1251" height="924" alt="image" src="https://github.com/user-attachments/assets/77390ce7-051c-4897-9f5c-8342ea6917df" />
<img width="1411" height="782" alt="image" src="https://github.com/user-attachments/assets/29816506-bfbc-47e4-b968-68cf99ecfa64" />


---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: haze
- add: Dodano aparat fotograficzny!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nowe funkcje**
  * Dodano aparat do wykonywania zdjęć obiektów w zasięgu i z nieprzesłoniętą linią widzenia.
  * Dodano wizjer z kadrowaniem, rozmyciem, przyciemnieniem i podświetleniem celu.
  * Dodano przełączaną lampę błyskową oraz wskaźniki stanu aparatu.
  * Zdjęcia można oglądać jako przedmioty wraz z opisem sfotografowanego obiektu.
  * Administratorzy mogą przeglądać, wybierać i usuwać zdjęcia z bieżącej rundy.

* **Dokumentacja i lokalizacja**
  * Dodano polskie i angielskie komunikaty interfejsu fotografii.

* **Testy**
  * Dodano testy kodowania, kadrowania, efektów obrazu i działania aparatu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->