### PR TITLE
Aktualizacje do metabolizmu gatunków

### DIFF
--- a/Resources/Prototypes/Body/Animals/bloodsucker.yml
+++ b/Resources/Prototypes/Body/Animals/bloodsucker.yml
@@ -4,7 +4,7 @@
   suffix: bloodsucker
   components:
   - type: Metabolizer
-    metabolizerTypes: [ Bloodsucker, Animal ] # Polonium: blood heal is bloodsucker, raw meat still needs animal
+    metabolizerTypes: [ Bloodsucker ]
 
 - type: entity
   id: OrganBloodsuckerStomach

--- a/Resources/Prototypes/Body/Animals/bloodsucker.yml
+++ b/Resources/Prototypes/Body/Animals/bloodsucker.yml
@@ -4,19 +4,19 @@
   suffix: bloodsucker
   components:
   - type: Metabolizer
-    metabolizerTypes: [ Bloodsucker ]
+    metabolizerTypes: [ Bloodsucker, Animal ] # Polonium: blood heal is bloodsucker, raw meat still needs animal
 
 - type: entity
   id: OrganBloodsuckerStomach
-  parent: [ OrganBloodsucker, OrganAnimalStomach ]
+  parent: [ OrganAnimalStomach, OrganBloodsucker ]
 
 - type: entity
   id: OrganBloodsuckerLiver
-  parent: [ OrganBloodsucker, OrganAnimalLiver ]
+  parent: [ OrganAnimalLiver, OrganBloodsucker ]
 
 - type: entity
   id: OrganBloodsuckerHeart
-  parent: [ OrganBloodsucker, OrganAnimalHeart ]
+  parent: [ OrganAnimalHeart, OrganBloodsucker ]
 
 - type: entity
   id: BaseMobBloodsucker

--- a/Resources/Prototypes/Body/Species/arachnid.yml
+++ b/Resources/Prototypes/Body/Species/arachnid.yml
@@ -145,7 +145,7 @@
   abstract: true
   components:
   - type: Metabolizer
-    metabolizerTypes: [ Arachnid ]
+    metabolizerTypes: [ Arachnid, Animal ] # Polonium: raw meat is bloodstream now so heart needs Animal too
 
 - type: entity
   parent: OrganArachnid
@@ -383,7 +383,7 @@
       Destroyed: 0
 
 - type: entity
-  parent: [ OrganBaseStomach, OrganArachnidInternal, OrganAnimalMetabolizer ]
+  parent: [ OrganBaseStomach, OrganArachnidInternal, OrganArachnidMetabolizer ]
   id: OrganArachnidStomach
   components:
   - type: OrganIntegrity
@@ -394,7 +394,7 @@
       Destroyed: 0
 
 - type: entity
-  parent: [ OrganBaseLiver, OrganSpriteHumanInternal, OrganArachnidInternal, OrganAnimalMetabolizer ]
+  parent: [ OrganBaseLiver, OrganSpriteHumanInternal, OrganArachnidInternal, OrganArachnidMetabolizer ]
   id: OrganArachnidLiver
   components:
   - type: OrganIntegrity
@@ -405,7 +405,7 @@
       Destroyed: 0
 
 - type: entity
-  parent: [ OrganBaseKidneys, OrganSpriteHumanInternal, OrganArachnidInternal, OrganAnimalMetabolizer ]
+  parent: [ OrganBaseKidneys, OrganSpriteHumanInternal, OrganArachnidInternal, OrganArachnidMetabolizer ]
   id: OrganArachnidKidneys
   components:
   - type: OrganIntegrity

--- a/Resources/Prototypes/Body/Species/dwarf.yml
+++ b/Resources/Prototypes/Body/Species/dwarf.yml
@@ -378,11 +378,18 @@
   components:
   - type: Metabolizer
     maxReagents: 5
+    metabolizerTypes: [ Dwarf, Human ] # Polonium: alcohol is metabolites, dwarf has to stay on the liver
 
 - type: entity
   parent: [ OrganDwarfMetabolizer, OrganHumanLiver ]
   id: OrganDwarfLiver
+  components:
+  - type: Metabolizer
+    metabolizerTypes: [ Dwarf, Human ]
 
 - type: entity
   parent: [ OrganDwarfMetabolizer, OrganHumanHeart ]
   id: OrganDwarfHeart
+  components:
+  - type: Metabolizer
+    metabolizerTypes: [ Dwarf, Human ]

--- a/Resources/Prototypes/Body/Species/moth.yml
+++ b/Resources/Prototypes/Body/Species/moth.yml
@@ -427,7 +427,7 @@
       Destroyed: 0
 
 - type: entity
-  parent: [ OrganBaseHeart, OrganMothInternal, OrganAnimalMetabolizer ]
+  parent: [ OrganBaseHeart, OrganMothInternal, OrganMothMetabolizer ] # Polonium: moth should eat cloth!
   id: OrganMothHeart
   components:
   - type: OrganIntegrity
@@ -455,7 +455,7 @@
       Destroyed: 0
 
 - type: entity
-  parent: [ OrganBaseLiver, OrganSpriteHumanInternal, OrganMothInternal, OrganAnimalMetabolizer ]
+  parent: [ OrganBaseLiver, OrganSpriteHumanInternal, OrganMothInternal, OrganMothMetabolizer ] # Polonium: moth should eat cloth!
   id: OrganMothLiver
   components:
   - type: OrganIntegrity

--- a/Resources/Prototypes/Body/Species/rodentia.yml
+++ b/Resources/Prototypes/Body/Species/rodentia.yml
@@ -167,7 +167,7 @@
   abstract: true
   components:
   - type: Metabolizer
-    metabolizerTypes: [ Animal ]
+    metabolizerTypes: [ Animal, Rat ] # Polonium:ammonia is respiration, garlic is digestion, both need their type on the organ that actually runs it
 
 - type: entity
   parent: OrganRodentia
@@ -415,13 +415,11 @@
       Damaged: 9
       Destroyed: 0
 
-# Rodentia keep a rat's stomach, so they can stomach things humans cannot.
+# rat stomach so they eat what humans cant, animal too or garlic never hits
 - type: entity
-  parent: [ OrganBaseStomach, OrganRodentiaInternal ]
+  parent: [ OrganBaseStomach, OrganRodentiaInternal, OrganRodentiaMetabolizer ]
   id: OrganRodentiaStomach
   components:
-  - type: Metabolizer
-    metabolizerTypes: [ Rat ]
   - type: OrganIntegrity
     integrityCap: 88
     integrityThresholds:

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -223,7 +223,7 @@
           reagent: Ethanol
           min: 15
         - !type:MetabolizerTypeCondition
-          type: [ Dwarf ]
+          type: [ Dwarf, Allulalo ]
           inverted: true
         damage:
           types:
@@ -235,7 +235,7 @@
           reagent: Ethanol
           min: 15
         - !type:MetabolizerTypeCondition
-          type: [ Dwarf ]
+          type: [ Dwarf, Allulalo ]
         damage:
           types:
             Poison: 0.02
@@ -245,7 +245,7 @@
           reagent: Ethanol
           min: 15
         - !type:MetabolizerTypeCondition
-          type: [ Dwarf ]
+          type: [ Dwarf, Allulalo ]
         damage:
           Brute: -0.1
       - !type:Vomit
@@ -256,7 +256,7 @@
           min: 12
         # dwarves immune to vomiting from alcohol
         - !type:MetabolizerTypeCondition
-          type: [ Dwarf ]
+          type: [ Dwarf, Allulalo ]
           inverted: true
       - !type:Drunk
         boozePower: 2
@@ -2337,7 +2337,7 @@
           reagent: BacchusBlessing
           min: 6
         - !type:MetabolizerTypeCondition
-          type: [Dwarf]
+          type: [Dwarf, Allulalo]
           inverted: true
         damage:
           types:
@@ -2348,7 +2348,7 @@
           reagent: BacchusBlessing
           min: 6
         - !type:MetabolizerTypeCondition
-          type: [Dwarf]
+          type: [Dwarf, Allulalo]
         damage:
           types:
             Poison: 0.04 # TODO: Might increase this, even though it's just double of ethanol from 0.02 to 0.04
@@ -2359,7 +2359,7 @@
           reagent: BacchusBlessing
           min: 8
         - !type:MetabolizerTypeCondition
-          type: [Dwarf]
+          type: [Dwarf, Allulalo]
           inverted: true
 
 # backported couple drinks - Yaket

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -13,7 +13,7 @@
       - !type:Oxygenate
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Human, Animal, Rat, Plant, Apid, Thaven, Arachnid ] # fork: Apid/Thaven (Macrocosm); upstream: Arachnid
+          type: [ Human, Animal, Rat, Plant, Apid, Thaven, Arachnid, Moth ]
       # Convert Oxygen into CO2.
       - !type:ModifyLungGas
         conditions:

--- a/Resources/Prototypes/_MACRO/Body/Species/allulalo.yml
+++ b/Resources/Prototypes/_MACRO/Body/Species/allulalo.yml
@@ -248,7 +248,7 @@
   abstract: true
   components:
   - type: Metabolizer
-    metabolizerTypes: [ Allulalo ]
+    metabolizerTypes: [ Allulalo, Animal ] # Polonium: saurians eat raw meat, thats bloodstream now
     updateIntervalMultiplier: 1.5 # This should make them metabolize things twice as fast. I think. This new system is scary.
 
 - type: entity
@@ -452,13 +452,13 @@
   id: OrganAllulaloHeart
 
 - type: entity
-  parent: [ OrganBaseStomach, OrganAllulaloInternal, OrganHumanMetabolizer ]
+  parent: [ OrganBaseStomach, OrganAllulaloInternal, OrganAllulaloMetabolizer ]
   id: OrganAllulaloStomach
 
 - type: entity
-  parent: [ OrganBaseLiver, OrganAllulaloInternal, OrganHumanMetabolizer ]
+  parent: [ OrganBaseLiver, OrganAllulaloInternal, OrganAllulaloMetabolizer ]
   id: OrganAllulaloLiver
 
 - type: entity
-  parent: [ OrganBaseKidneys, OrganAllulaloInternal, OrganHumanMetabolizer ]
+  parent: [ OrganBaseKidneys, OrganAllulaloInternal, OrganAllulaloMetabolizer ]
   id: OrganAllulaloKidneys

--- a/Resources/Prototypes/_MACRO/Body/Species/apid.yml
+++ b/Resources/Prototypes/_MACRO/Body/Species/apid.yml
@@ -159,10 +159,10 @@
       Appendix: OrganMothAppendix
       Ears: OrganMothEars
       Lungs: OrganApidLungs
-      Heart: OrganMothHeart
+      Heart: OrganHumanHeart
       Stomach: OrganHumanStomach
-      Liver: OrganMothLiver
-      Kidneys: OrganMothKidneys
+      Liver: OrganHumanLiver
+      Kidneys: OrganHumanKidneys
   - type: HumanoidProfile
     species: Apid
 

--- a/Resources/Prototypes/_MACRO/Reagents/biological.yml
+++ b/Resources/Prototypes/_MACRO/Reagents/biological.yml
@@ -54,7 +54,7 @@
           reagent: Ethanol
           min: 15
         - !type:MetabolizerTypeCondition
-          type: [ Dwarf ]
+          type: [ Dwarf, Allulalo ]
           inverted: true
         damage:
           types:
@@ -66,7 +66,7 @@
           reagent: Ethanol
           min: 15
         - !type:MetabolizerTypeCondition
-          type: [ Dwarf ]
+          type: [ Dwarf, Allulalo ]
         damage:
           types:
             Poison: 0.02
@@ -76,7 +76,7 @@
           reagent: Ethanol
           min: 15
         - !type:MetabolizerTypeCondition
-          type: [ Dwarf ]
+          type: [ Dwarf, Allulalo ]
         damage:
           Brute: -0.1
       - !type:Vomit
@@ -87,7 +87,7 @@
           min: 12
         # dwarves immune to vomiting from alcohol
         - !type:MetabolizerTypeCondition
-          type: [ Dwarf ]
+          type: [ Dwarf, Allulalo ]
           inverted: true
       - !type:Drunk
         boozePower: 2


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
<!-- Co zostało zmienione? -->
Po przeniesieniu surowego mięsa do krwi część gatunków miała zły typ metabolizerra na złym organie. Jedzenie i trucizny sprawdzały typ serca, żołądka, wątroby albo płuc - i się mocno rozjeżdżały.

Arachnid - serce dostało Animal obok Arachnid. Zjedzenie surowego mięsa nie wywołuje już wymiotów, ale czekolada i czosnek dalej trują.

Ćmy - serce i wątroba były zwierzęce, więc surowe białko w krwi szło jak u zwierząt. Teraz wszędzie jest `Moth`.

Grzyzonie - żołądek był tylko szczurzy, płuca tylko zwierzęce. Czosnek ich nie truł, amoniak nie leczył - teraz czosnek zabija, amoniak działa jak na szczurach

Krasnoludy - na sercu, żołądku i wątrobie jest wprost `[Dwarf, Human]`, żeby alkohol na metabolitach nie zabił krasnoluda zbyt wcześnie.

Krwiopijce - `[Bloodsucker, Animal]`.

Allulalo - nie wiem co to za gatunek w ogóle, ale zrobiłem `[Allulalo, Animal]`.

Apidy - serce/wątroba/nerki miały z ćmy. Teraz ludzkie, jak żołądek. Płuca zostają Apid.

**Changelog**
<!-- Dodaj wpis do dziennika zmian, aby gracze byli świadomi nowych funkcji lub zmian, które mogą wpływać na rozgrywkę.
Zapoznaj się z wytycznymi i usuń komentarz wokół szablonu changelogu, aby został on uwzględniony.
Wpis changelogu musi zawierać symbol :cl:, aby bot rozpoznał zmiany i dodał je do dziennika zmian gry. -->
:cl: Nikita
- tweak: Arachnidzi, allulalo i gryzonie teraz mogą jeść surowe mięso.
- tweak: Ćmy nie mogą teraz jeść surowe mięso.
- tweak: Czosnek, czekolada, cebula teraz trują gryzoni.
- tweak: Amoniak w powietrzu na gryzoni teraz działa jak na szczurów (leczy).
- tweak: Apidy mają teraz serce, wątrobę i nerkę

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nowe funkcje**
  - Zaktualizowano metabolizm arachnidów, Allulalo, krasnoludów, ciem, gryzoni i innych gatunków, zapewniając właściwe działanie ich narządów.
  - Allulalo otrzymują efekty alkoholu i krwi Allulalo analogiczne do krasnoludów.
  - Ćmy mogą prawidłowo metabolizować tlen, a ich unikalny metabolizm wspiera spożywanie tkanin.
  - Poprawiono przypisanie narządów wewnętrznych u Apidów.
  - Uporządkowano dziedziczenie narządów wampirów, bez zmiany ich właściwości.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->