### PR TITLE
Readded hairball action for Felinids

### DIFF
--- a/Content.Server/Abilities/Felinid/FelinidSystem.cs
+++ b/Content.Server/Abilities/Felinid/FelinidSystem.cs
@@ -83,7 +83,7 @@ public sealed partial class FelinidSystem : EntitySystem
         if (component.HairballAction != null)
             return;
 
-        // _actionsSystem.AddAction(uid, ref component.HairballAction, component.HairballActionId); // funkystation - No
+        _actionsSystem.AddAction(uid, ref component.HairballAction, component.HairballActionId);
     }
 
     private void OnEquipped(EntityUid uid, FelinidComponent component, DidEquipHandEvent args)


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Przywrócono akcję wypluwania kłaczka dla Felinidów. Przy okazji naprawia to brak możliwości używania akcji jedzenia myszy więcej niż 1 raz

## Powód / Balans
<!-- Opisz, jak zmiana wpłynie na balans rozgrywki lub dlaczego została wprowadzona. Podaj linki do odpowiednich dyskusji lub zgłoszeń, jeśli są dostępne. -->
Dodaje więcej unikalności rasie

## Szczegóły techniczne
<!-- Podsumowanie zmian w kodzie dla ułatwienia przeglądu. -->
Odkomentowano _actionsSystem.AddAction(uid, ref component.HairballAction, component.HairballActionId);

## Media
<!-- Dołącz materiały multimedialne, jeśli PR wprowadza zmiany w grze (ubrania, przedmioty, funkcje itp.).
Drobne poprawki/refaktoryzacje są z tego zwolnione. Materiały mogą zostać użyte w raportach postępów SS14 z podaniem autora. -->

---

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->

:cl: Yaket
- add: Przywrócono kłaczki Felinidom

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Poprawki**
  * Przywrócono rejestrowanie akcji wypluwania kłębka sierści dla postaci Felinid.
  * Akcja jest teraz poprawnie dostępna po inicjalizacji postaci.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->