### PR TITLE
Poprawki do kseno | Zdrowie i podłogowa żywica (DRAFT)

### DIFF
--- a/Resources/Prototypes/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/Reagents/pyrotechnic.yml
@@ -236,6 +236,7 @@
   color: "#3d5cff"
   boilingPoint: -84.7 # Acetylene. Close enough.
   meltingPoint: -80.7
+  flammability: 3 # Polonium fix
   friction: 0.4
   tileReactions:
   - !type:FlammableTileReaction {}

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -143,6 +143,7 @@
   - type: Tag
     tags:
     - DoorBumpOpener
+    - Xeno
   - type: MeleeWeapon
     altDisarm: false
     angle: 0
@@ -195,3 +196,4 @@
   - type: Tag
     tags:
     - DoorBumpOpener
+    - Xeno

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
@@ -9,8 +9,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      500: Critical
-      600: Dead
+      450: Critical
+      550: Dead
   - type: XenoEnvironmentVulnerability
     fire: 0.9
     space: 0.9

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
@@ -9,8 +9,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      500: Critical
-      600: Dead
+      250: Critical
+      350: Dead
   - type: XenoEnvironmentVulnerability
     fire: 1.1
     space: 1.15

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
@@ -37,7 +37,7 @@
   - type: XenoPlasma
     plasma: 1000
     maxPlasma: 1000
-    plasmaRegenOnWeeds: 6
+    plasmaRegenOnWeeds: 5.5
   - type: XenoConstruction
     buildDelay: 1
     canUpgrade: true

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
@@ -37,7 +37,7 @@
   - type: XenoPlasma
     plasma: 1000
     maxPlasma: 1000
-    plasmaRegenOnWeeds: 5.5
+    plasmaRegenOnWeeds: 6
   - type: XenoConstruction
     buildDelay: 1
     canUpgrade: true

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
@@ -9,8 +9,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      450: Critical
-      550: Dead
+      250: Critical
+      350: Dead
   - type: XenoEnvironmentVulnerability
     fire: 1.2
     space: 1.15

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
@@ -29,7 +29,7 @@
   - type: XenoPlasma
     plasma: 400
     maxPlasma: 400
-    plasmaRegenOnWeeds: 6
+    plasmaRegenOnWeeds: 3
   - type: XenoEvolution
     canEvolveWithoutGranter: true
     max: 200

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
@@ -9,8 +9,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      500: Critical
-      600: Dead
+      200: Critical
+      350: Dead
   - type: XenoEnvironmentVulnerability
     fire: 1.15
     space: 1.1
@@ -29,7 +29,7 @@
   - type: XenoPlasma
     plasma: 400
     maxPlasma: 400
-    plasmaRegenOnWeeds: 3
+    plasmaRegenOnWeeds: 6
   - type: XenoEvolution
     canEvolveWithoutGranter: true
     max: 200

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
@@ -31,7 +31,7 @@
   - type: XenoPlasma
     plasma: 600
     maxPlasma: 600
-    plasmaRegenOnWeeds: 6
+    plasmaRegenOnWeeds: 4
   - type: XenoEvolution
     max: 500
     evolvesTo:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
@@ -9,8 +9,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      550: Critical
-      650: Dead
+      400: Critical
+      500: Dead
   - type: XenoEnvironmentVulnerability
     fire: 1.1
     space: 1.1
@@ -31,7 +31,7 @@
   - type: XenoPlasma
     plasma: 600
     maxPlasma: 600
-    plasmaRegenOnWeeds: 4
+    plasmaRegenOnWeeds: 6
   - type: XenoEvolution
     max: 500
     evolvesTo:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
@@ -9,8 +9,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      500: Critical
-      600: Dead
+      400: Critical
+      500: Dead
   - type: XenoEnvironmentVulnerability
     fire: 0.9
     space: 0.95

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_floor_resin.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_floor_resin.yml
@@ -56,6 +56,12 @@
     speedMultiplier: 0.4
   - type: XenoConstructionPlasmaCost
     plasma: 66
+  - type: SpeedModifierContacts
+    walkSpeedModifier: 0.6
+    sprintSpeedModifier: 0.6
+    ignoreWhitelist:
+      tags:
+      - Xeno
 
 - type: entity
   parent: XenoStickyResin
@@ -69,6 +75,13 @@
     speedMultiplier: 0.55
   - type: TimedDespawn
     lifetime: 20
+  - type: SpeedModifierContacts
+    walkSpeedModifier: 0.7
+    sprintSpeedModifier: 0.7
+    ignoreWhitelist:
+      tags:
+      - Xeno
+  
 
 - type: entity
   parent: XenoBaseFloorResin
@@ -82,6 +95,9 @@
     speedMultiplier: 1.33
   - type: XenoConstructionPlasmaCost
     plasma: 42
+  - type: SpeedModifierContacts
+    walkSpeedModifier: 1.6
+    sprintSpeedModifier: 1.6
 
 - type: entity
   parent: XenoBaseFloorResin
@@ -98,7 +114,16 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 60
+        damage: 20
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: DamageContacts
+    damage:
+      types:
+        Slash: 1.5
+        Piercing: 5
+    ignoreWhitelist:
+      tags:
+      - Xeno
+

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_floor_resin.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_floor_resin.yml
@@ -95,9 +95,14 @@
     speedMultiplier: 1.33
   - type: XenoConstructionPlasmaCost
     plasma: 42
-  - type: SpeedModifierContacts
-    walkSpeedModifier: 1.6
-    sprintSpeedModifier: 1.6
+  ##- type: SpeedModifierContacts
+  ##  walkSpeedModifier: 1.6
+  ##  sprintSpeedModifier: 1.6
+  ##  whitelist:
+  ##    tags:
+  ##    - Xeno
+
+  ## ^ Potrzebuje kodu whitelist (czyli tylko te encje które posiadają ten tag, mogą korzystać z prędkości)
 
 - type: entity
   parent: XenoBaseFloorResin
@@ -114,7 +119,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 20
+        damage: 50
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]


### PR DESCRIPTION
<!-- Wytyczne: https://github.com/polonium14/polonium-space/blob/master/CONTRIBUTING.md -->

## Informacje o PR
Zmniejszono zdrowie niektórych kseno (przede wszystkim, drona), aby bardziej odpowiadały im nadanych ról. Zarówno naprawiono kolce i lepką żywice, skopiowane z kodu meatzu. Nadano tag Xeno, aby uniknąć zranienia i spowolnienia poprzez kolce i lepką żywice (zakomentowano zmiane prędkości u szybkiej żywicy, potrzebuje kodu whitelist)

## Powód / Balans
Dron (tier 1) miał tyle samo zdrowia co wojownik (tier 2). Podłogowa żywica dla mnie nawet mocno brakowała.

## Szczegóły techniczne
base_xeno otrzymał nowy tag: Xeno, dla kolczastej żywicy i lepkiej

---

**Changelog**
:cl: Oxtailime
- tweak: Zmniejszono zdrowie kseno, w oparciu o jego rolę w roju.
- fix: Naprawiono kolce żywicy oraz lepką żywicę!
