### PR TITLE
przwrócono funkcjonalność scrap bagów z przed rebase

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -1,8 +1,8 @@
 - type: entity
-  name: ore bag
+  name: scrap bag # Funky Station changed to make it also be able to pick up scrap items 
   id: OreBag
   parent: BaseStorageItem
-  description: A robust bag for salvage specialists and miners alike to carry large amounts of ore. Magnetises any nearby ores when attached to a belt.
+  description: A robust bag for salvage specialists and miners alike to carry large amounts of ore or scrap. Magnetises any nearby raw resources when attached to a belt.
   components:
   - type: MagnetPickup
   - type: Sprite
@@ -16,15 +16,16 @@
   - type: Item
     size: Ginormous
   - type: Storage
-    maxItemSize: Normal
+    maxItemSize: Huge
     grid:
-    - 0,0,9,3
+    - 0,0,9,4
     quickInsert: true
     areaInsert: true
     whitelist:
       tags:
         - ArtifactFragment
         - Ore
+        - Recyclable
   - type: Dumpable
 
 - type: entity


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->

## Powód / Balans
Closes: #881 

## Szczegóły techniczne
Zmiana prototypu

## Media
Brak

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: notsssnek
- tweak: Umożliwiono zbieranie złomu do scrap bagów


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nowe funkcje**
  * Worek na rudę został przemianowany na worek na złom.
  * Dodano możliwość przenoszenia złomu oraz magnetyzowania surowców odpadowych.
  * Zwiększono pojemność worka i rozszerzono jego przestrzeń magazynową.
  * Worek może teraz przechowywać przedmioty oznaczone jako nadające się do recyklingu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->