### PR TITLE
Przywrócenie donk pocketów do logistyki. Zmiana krewetek aby używała kategorii food

### DIFF
--- a/Resources/Locale/en-US/prototypes/generated/_funkystation/catalog/fills/crates/food.ftl
+++ b/Resources/Locale/en-US/prototypes/generated/_funkystation/catalog/fills/crates/food.ftl
@@ -1,2 +1,4 @@
 ent-CrateFoodShrimpRaw = Jumbo Space Shrimp Pack
     .desc = Don't let the package name fool you. Space Shrimp is nothing more than a brand name.
+ent-CrateFoodRandomDonkPocket = donk pockets crate
+    .desc = You should order four more of these. Includes a box of donk pockets.

--- a/Resources/Locale/pl-PL/prototypes/generated/_funkystation/catalog/fills/crates/food.ftl
+++ b/Resources/Locale/pl-PL/prototypes/generated/_funkystation/catalog/fills/crates/food.ftl
@@ -1,2 +1,4 @@
 ent-CrateFoodShrimpRaw = paczka gigantycznych krewetek kosmicznych
     .desc = Nie daj się zwieść nazwie na opakowaniu. „Krewetka Kosmiczna” to nic więcej niż nazwa marki.
+ent-CrateFoodRandomDonkPocket = skrzynia donk pocketów
+    .desc = Powinieneś zamówić jeszcze cztery takie. Zawiera pudełko donk pocketów.

--- a/Resources/Prototypes/_Funkystation/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/_Funkystation/Catalog/Cargo/cargo_food.yml
@@ -1,0 +1,20 @@
+#moved shrimps to cargo_food, makes more sense imo - Yaket
+- type: cargoProduct
+  id: ServiceFoodShrimpRaw
+  icon:
+    sprite: _Funkystation/Objects/Consumable/Food/meat.rsi
+    state: shrimpfried
+  product: CrateFoodShrimpRaw
+  cost: 350
+  category: cargoproduct-category-name-food
+  group: market
+
+- type: cargoProduct
+  id: FoodRandomDonkpocket
+  icon:
+    sprite: Objects/Consumable/Food/Baked/donkpocket.rsi
+    state: plain
+  product: CrateFoodRandomDonkPocket
+  cost: 1500
+  category: cargoproduct-category-name-food
+  group: market

--- a/Resources/Prototypes/_Funkystation/Catalog/Cargo/cargo_service.yml
+++ b/Resources/Prototypes/_Funkystation/Catalog/Cargo/cargo_service.yml
@@ -11,13 +11,3 @@
   cost: 1500
   category: cargoproduct-category-name-service
   group: market
-
-- type: cargoProduct
-  id: ServiceFoodShrimpRaw
-  icon:
-    sprite: _Funkystation/Objects/Consumable/Food/meat.rsi
-    state: shrimpfried
-  product: CrateFoodShrimpRaw
-  cost: 350
-  category: cargoproduct-category-name-service
-  group: market

--- a/Resources/Prototypes/_Funkystation/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/_Funkystation/Catalog/Fills/Crates/food.yml
@@ -13,29 +13,29 @@
     - id: FoodShrimpRaw
       amount: 6
 
-# - type: entityTable
-#   id: RandomDonkpocketTable
-#   table: !type:GroupSelector
-#     children:
-#     - id: FoodBoxDonkpocket
-#     - id: FoodBoxDonkpocketSpicy
-#     - id: FoodBoxDonkpocketTeriyaki
-#     - id: FoodBoxDonkpocketPizza
-#     - id: FoodBoxDonkpocketCarp
-#     - id: FoodBoxDonkpocketBerry
-#     - id: FoodBoxDonkpocketHonk
-#     - id: FoodBoxDonkpocketDink
-#     - id: FoodBoxDonkpocketStonk
-#       weight: 0.2
-#     - id: FoodBoxDonkpocketMoth
+- type: entityTable
+  id: RandomDonkpocketTable
+  table: !type:GroupSelector
+    children:
+    - id: FoodBoxDonkpocket
+    - id: FoodBoxDonkpocketSpicy
+    - id: FoodBoxDonkpocketTeriyaki
+    - id: FoodBoxDonkpocketPizza
+    - id: FoodBoxDonkpocketCarp
+    - id: FoodBoxDonkpocketBerry
+    - id: FoodBoxDonkpocketHonk
+    - id: FoodBoxDonkpocketDink
+    - id: FoodBoxDonkpocketStonk
+      weight: 0.2
+    - id: FoodBoxDonkpocketMoth
 
-# - type: entity
-#   id: CrateFoodRandomDonkPocket
-#   parent: CratePlastic
-#   name: donk pockets crate
-#   description: You should order four more of these. Includes a box of donk pockets.
-#   components:
-#   - type: EntityTableContainerFill
-#     containers:
-#       entity_storage: !type:NestedSelector
-#         tableId: RandomDonkpocketTable
+- type: entity
+  id: CrateFoodRandomDonkPocket
+  parent: CratePlastic
+  name: donk pockets crate
+  description: You should order four more of these. Includes a box of donk pockets.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: RandomDonkpocketTable

--- a/Resources/Prototypes/_Funkystation/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/_Funkystation/Catalog/Fills/Crates/food.yml
@@ -13,22 +13,6 @@
     - id: FoodShrimpRaw
       amount: 6
 
-- type: entityTable
-  id: RandomDonkpocketTable
-  table: !type:GroupSelector
-    children:
-    - id: FoodBoxDonkpocket
-    - id: FoodBoxDonkpocketSpicy
-    - id: FoodBoxDonkpocketTeriyaki
-    - id: FoodBoxDonkpocketPizza
-    - id: FoodBoxDonkpocketCarp
-    - id: FoodBoxDonkpocketBerry
-    - id: FoodBoxDonkpocketHonk
-    - id: FoodBoxDonkpocketDink
-    - id: FoodBoxDonkpocketStonk
-      weight: 0.2
-    - id: FoodBoxDonkpocketMoth
-
 - type: entity
   id: CrateFoodRandomDonkPocket
   parent: CratePlastic

--- a/Resources/Prototypes/_Funkystation/Entities/Markers/Spawners/spawnertables.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Markers/Spawners/spawnertables.yml
@@ -45,6 +45,13 @@
     - id: FoodBoxDonkpocketSpicy
     - id: FoodBoxDonkpocketTeriyaki
     - id: FoodBoxDonkpocketPizza
+    - id: FoodBoxDonkpocketCarp
+    - id: FoodBoxDonkpocketBerry
+    - id: FoodBoxDonkpocketHonk
+    - id: FoodBoxDonkpocketDink
+    - id: FoodBoxDonkpocketStonk
+      weight: 0.2
+    - id: FoodBoxDonkpocketMoth
 
 - type: entityTable
   id: MaintLocker50


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Została przywrócona opcja zamówienia losowego produktu Donk Co. w logistyce. Cena jak sprzed rebase'a.
Przy okazji zmieniłem aby krewetki były w kategorii food. Ma to więcej sensu

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
Donk pockety są fajne. Fajnie też mieć do nich łatwiejszy dostęp.

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
1. Przywrócenie donk pocketowych crate'ów w Resources/Prototypes/_Funkystation/Catalog/Fills/Crates/food.yml
2. Dodanie ich do Resources/Prototypes/_Funkystation/Catalog/Fills/Crates/food.yml
3. Przeniesienie krewetek z service.yml do food.yml
4. Przywrócenie angielskich i polskich opisów donk crate'ów

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->
<img width="397" height="353" alt="Content Client_iN0i9rXrjj" src="https://github.com/user-attachments/assets/4501c6cb-a0c4-4295-8f5a-198d0db1b563" />
<img width="1000" height="614" alt="Content Client_K8dGqZ9Qma" src="https://github.com/user-attachments/assets/4ed2f41e-3cbd-44be-b7c6-650c7e49b65c" />


---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: Yaket
- add: Przywrócono skrzynki z donk pocketami do logistyki.
- tweak: Przeniesiono krewetki z kategorii serwis do jedzenia.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nowe funkcje**
  * Dodano do katalogu cargo surowe krewetki oraz losowe donk-pockety.
  * Dodano ceny, ikony i odpowiednie kategorie produktów spożywczych.
  * Udostępniono skrzynię z losowo wybieranymi wariantami donk-pocketów.
  * Rozszerzono pulę dostępnych wariantów o donk-pockety Carp, Berry, Honk, Dink, Stonk i Moth.
  * Skrzynia może być automatycznie wypełniana różnymi produktami tego typu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->