### PR TITLE
Ignorowane funkcje

### DIFF
--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -68,11 +68,27 @@ namespace Content.Shared.Localizations
             _loc.AddFunction(culture, "NATURALFIXED", FormatNaturalFixed);
             _loc.AddFunction(culture, "NATURALPERCENT", FormatNaturalPercent);
             _loc.AddFunction(culture, "PLAYTIME", FormatPlaytime);
-            _loc.AddFunction(culture, "MANY", FormatMany);
             _loc.AddFunction(culture, "GASQUANTITY", FormatGasQuantity); // Frontier
 
-            _loc.AddFunction(cultureEn, "MAKEPLURAL", FormatMakePlural);
-            _loc.AddFunction(cultureEn, "MANY", FormatMany);
+            // skipped function as they are breaking Polish grammar
+            _loc.AddFunction(culture, "THE", FormatPassthrough);
+            _loc.AddFunction(culture, "MAKEPLURAL", FormatPassthrough);
+            _loc.AddFunction(culture, "MANY", FormatPassthrough);
+            _loc.AddFunction(culture, "INDEFINITE", FormatEmpty);
+            _loc.AddFunction(cultureEn, "THE", FormatPassthrough);
+            _loc.AddFunction(cultureEn, "MAKEPLURAL", FormatPassthrough);
+            _loc.AddFunction(cultureEn, "MANY", FormatPassthrough);
+            _loc.AddFunction(cultureEn, "INDEFINITE", FormatEmpty);
+        }
+
+        private static ILocValue FormatPassthrough(LocArgs args)
+        {
+            return args.Args.Count > 0 ? args.Args[0] : new LocValueString("");
+        }
+
+        private static ILocValue FormatEmpty(LocArgs args)
+        {
+            return new LocValueString("");
         }
 
         private ILocValue FormatMany(LocArgs args)

--- a/Resources/Locale/en-US/photography/photography.ftl
+++ b/Resources/Locale/en-US/photography/photography.ftl
@@ -1,6 +1,6 @@
 # TODO: Make this a fluent function in RT
 photograph-name-text = This is a photograph of { PROPER($entity) ->
-    *[false] { INDEFINITE($entity) } { $entity }
+    *[false] { INDEFINITE($entity) }{ $entity }
      [true] { $entity }
     }.
 photograph-name-text-empty = This is a photograph.

--- a/Resources/Locale/pl-PL/photography/photography.ftl
+++ b/Resources/Locale/pl-PL/photography/photography.ftl
@@ -1,7 +1,7 @@
 # TODO: Make this a fluent function in RT
 photograph-name-text =
     This is a photograph of { PROPER($entity) ->
-       *[false] { INDEFINITE($entity) } { $entity }
+       *[false] { INDEFINITE($entity) }{ $entity }
         [true] { $entity }
     }.
 photograph-name-text-empty = This is a photograph.


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Funkcje lokalizacyjne `MANY(...)`, `MAKEPLURAL(...)`, `INDEFINITE(...)`, `THE(...)` są ignorowane (nic nie formatują). To rozwiązuje następujące sytuacje:
- `{THE($crowbar)}` -> "łom", nie "the łom".
- `{MAKEPLURAL($name)}` -> "wrona", nie "wronas".
- i analogiczne z `MANY(...)` oraz `INDEFINITE(...)`

...bez konieczności usuwania tych wszystkich funkcji z plików

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Poprawki**
  * Ujednolicono działanie wybranych funkcji formatowania lokalizacji dla języka polskiego i angielskiego (en-US).
  * Niektóre wyrażenia zachowują teraz przekazany tekst bez dodatkowej odmiany, a funkcje bez treści zwracają pusty wynik.
  * Zmniejszono ryzyko nieoczekiwanych zmian form wyrazów w komunikatach lokalizowanych.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->