### PR TITLE
Xeno są teraz bardziej podatni na zagrożenia

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Weeds/XenoWeedsSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Weeds/XenoWeedsSystem.cs
@@ -82,14 +82,7 @@ public sealed partial class XenoWeedsSystem : SharedXenoWeedsSystem
                     continue;
 
                 var spawned = Spawn(weeds.Spawns, coords);
-                if (TryComp(spawned, out XenoWeedsComponent? childWeeds))
-                {
-                    childWeeds.IsSource = false;
-                    childWeeds.Source = source;
-                    childWeeds.Spreads = true;
-                    Dirty(spawned, childWeeds);
-                }
-
+                AssignSource(spawned, source.Value);
                 _hive.SetSameHive(uid, spawned);
             }
         }

--- a/Content.Server/_RMC14/Xenonids/XenoEnvironmentSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/XenoEnvironmentSystem.cs
@@ -1,0 +1,39 @@
+using Content.Server.Atmos.Components;
+using Content.Shared._RMC14.Xenonids;
+using Content.Shared.Atmos.Components;
+using Content.Shared.Temperature.Components;
+
+namespace Content.Server._RMC14.Xenonids;
+
+public sealed class XenoEnvironmentSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<XenoEnvironmentVulnerabilityComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(Entity<XenoEnvironmentVulnerabilityComponent> ent, ref MapInitEvent args)
+    {
+        if (TryComp<FlammableComponent>(ent, out var flammable)
+            && !MathHelper.CloseTo(ent.Comp.Fire, 1f))
+        {
+            flammable.Damage *= ent.Comp.Fire;
+            Dirty(ent, flammable);
+        }
+
+        if (TryComp<TemperatureDamageComponent>(ent, out var temperature))
+        {
+            if (!MathHelper.CloseTo(ent.Comp.Fire, 1f))
+                temperature.HeatDamage *= ent.Comp.Fire;
+
+            if (!MathHelper.CloseTo(ent.Comp.Space, 1f))
+                temperature.ColdDamage *= ent.Comp.Space;
+        }
+
+        if (TryComp<BarotraumaComponent>(ent, out var barotrauma)
+            && !MathHelper.CloseTo(ent.Comp.Space, 1f))
+        {
+            barotrauma.Damage *= ent.Comp.Space;
+        }
+    }
+}

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -1,28 +1,39 @@
 using Content.Shared._RMC14.Map;
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Construction.Events;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared._RMC14.Xenonids.Weeds;
+using Content.Shared.Body;
 using Content.Shared.DoAfter;
+using Content.Shared.Doors;
+using Content.Shared.Doors.Components;
+using Content.Shared.Doors.Systems;
 using Content.Shared.FixedPoint;
+using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids.Construction;
 
 public sealed partial class SharedXenoConstructionSystem : EntitySystem
 {
+    private static readonly TimeSpan ResinDoorAutoCloseDelay = TimeSpan.FromSeconds(5);
+
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private IComponentFactory _compFactory = default!;
     [Dependency] private SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private SharedDoorSystem _doors = default!;
     [Dependency] private SharedXenoHiveSystem _hive = default!;
     [Dependency] private INetManager _net = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private RMCMapSystem _rmcMap = default!;
+    [Dependency] private IGameTiming _timing = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private SharedUserInterfaceSystem _ui = default!;
     [Dependency] private XenoPlasmaSystem _plasma = default!;
@@ -34,11 +45,42 @@ public sealed partial class SharedXenoConstructionSystem : EntitySystem
         SubscribeLocalEvent<XenoConstructionComponent, XenoChooseStructureActionEvent>(OnChooseStructure);
         SubscribeLocalEvent<XenoConstructionComponent, XenoSecreteStructureActionEvent>(OnSecreteStructure);
         SubscribeLocalEvent<XenoConstructionComponent, XenoSecreteStructureDoAfterEvent>(OnSecreteStructureDoAfter);
+        SubscribeLocalEvent<XenoConstructComponent, DoorStateChangedEvent>(OnConstructDoorStateChanged);
+        SubscribeLocalEvent<XenoConstructComponent, ActivateInWorldEvent>(OnConstructDoorActivate, before: [typeof(SharedDoorSystem)]);
 
         Subs.BuiEvents<XenoConstructionComponent>(XenoChooseStructureUI.Key, subs =>
         {
             subs.Event<XenoChooseStructureMessage>(OnChooseStructureMessage);
         });
+    }
+
+    private void OnConstructDoorStateChanged(Entity<XenoConstructComponent> ent, ref DoorStateChangedEvent args)
+    {
+        if (_timing.ApplyingState)
+            return;
+
+        if (args.State != DoorState.Open)
+            return;
+
+        if (!HasComp<DoorComponent>(ent))
+            return;
+
+        _doors.SetNextStateChange(ent, ResinDoorAutoCloseDelay);
+    }
+
+    private void OnConstructDoorActivate(Entity<XenoConstructComponent> ent, ref ActivateInWorldEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (!TryComp<DoorComponent>(ent, out var door) || !door.ClickOpen)
+            return;
+
+        if (!HasComp<XenoComponent>(args.User) && !HasComp<VisualBodyComponent>(args.User))
+            return;
+
+        if (_doors.TryToggleDoor(ent, door, args.User, predicted: true))
+            args.Handled = true;
     }
 
     private void OnPlantWeeds(Entity<XenoConstructionComponent> xeno, ref XenoPlantWeedsActionEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Weeds/SharedXenoWeedsSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Weeds/SharedXenoWeedsSystem.cs
@@ -8,6 +8,8 @@ using Content.Shared.Movement.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Physics.Events;
+using Robust.Shared.Random;
+using Robust.Shared.Spawners;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids.Weeds;
@@ -19,6 +21,7 @@ public abstract partial class SharedXenoWeedsSystem : EntitySystem
     [Dependency] private SharedXenoHiveSystem _hive = default!;
     [Dependency] private MovementSpeedModifierSystem _movementSpeed = default!;
     [Dependency] private INetManager _net = default!;
+    [Dependency] private IRobustRandom _random = default!;
     [Dependency] private RMCMapSystem _rmcMap = default!;
     [Dependency] private IGameTiming _timing = default!;
 
@@ -37,6 +40,7 @@ public abstract partial class SharedXenoWeedsSystem : EntitySystem
 
         SubscribeLocalEvent<XenoWeedsComponent, MapInitEvent>(OnWeedsMapInit);
         SubscribeLocalEvent<XenoWeedsComponent, AnchorStateChangedEvent>(OnWeedsAnchorChanged);
+        SubscribeLocalEvent<XenoWeedsComponent, EntityTerminatingEvent>(OnWeedsTerminating);
         SubscribeLocalEvent<XenoWeedsComponent, StartCollideEvent>(OnWeedsStartCollide);
         SubscribeLocalEvent<XenoWeedsComponent, EndCollideEvent>(OnWeedsEndCollide);
 
@@ -69,6 +73,66 @@ public abstract partial class SharedXenoWeedsSystem : EntitySystem
     {
         if (_net.IsServer && !args.Anchored)
             QueueDel(weeds);
+    }
+
+    private void OnWeedsTerminating(Entity<XenoWeedsComponent> ent, ref EntityTerminatingEvent args)
+    {
+        if (!_net.IsServer)
+            return;
+
+        if (!ent.Comp.IsSource)
+        {
+            if (ent.Comp.Source is { } source && TryComp(source, out XenoWeedsComponent? weeds))
+            {
+                weeds.Spread.Remove(ent);
+                Dirty(source, weeds);
+            }
+
+            return;
+        }
+
+        var toDelete = new HashSet<EntityUid>(ent.Comp.Spread);
+        var query = EntityQueryEnumerator<XenoWeedsComponent>();
+        while (query.MoveNext(out var uid, out var weeds))
+        {
+            if (weeds.Source == ent.Owner)
+                toDelete.Add(uid);
+        }
+
+        foreach (var spread in toDelete)
+        {
+            if (TerminatingOrDeleted(spread))
+                continue;
+
+            if (TryComp(spread, out XenoWeedsComponent? weeds))
+            {
+                weeds.Source = null;
+                Dirty(spread, weeds);
+            }
+
+            var timed = EnsureComp<TimedDespawnComponent>(spread);
+            var offset = _random.Next(ent.Comp.MinRandomDelete, ent.Comp.MaxRandomDelete);
+            timed.Lifetime = (float)offset.TotalSeconds;
+        }
+
+        ent.Comp.Spread.Clear();
+    }
+
+    public void AssignSource(EntityUid weeds, EntityUid source)
+    {
+        if (TryComp(weeds, out XenoWeedsComponent? weedsComp))
+        {
+            weedsComp.IsSource = false;
+            weedsComp.Source = source;
+            weedsComp.Spreads = true;
+            Dirty(weeds, weedsComp);
+        }
+
+        if (!TryComp(source, out XenoWeedsComponent? sourceComp))
+            return;
+
+        sourceComp.Spread.Add(weeds);
+        Dirty(source, sourceComp);
     }
 
     private void OnWeedsStartCollide(Entity<XenoWeedsComponent> ent, ref StartCollideEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Weeds/XenoWeedsComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Weeds/XenoWeedsComponent.cs
@@ -23,6 +23,15 @@ public sealed partial class XenoWeedsComponent : Component
     public EntityUid? Source;
 
     [DataField, AutoNetworkedField]
+    public List<EntityUid> Spread = new();
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan MinRandomDelete = TimeSpan.FromSeconds(9);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan MaxRandomDelete = TimeSpan.FromSeconds(10);
+
+    [DataField, AutoNetworkedField]
     public float SpeedMultiplierXeno = 1f;
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/Weeds/XenoWeedsSpreadingComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Weeds/XenoWeedsSpreadingComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared._RMC14.Xenonids.Weeds;
 public sealed partial class XenoWeedsSpreadingComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public TimeSpan SpreadDelay = TimeSpan.FromSeconds(3.33);
+    public TimeSpan SpreadDelay = TimeSpan.FromSeconds(6);
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan NextSpread;

--- a/Content.Shared/_RMC14/Xenonids/XenoEnvironmentVulnerabilityComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoEnvironmentVulnerabilityComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class XenoEnvironmentVulnerabilityComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public float Fire = 1f;
+
+    [DataField, AutoNetworkedField]
+    public float Space = 1f;
+}

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CMXenoBase
-  parent: BaseMobDestructible
+  parent: [ BaseMobDestructible, MobFlammable ]
   abstract: true
   save: false
   components:
@@ -8,6 +8,11 @@
   - type: Damageable
   - type: Injurable
     damageContainer: Xeno
+  - type: Reactive
+    groups:
+      Flammable: [ Touch ]
+      Extinguish: [ Touch ]
+      Acidic: [ Touch ]
   - type: MobState
     allowedStates:
     - Alive
@@ -61,10 +66,22 @@
     coldDamageThreshold: 260
     coldDamage:
       types:
-        Cold: 0.1
+        Cold: 0.2
     heatDamage:
       types:
-        Heat: 0.5
+        Heat: 0.65
+  - type: Barotrauma
+    damage:
+      types:
+        Blunt: 0.12
+    protectionSlots: []
+  - type: Flammable
+    fireSpread: true
+    canResistFire: true
+    damage:
+      types:
+        Heat: 1.75
+  - type: XenoEnvironmentVulnerability
   - type: ThermalRegulator
     metabolismHeat: 800
     radiatedHeat: 100

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
@@ -11,6 +11,9 @@
       0: Alive
       700: Critical
       800: Dead
+  - type: XenoEnvironmentVulnerability
+    fire: 0.8
+    space: 0.8
   - type: Xeno
     tier: 3
     unlockAt: 900

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
@@ -11,6 +11,9 @@
       0: Alive
       500: Critical
       600: Dead
+  - type: XenoEnvironmentVulnerability
+    fire: 0.9
+    space: 0.9
   - type: Xeno
     tier: 1
     unlockAt: 240

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
@@ -11,6 +11,9 @@
       0: Alive
       500: Critical
       600: Dead
+  - type: XenoEnvironmentVulnerability
+    fire: 1.1
+    space: 1.15
   - type: Xeno
     tier: 1
     unlockAt: 60

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
@@ -11,6 +11,9 @@
       0: Alive
       550: Critical
       650: Dead
+  - type: XenoEnvironmentVulnerability
+    fire: 1.05
+    space: 1.1
   - type: Xeno
     tier: 2
     unlockAt: 180

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/larva.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/larva.yml
@@ -11,6 +11,9 @@
       0: Alive
       35: Critical
       70: Dead
+  - type: XenoEnvironmentVulnerability
+    fire: 1.4
+    space: 1.5
   - type: Xeno
     tier: 0
     unlockAt: 0

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
@@ -11,6 +11,9 @@
       0: Alive
       450: Critical
       550: Dead
+  - type: XenoEnvironmentVulnerability
+    fire: 1.2
+    space: 1.15
   - type: Xeno
     tier: 2
     unlockAt: 540

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/maid.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/maid.yml
@@ -11,6 +11,9 @@
       0: Alive
       125: Critical
       200: Dead
+  - type: XenoEnvironmentVulnerability
+    fire: 1.3
+    space: 1.35
   - type: Xeno
     tier: 0
     bypassTierCount: true

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
@@ -11,6 +11,9 @@
       0: Alive
       650: Critical
       750: Dead
+  - type: XenoEnvironmentVulnerability
+    fire: 0.95
+    space: 0.9
   - type: Xeno
     tier: 3
     unlockAt: 900

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -18,6 +18,9 @@
       0: Alive
       900: Critical
       1000: Dead
+  - type: XenoEnvironmentVulnerability
+    fire: 0.85
+    space: 0.85
   - type: Xeno
     tier: 0
     bypassTierCount: true

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
@@ -11,6 +11,9 @@
       0: Alive
       650: Critical
       750: Dead
+  - type: XenoEnvironmentVulnerability
+    fire: 0.95
+    space: 0.9
   - type: Xeno
     tier: 3
     unlockAt: 900

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
@@ -11,6 +11,9 @@
       0: Alive
       175: Critical
       250: Dead
+  - type: XenoEnvironmentVulnerability
+    fire: 1.3
+    space: 1.25
   - type: Xeno
     tier: 1
     unlockAt: 300

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
@@ -11,6 +11,9 @@
       0: Alive
       500: Critical
       600: Dead
+  - type: XenoEnvironmentVulnerability
+    fire: 1.15
+    space: 1.1
   - type: Xeno
     tier: 1
     unlockAt: 300

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
@@ -11,6 +11,9 @@
       0: Alive
       550: Critical
       650: Dead
+  - type: XenoEnvironmentVulnerability
+    fire: 1.1
+    space: 1.1
   - type: Xeno
     tier: 2
     unlockAt: 540

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
@@ -11,6 +11,9 @@
       0: Alive
       500: Critical
       600: Dead
+  - type: XenoEnvironmentVulnerability
+    fire: 0.9
+    space: 0.95
   - type: Xeno
     tier: 2
     unlockAt: 540

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
@@ -116,7 +116,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 11
+        damage: 39
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
fix #905
fix #904

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
:cl: Nikita
- tweak: Xeno są teraz podatni na ogień, próżnię i niską temperaturę.
- tweak: Rozpowszechnianie trawy xeno zmieniono na 1 płytkę w 6 sekund (zamiast 3.33)
- tweak: Xeno mają teraz reakcję ciał na chemikalia
- fix: Xeno teraz mogą otwierać własne drzwi
- fix: Naprawiono zabawę!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nowe funkcje**
  - Ksenonidy mają zróżnicowaną podatność na ogień, ekstremalne temperatury i próżnię kosmiczną.
  - Drzwi w konstrukcjach ksenonidów można otwierać i zamykać kliknięciem; po otwarciu zamykają się automatycznie po 5 sekundach.
  - Ksenonidy reagują na kontakt z ogniem, gaszeniem i kwasem.
  - Ulepszono zarządzanie rozprzestrzenianiem i usuwaniem chwastów.

- **Balans rozgrywki**
  - Zwiększono obrażenia od zimna i gorąca.
  - Wydłużono czas rozprzestrzeniania chwastów z 3,33 do 6 sekund.
  - Zwiększono wytrzymałość węzłów chwastów.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->