### PR TITLE
Poprawki do oleju ksenoborgów | możliwość otwartego ognia

### DIFF
--- a/Resources/Prototypes/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/Reagents/pyrotechnic.yml
@@ -236,6 +236,7 @@
   color: "#3d5cff"
   boilingPoint: -84.7 # Acetylene. Close enough.
   meltingPoint: -80.7
+  flammability: 3 # Polonium fix
   friction: 0.4
   tileReactions:
   - !type:FlammableTileReaction {}


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR

Nadałem małą poprawke co brakowała, czyli dodanie łatwopalności do oleju ksenoborgów. Teraz powinna móc się rozpalić na podłodze.

## Powód / Balans
Moim zdaniem mi brakowało tego, ponieważ olej sam nadawał łatwopalność dla entity które zostały oblane tym, ale na podłodze się nie podpalał. 

## Szczegóły techniczne
Dodano Flammibility do prototypów chemikali, pyrotechnicznych.

---

**Changelog**
<!--
:cl: Oxtailime
- fix: Naprawiono brakujące podpalanie się oleju ksenoborgów
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Poprawki**
  * Zaktualizowano łatwopalność reagenta „XenoborgOil” do wartości 3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->